### PR TITLE
security: Consolidate credential error codes

### DIFF
--- a/src/errors/__tests__/app-error.test.ts
+++ b/src/errors/__tests__/app-error.test.ts
@@ -18,43 +18,43 @@ describe('AppError', () => {
   })
 
   test('should handle undefined custom message', () => {
-    const error = new AppError(ErrorCode.BadCredentials, undefined)
+    const error = new AppError(ErrorCode.InvalidCredentials, undefined)
 
-    expect(error.code).toBe(ErrorCode.BadCredentials)
+    expect(error.code).toBe(ErrorCode.InvalidCredentials)
     expect(error.name).toBe(APP_ERROR_NAME)
-    expect(error.message).toBe(ErrorRegistry[ErrorCode.BadCredentials].error)
+    expect(error.message).toBe(ErrorRegistry[ErrorCode.InvalidCredentials].error)
   })
 
   test('should handle null custom message', () => {
     // @ts-expect-error - testing invalid input
-    const error = new AppError(ErrorCode.BadCredentials, null)
+    const error = new AppError(ErrorCode.InvalidCredentials, null)
 
-    expect(error.code).toBe(ErrorCode.BadCredentials)
+    expect(error.code).toBe(ErrorCode.InvalidCredentials)
     expect(error.name).toBe(APP_ERROR_NAME)
-    expect(error.message).toBe(ErrorRegistry[ErrorCode.BadCredentials].error)
+    expect(error.message).toBe(ErrorRegistry[ErrorCode.InvalidCredentials].error)
   })
 
   test('should handle empty string custom message', () => {
-    const error = new AppError(ErrorCode.BadCredentials, '')
+    const error = new AppError(ErrorCode.InvalidCredentials, '')
 
-    expect(error.code).toBe(ErrorCode.BadCredentials)
+    expect(error.code).toBe(ErrorCode.InvalidCredentials)
     expect(error.name).toBe(APP_ERROR_NAME)
-    expect(error.message).toBe(ErrorRegistry[ErrorCode.BadCredentials].error)
+    expect(error.message).toBe(ErrorRegistry[ErrorCode.InvalidCredentials].error)
   })
 
   test('should handle whitespace-only custom message', () => {
-    const error = new AppError(ErrorCode.BadCredentials, '   ')
+    const error = new AppError(ErrorCode.InvalidCredentials, '   ')
 
-    expect(error.code).toBe(ErrorCode.BadCredentials)
+    expect(error.code).toBe(ErrorCode.InvalidCredentials)
     expect(error.name).toBe(APP_ERROR_NAME)
-    expect(error.message).toBe(ErrorRegistry[ErrorCode.BadCredentials].error)
+    expect(error.message).toBe(ErrorRegistry[ErrorCode.InvalidCredentials].error)
   })
 
   test('should create AppError with custom message that overrides ErrorRegistry', () => {
     const customMessage = 'Custom error message for testing'
-    const error = new AppError(ErrorCode.BadCredentials, customMessage)
+    const error = new AppError(ErrorCode.InvalidCredentials, customMessage)
 
-    expect(error.code).toBe(ErrorCode.BadCredentials)
+    expect(error.code).toBe(ErrorCode.InvalidCredentials)
     expect(error.name).toBe(APP_ERROR_NAME)
     expect(error.message).toBe(customMessage)
   })

--- a/src/errors/codes.ts
+++ b/src/errors/codes.ts
@@ -3,7 +3,6 @@
 // to ensure all error codes have corresponding HTTP status mappings
 enum ErrorCode {
   AlreadyVerified = 'auth/already-verified',
-  BadCredentials = 'auth/bad-credentials',
   EmailAlreadyInUse = 'auth/email-already-in-use',
   Forbidden = 'auth/unverified-account',
   InvalidCredentials = 'auth/invalid-credentials',

--- a/src/errors/registry.ts
+++ b/src/errors/registry.ts
@@ -9,9 +9,6 @@ const ErrorRegistry: Record<ErrorCode, ErrorDetails> = {
   [ErrorCode.AlreadyVerified]: {
     error: 'User is already verified.',
   },
-  [ErrorCode.BadCredentials]: {
-    error: 'Invalid email or password.',
-  },
   [ErrorCode.EmailAlreadyInUse]: {
     error: 'Email is already in use.',
   },
@@ -19,7 +16,7 @@ const ErrorRegistry: Record<ErrorCode, ErrorDetails> = {
     error: 'Unverified account.',
   },
   [ErrorCode.InvalidCredentials]: {
-    error: 'Invalid credentials.',
+    error: 'Invalid email or password.',
   },
   [ErrorCode.Unauthorized]: {
     error: 'Unauthorized access.',

--- a/src/handlers/http-status-mapper.ts
+++ b/src/handlers/http-status-mapper.ts
@@ -4,7 +4,6 @@ import { HttpStatus } from '@/net/http'
 const httpStatusMap: Record<ErrorCode, HttpStatus> = {
   // Auth errors
   [ErrorCode.AlreadyVerified]: HttpStatus.BAD_REQUEST,
-  [ErrorCode.BadCredentials]: HttpStatus.UNAUTHORIZED,
   [ErrorCode.EmailAlreadyInUse]: HttpStatus.CONFLICT,
   [ErrorCode.Forbidden]: HttpStatus.FORBIDDEN,
   [ErrorCode.InvalidCredentials]: HttpStatus.UNAUTHORIZED,

--- a/src/use-cases/auth/__tests__/login.test.ts
+++ b/src/use-cases/auth/__tests__/login.test.ts
@@ -167,12 +167,12 @@ describe('Login with Email', () => {
   })
 
   describe('password validation scenarios', () => {
-    it('should throw BadCredentials for incorrect password', async () => {
+    it('should throw InvalidCredentials for incorrect password', async () => {
       mockComparePasswords.mockImplementation(async () => false)
 
       expect(logInWithEmail(mockLoginParams)).rejects.toMatchObject({
         name: 'AppError',
-        code: ErrorCode.BadCredentials,
+        code: ErrorCode.InvalidCredentials,
       })
     })
 
@@ -181,7 +181,7 @@ describe('Login with Email', () => {
 
       expect(logInWithEmail({ ...mockLoginParams, password: '' })).rejects.toMatchObject({
         name: 'AppError',
-        code: ErrorCode.BadCredentials,
+        code: ErrorCode.InvalidCredentials,
       })
     })
 

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -54,7 +54,7 @@ const logInWithEmail = async ({ email, password, deviceInfo }: LoginParams) => {
   const isPasswordValid = await comparePasswords(password, auth.passwordHash)
 
   if (!isPasswordValid) {
-    throw new AppError(ErrorCode.BadCredentials)
+    throw new AppError(ErrorCode.InvalidCredentials)
   }
 
   const accessToken = await createAccessToken(user)


### PR DESCRIPTION
Merge BadCredentials into InvalidCredentials to prevent email enumeration attacks. Both error codes previously mapped to HTTP 401 but returned different messages, allowing attackers to probe for valid email addresses.

Changes:
- Remove ErrorCode.BadCredentials from error codes enum
- Update InvalidCredentials message to "Invalid email or password"
- Update login use case to use InvalidCredentials for all failures
- Update HTTP status mapper to remove BadCredentials mapping
- Update tests to reflect consolidated error code

All login failures (user not found, auth missing, wrong password) now return the same error code and message, eliminating the ability to distinguish between non-existent and existing accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)