### PR TITLE
refactor: Remove redundant HTTP method validation tests

### DIFF
--- a/src/routes/auth/login/__tests__/endpoint.test.ts
+++ b/src/routes/auth/login/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, doRequest, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post } from '@/__tests__'
 import { mockCaptchaSuccess, VALID_CAPTCHA_TOKEN } from '@/middleware/captcha/__tests__'
 import { HttpStatus } from '@/net/http'
 
@@ -253,20 +253,6 @@ describe('Login Endpoint', () => {
           path: '/',
         }),
       )
-    })
-
-    it('should only accept POST method', async () => {
-      const methods = ['GET', 'PUT', 'DELETE', 'PATCH']
-
-      for (const method of methods) {
-        const res = await doRequest(app, LOGIN_URL, method, {
-          email: 'test@example.com',
-          password: 'validPassword123',
-          captchaToken: VALID_CAPTCHA_TOKEN,
-        }, { 'Content-Type': 'application/json' })
-
-        expect(res.status).toBe(HttpStatus.NOT_FOUND)
-      }
     })
   })
 })

--- a/src/routes/auth/logout/__tests__/endpoint.test.ts
+++ b/src/routes/auth/logout/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, doRequest, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 
 import logoutRoute from '../index'
@@ -136,18 +136,6 @@ describe('Logout Endpoint', () => {
       // Verify all calls were made with the correct context
       for (let i = 0; i < numCalls; i++) {
         expect(mockDeleteRefreshCookie).toHaveBeenNthCalledWith(i + 1, expect.any(Object))
-      }
-    })
-
-    it('should only accept POST method', async () => {
-      const methods = ['GET', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS']
-
-      for (const method of methods) {
-        const res = await doRequest(app, LOGOUT_URL, method)
-
-        expect(res.status).toBe(HttpStatus.NOT_FOUND)
-        // Verify cookie deletion is NOT called for invalid methods
-        expect(mockDeleteRefreshCookie).not.toHaveBeenCalled()
       }
     })
   })

--- a/src/routes/auth/request-password-reset/__tests__/endpoint.test.ts
+++ b/src/routes/auth/request-password-reset/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, doRequest, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post } from '@/__tests__'
 import { mockCaptchaSuccess, VALID_CAPTCHA_TOKEN } from '@/middleware/captcha/__tests__'
 import { HttpStatus } from '@/net/http'
 
@@ -83,19 +83,6 @@ describe('Request Password Reset Endpoint', () => {
       for (const { headers, body } of scenarios) {
         const res = await post(app, REQUEST_PASSWORD_RESET_URL, body, headers)
         expect(res.status).toBe(HttpStatus.BAD_REQUEST)
-      }
-    })
-
-    it('should only accept POST method', async () => {
-      const methods = ['GET', 'PUT', 'DELETE', 'PATCH']
-
-      for (const method of methods) {
-        const res = await doRequest(app, REQUEST_PASSWORD_RESET_URL, method, {
-          email: 'test@example.com',
-          captchaToken: VALID_CAPTCHA_TOKEN,
-        }, { 'Content-Type': 'application/json' })
-
-        expect(res.status).toBe(HttpStatus.NOT_FOUND)
       }
     })
   })

--- a/src/routes/auth/resend-verification-email/__tests__/endpoint.test.ts
+++ b/src/routes/auth/resend-verification-email/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, doRequest, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post } from '@/__tests__'
 import { mockCaptchaSuccess, VALID_CAPTCHA_TOKEN } from '@/middleware/captcha/__tests__'
 import { HttpStatus } from '@/net/http'
 
