### PR TITLE
Remove role from signup input and enforce user role

### DIFF
--- a/postman.json
+++ b/postman.json
@@ -77,7 +77,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"firstName\": \"Slava\",\n    \"lastName\": \"Melanko\",\n    \"email\": \"slava.melanko+52@gmail.com\",\n    \"password\": \"P@ssw0rd!\",\n    \"role\": \"user\",\n    \"captchaToken\": \"03AAYGu2S8_HuuT4N0xE8N8zQJ9nQJ8nQJ8nQJ8nQJ8nQJ8nQJ8n---\"\n}\n",
+					"raw": "{\n    \"firstName\": \"Slava\",\n    \"lastName\": \"Melanko\",\n    \"email\": \"slava.melanko+54@gmail.com\",\n    \"password\": \"P@ssw0rd!\",\n    \"captchaToken\": \"03AAYGu2S8_HuuT4N0xE8N8zQJ9nQJ8nQJ8nQJ8nQJ8nQJ8nQJ8n---\"\n}\n",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/src/routes/auth/signup/__tests__/endpoint.test.ts
+++ b/src/routes/auth/signup/__tests__/endpoint.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { createTestApp, doRequest, ModuleMocker, post } from '@/__tests__'
 import HttpStatus from '@/lib/http-status'
 import { mockCaptchaSuccess, VALID_CAPTCHA_TOKEN } from '@/middleware/__tests__/mocks/captcha'
-import { Role } from '@/types'
+import { Role, Status } from '@/types'
 
 import signupRoute from '../index'
 