@@ -91,19 +91,6 @@ describe('Resend Verification Email Endpoint', () => {
         const res = await post(app, RESEND_VERIFICATION_EMAIL_URL, body, headers)
 
         expect(res.status).toBe(HttpStatus.BAD_REQUEST)
-      }
-    })
-
-    it('should only accept POST method', async () => {
-      const methods = ['GET', 'PUT', 'DELETE', 'PATCH']
-
-      for (const method of methods) {
-        const res = await doRequest(app, RESEND_VERIFICATION_EMAIL_URL, method, {
-          email: 'test@example.com',
-          captchaToken: VALID_CAPTCHA_TOKEN,
-        }, { 'Content-Type': 'application/json' })
-
-        expect(res.status).toBe(HttpStatus.NOT_FOUND)
       }
     })
   })

--- a/src/routes/auth/reset-password/__tests__/endpoint.test.ts
+++ b/src/routes/auth/reset-password/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, doRequest, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { TOKEN_LENGTH } from '@/security/token'
 
@@ -120,16 +120,6 @@ describe('Reset Password Endpoint', () => {
 
         expect(res.status).toBe(HttpStatus.BAD_REQUEST)
         expect(mockResetPassword).not.toHaveBeenCalled()
-      }
-    })
-
-    it('should only accept POST method', async () => {
-      const methods = ['GET', 'PUT', 'DELETE', 'PATCH']
-
-      for (const method of methods) {
-        const res = await doRequest(app, RESET_PASSWORD_URL, method, validPayload, { 'Content-Type': 'application/json' })
-
-        expect(res.status).toBe(HttpStatus.NOT_FOUND)
       }
     })
   })

--- a/src/routes/auth/signup/__tests__/endpoint.test.ts
+++ b/src/routes/auth/signup/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, doRequest, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post } from '@/__tests__'
 import { mockCaptchaSuccess, VALID_CAPTCHA_TOKEN } from '@/middleware/captcha/__tests__'
 import { HttpStatus } from '@/net/http'
 import { Role, Status } from '@/types'
@@ -188,22 +188,6 @@ describe('Signup Endpoint', () => {
       expect(res.status).toBe(HttpStatus.INTERNAL_SERVER_ERROR)
       expect(mockSetRefreshCookie).not.toHaveBeenCalled()
       expect(mockSignUpWithEmail).toHaveBeenCalledTimes(1)
-    })
-
-    it('should only accept POST method', async () => {
-      const methods = ['GET', 'PUT', 'DELETE', 'PATCH']
-
-      for (const method of methods) {
-        const res = await doRequest(app, SIGNUP_URL, method, {
-          firstName: 'John',
-          lastName: 'Doe',
-          email: 'test@example.com',
-          password: 'ValidPass123!',
-          captchaToken: VALID_CAPTCHA_TOKEN,
-        }, { 'Content-Type': 'application/json' })
-
-        expect(res.status).toBe(HttpStatus.NOT_FOUND)
-      }
     })
   })
 })

--- a/src/routes/auth/verify-email/__tests__/endpoint.test.ts
+++ b/src/routes/auth/verify-email/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, doRequest, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { Role, Status } from '@/types'
 
@@ -128,17 +128,6 @@ describe('Verify Email Endpoint', () => {
 
       expect(res.status).toBe(HttpStatus.INTERNAL_SERVER_ERROR)
       expect(mockVerifyEmail).toHaveBeenCalledTimes(1)
-    })
-
-    it('should only accept POST method', async () => {
-      const methods = ['GET', 'PUT', 'DELETE', 'PATCH']
-      const validToken = 'a'.repeat(64)
-
-      for (const method of methods) {
-        const res = await doRequest(app, VERIFY_EMAIL_URL, method, { token: validToken }, { 'Content-Type': 'application/json' })
-
-        expect(res.status).toBe(HttpStatus.NOT_FOUND)
-      }
     })
   })
 })


### PR DESCRIPTION
Remove "should only accept POST method" tests from all auth route endpoints. These tests verify framework-level behavior (Hono's method routing) rather than application logic.

Rationale:
- HTTP method validation is Hono's responsibility, not app code
- The notFound handler (only app code executed) has dedicated tests
- Every successful POST test implicitly proves method routing works
- Removes 7 redundant tests without impacting coverage

Also cleaned up unused doRequest imports from test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)