@@ -26,7 +26,7 @@ describe('Signup Endpoint', () => {
         lastName: 'Doe',
         email: 'test@example.com',
         role: Role.User,
-        status: 'new',
+        status: Status.New,
         createdAt: new Date('2024-01-01'),
         updatedAt: new Date('2024-01-01'),
       },
@@ -59,7 +59,6 @@ describe('Signup Endpoint', () => {
         lastName: 'Doe',
         email: 'test@example.com',
         password: 'ValidPass123!',
-        role: Role.User,
         captchaToken: VALID_CAPTCHA_TOKEN,
       }
 
@@ -75,7 +74,7 @@ describe('Signup Endpoint', () => {
           lastName: 'Doe',
           email: 'test@example.com',
           role: Role.User,
-          status: 'new',
+          status: Status.New,
           createdAt: '2024-01-01T00:00:00.000Z',
           updatedAt: '2024-01-01T00:00:00.000Z',
         },
@@ -91,18 +90,17 @@ describe('Signup Endpoint', () => {
         lastName: 'Doe',
         email: 'test@example.com',
         password: 'ValidPass123!',
-        role: Role.User,
       })
     })
 
     it('should validate required field formats', async () => {
       const invalidData = [
-        { firstName: '', lastName: 'Doe', email: 'test@example.com', password: 'ValidPass123!', role: Role.User, captchaToken: VALID_CAPTCHA_TOKEN }, // empty firstName
-        { firstName: 'John', lastName: '', email: 'test@example.com', password: 'ValidPass123!', role: Role.User, captchaToken: VALID_CAPTCHA_TOKEN }, // empty lastName
-        { firstName: 'John', lastName: 'Doe', email: 'invalid', password: 'ValidPass123!', role: Role.User, captchaToken: VALID_CAPTCHA_TOKEN }, // invalid email format
-        { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'short', role: Role.User, captchaToken: VALID_CAPTCHA_TOKEN }, // password too short
-        { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'NoNumbers!', role: Role.User, captchaToken: VALID_CAPTCHA_TOKEN }, // password missing numbers
-        { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'NoSpecial123', role: Role.User, captchaToken: VALID_CAPTCHA_TOKEN }, // password missing special chars
+        { firstName: '', lastName: 'Doe', email: 'test@example.com', password: 'ValidPass123!', captchaToken: VALID_CAPTCHA_TOKEN }, // empty firstName
+        { firstName: 'John', lastName: '', email: 'test@example.com', password: 'ValidPass123!', captchaToken: VALID_CAPTCHA_TOKEN }, // empty lastName
+        { firstName: 'John', lastName: 'Doe', email: 'invalid', password: 'ValidPass123!', captchaToken: VALID_CAPTCHA_TOKEN }, // invalid email format
+        { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'short', captchaToken: VALID_CAPTCHA_TOKEN }, // password too short
+        { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'NoNumbers!', captchaToken: VALID_CAPTCHA_TOKEN }, // password missing numbers
+        { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'NoSpecial123', captchaToken: VALID_CAPTCHA_TOKEN }, // password missing special chars
       ]
 
       for (const body of invalidData) {
@@ -116,9 +114,9 @@ describe('Signup Endpoint', () => {
 
     it('should require all required fields', async () => {
       const incompleteRequests = [
-        { lastName: 'Doe', email: 'test@example.com', password: 'ValidPass123!', role: Role.User, captchaToken: VALID_CAPTCHA_TOKEN }, // missing firstName
-        { firstName: 'John', password: 'ValidPass123!', role: Role.User, captchaToken: VALID_CAPTCHA_TOKEN }, // missing lastName and email
-        { firstName: 'John', lastName: 'Doe', email: 'test@example.com', captchaToken: VALID_CAPTCHA_TOKEN }, // missing password and role
+        { lastName: 'Doe', email: 'test@example.com', password: 'ValidPass123!', captchaToken: VALID_CAPTCHA_TOKEN }, // missing firstName
+        { firstName: 'John', password: 'ValidPass123!', captchaToken: VALID_CAPTCHA_TOKEN }, // missing lastName and email
+        { firstName: 'John', lastName: 'Doe', email: 'test@example.com', captchaToken: VALID_CAPTCHA_TOKEN }, // missing password
         { captchaToken: VALID_CAPTCHA_TOKEN }, // only captchaToken provided
         {}, // completely empty
       ]
@@ -138,7 +136,6 @@ describe('Signup Endpoint', () => {
         lastName: 'Doe',
         email: 'test@example.com',
         password: 'ValidPass123!',
-        role: Role.User,
         captchaToken: VALID_CAPTCHA_TOKEN,
       }
 
@@ -165,7 +162,6 @@ describe('Signup Endpoint', () => {
         lastName: 'Doe',
         email: 'test@example.com',
         password: 'ValidPass123!',
-        role: Role.User,
         captchaToken: VALID_CAPTCHA_TOKEN,
       })
 
@@ -183,7 +179,6 @@ describe('Signup Endpoint', () => {
           lastName: 'Doe',
           email: 'test@example.com',
           password: 'ValidPass123!',
-          role: Role.User,
           captchaToken: VALID_CAPTCHA_TOKEN,
         }, { 'Content-Type': 'application/json' })
 

--- a/src/routes/auth/signup/__tests__/signup.test.ts
+++ b/src/routes/auth/signup/__tests__/signup.test.ts
@@ -16,7 +16,6 @@ describe('Signup with Email', () => {
     lastName: 'Doe',
     email: 'john@example.com',
     password: 'ValidPass123!',
-    role: Role.User,
   }
 
   const mockNewUser = {
@@ -91,7 +90,7 @@ describe('Signup with Email', () => {
         firstName: mockSignupParams.firstName,
         lastName: mockSignupParams.lastName,
         email: mockSignupParams.email,
-        role: mockSignupParams.role,
+        role: 'user',
         status: Status.New,
       })
       expect(userRepo.create).toHaveBeenCalledTimes(1)
@@ -381,7 +380,7 @@ describe('Signup with Email', () => {
         firstName: mockSignupParams.firstName,
         lastName: mockSignupParams.lastName,
         email: uppercaseEmail,
-        role: mockSignupParams.role,
+        role: 'user',
         status: Status.New,
       })
       const { tokenVersion, ...expectedUser } = mockNewUser
@@ -416,7 +415,7 @@ describe('Signup with Email', () => {
         firstName: 'Al',
         lastName: 'Bo',
         email: mockSignupParams.email,
-        role: mockSignupParams.role,
+        role: 'user',
         status: Status.New,
       })
 
@@ -427,41 +426,19 @@ describe('Signup with Email', () => {
       })
     })
 
-    it('should handle different user roles', async () => {
-      const adminSignupParams = { ...mockSignupParams, role: Role.Admin }
-      const adminUser = { ...mockNewUser, role: Role.Admin }
-
-      await moduleMocker.mock('@/repositories', () => ({
-        userRepo: {
-          findByEmail: mock(() => Promise.resolve(null)),
-          create: mock(() => Promise.resolve(adminUser)),
-        },
-        authRepo: {
-          create: mock(() => Promise.resolve()),
-        },
-        tokenRepo: {
-          deprecateOld: mock(() => Promise.resolve()),
-          create: mock(() => Promise.resolve()),
-        },
-      }))
-
-      const result = await signUpWithEmail(adminSignupParams)
+    it('should always assign user role regardless of input', async () => {
+      const result = await signUpWithEmail(mockSignupParams)
 
       expect(userRepo.create).toHaveBeenCalledWith({
         firstName: mockSignupParams.firstName,
         lastName: mockSignupParams.lastName,
         email: mockSignupParams.email,
-        role: Role.Admin,
+        role: 'user',
         status: Status.New,
       })
-      const { tokenVersion: _, ...expectedAdminUser } = adminUser
-      expect(result.user).toEqual(expectedAdminUser)
-
-      // Also verify no sensitive fields for admin users
-      expect(result.user).not.toHaveProperty('tokenVersion')
-      // createdAt and updatedAt are now included in the response
-      expect(result.user).toHaveProperty('createdAt')
-      expect(result.user).toHaveProperty('updatedAt')
+      const { tokenVersion: _, ...expectedUser } = mockNewUser
+      expect(result.user).toEqual(expectedUser)
+      expect(result.user.role).toBe(Role.User)
     })
 
     it('should handle complex passwords', async () => {
@@ -496,7 +473,7 @@ describe('Signup with Email', () => {
         firstName: longFirstName,
         lastName: longLastName,
         email: mockSignupParams.email,
-        role: mockSignupParams.role,
+        role: 'user',
         status: Status.New,
       })
     })

--- a/src/routes/auth/signup/handler.ts
+++ b/src/routes/auth/signup/handler.ts
@@ -6,9 +6,9 @@ import HttpStatus from '@/lib/http-status'
 import signUpWithEmail from './signup'
 
 const signupHandler = async (c: Context) => {
-  const { firstName, lastName, email, password, role } = await c.req.json()
+  const { firstName, lastName, email, password } = await c.req.json()
 
-  const result = await signUpWithEmail({ firstName, lastName, email, password, role })
+  const result = await signUpWithEmail({ firstName, lastName, email, password })
 
   setAccessCookie(c, result.token)
 

--- a/src/routes/auth/signup/schema.ts
+++ b/src/routes/auth/signup/schema.ts
@@ -5,7 +5,6 @@ const signupSchema = buildSchema({
   lastName: userRules.name.opt,
   email: userRules.email,
   password: userRules.password,
-  role: userRules.role,
   captchaToken: tokenRules.captchaToken,
 })
 

--- a/src/routes/auth/signup/signup.ts
+++ b/src/routes/auth/signup/signup.ts
@@ -1,5 +1,3 @@
-import type { Role } from '@/types'
-
 import { AppError, ErrorCode } from '@/lib/catch'
 import { createPasswordEncoder } from '@/lib/crypto'
 import { emailAgent } from '@/lib/email-agent'
@@ -8,22 +6,21 @@ import logger from '@/lib/logger'
 import { EMAIL_VERIFICATION_EXPIRY_HOURS, generateToken } from '@/lib/token'
 import { normalizeUser } from '@/lib/user'
 import { authRepo, tokenRepo, userRepo } from '@/repositories'
-import { AuthProvider, Status, Token } from '@/types'
+import { AuthProvider, Role, Status, Token } from '@/types'
 
 export interface SignupParams {
   firstName: string
   lastName: string
   email: string
   password: string
-  role: Role
 }
 
-const createUser = async ({ firstName, lastName, email, password, role }: SignupParams) => {
+const createUser = async ({ firstName, lastName, email, password }: SignupParams) => {
   const newUser = await userRepo.create({
     firstName,
     lastName,
     email,
-    role,
+    role: Role.User,
     status: Status.New,
   })
 
@@ -54,7 +51,7 @@ const createEmailVerificationToken = async (userId: number) => {
 }
 
 const signUpWithEmail = async (
-  { firstName, lastName, email, password, role }: SignupParams,
+  { firstName, lastName, email, password }: SignupParams,
 ) => {
   const existingUser = await userRepo.findByEmail(email)
 
@@ -67,7 +64,6 @@ const signUpWithEmail = async (
     lastName,
     email,
     password,
-    role,
   })
 
   const secureToken = await createEmailVerificationToken(newUser.id)


### PR DESCRIPTION
The signup flow no longer accepts a 'role' field from user input and always assigns the 'user' role internally. Tests and schema have been updated to reflect this change, ensuring that users cannot self-assign roles during registration.