### PR TITLE
Remove type conversion functions using Drizzle $type

### DIFF
--- a/src/data/repositories/auth/queries.ts
+++ b/src/data/repositories/auth/queries.ts
@@ -1,19 +1,10 @@
 import { eq } from 'drizzle-orm'
 
-import type { AuthProvider } from '@/types'
-
 import type { Database } from '../../clients'
-import type { Auth, AuthRecord } from './types'
+import type { Auth } from './types'
 
 import { db } from '../../clients'
 import { authTable } from '../../schema'
-
-export const toTypeSafeAuth = (auth: AuthRecord): Auth => {
-  return {
-    ...auth,
-    provider: auth.provider as AuthProvider,
-  }
-}
 
 export const findByUserId = async (
   userId: number,
@@ -26,5 +17,5 @@ export const findByUserId = async (
     .from(authTable)
     .where(eq(authTable.userId, userId))
 
-  return foundAuth ? toTypeSafeAuth(foundAuth) : undefined
+  return foundAuth
 }

--- a/src/data/repositories/token/mutations.ts
+++ b/src/data/repositories/token/mutations.ts
@@ -1,5 +1,7 @@
 import { and, eq, isNull } from 'drizzle-orm'
 
+import type { TokenType } from '@/security/token'
+
 import { TokenStatus } from '@/security/token'
 
 import type { Database } from '../../clients'
@@ -10,7 +12,7 @@ import { tokensTable } from '../../schema'
 
 export const deprecateOldTokens = async (
   userId: number,
-  tokenType: string,
+  tokenType: TokenType,
   tx?: Database,
 ) => {
   const executor = tx || db

--- a/src/data/repositories/token/queries.ts
+++ b/src/data/repositories/token/queries.ts
@@ -1,20 +1,10 @@
 import { eq } from 'drizzle-orm'
 
-import type { TokenStatus, TokenType } from '@/security/token'
-
 import type { Database } from '../../clients'
-import type { Token, TokenRecord } from './types'
+import type { Token } from './types'
 
 import { db } from '../../clients'
 import { tokensTable } from '../../schema'
-
-export const toTypeSafeToken = (token: TokenRecord): Token => {
-  return {
-    ...token,
-    type: token.type as TokenType,
-    status: token.status as TokenStatus,
-  }
-}
 
 export const findByToken = async (
   token: string,
@@ -29,5 +19,5 @@ export const findByToken = async (
       eq(tokensTable.token, token),
     )
 
-  return foundToken ? toTypeSafeToken(foundToken) : undefined
+  return foundToken
 }

--- a/src/data/repositories/user/mutations.ts
+++ b/src/data/repositories/user/mutations.ts
@@ -7,7 +7,6 @@ import type { CreateUserInput, UpdateUserInput, User } from './types'
 
 import { db } from '../../clients'
 import { usersTable } from '../../schema'
-import { toTypeSafeUser } from './queries'
 
 export const createUser = async (user: CreateUserInput, tx?: Database): Promise<User> => {
   const executor = tx || db
@@ -21,7 +20,7 @@ export const createUser = async (user: CreateUserInput, tx?: Database): Promise<
     throw new AppError(ErrorCode.InternalError, 'Failed to create user')
   }
 
-  return toTypeSafeUser(createdUser) as User
+  return createdUser
 }
 
 export const updateUser = async (
@@ -41,7 +40,7 @@ export const updateUser = async (
     throw new AppError(ErrorCode.InternalError, 'Failed to update user')
   }
 
-  return toTypeSafeUser(updatedUser) as User
+  return updatedUser
 }
 
 export const deleteUser = async (email: string, tx?: Database): Promise<void> => {

--- a/src/data/repositories/user/queries.ts
+++ b/src/data/repositories/user/queries.ts
@@ -4,23 +4,11 @@ import type { Role, Status } from '@/types'
 
 import type { Database } from '../../clients'
 import type { PaginatedResult, PaginationParams } from '../pagination'
-import type { User, UserRecord } from './types'
+import type { User } from './types'
 
 import { db } from '../../clients'
 import { usersTable } from '../../schema'
 import { calcOffset } from '../pagination'
-
-export const toTypeSafeUser = (user: UserRecord): User | undefined => {
-  if (!user) {
-    return undefined
-  }
-
-  return {
-    ...user,
-    status: user.status as Status,
-    role: user.role as Role,
-  }
-}
 
 export const findUserById = async (
   userId: number,
@@ -33,7 +21,7 @@ export const findUserById = async (
     .from(usersTable)
     .where(eq(usersTable.id, userId))
 
-  return toTypeSafeUser(foundUser)
+  return foundUser
 }
 
 export const findUserByEmail = async (
@@ -47,7 +35,7 @@ export const findUserByEmail = async (
     .from(usersTable)
     .where(eq(usersTable.email, email))
 
-  return toTypeSafeUser(foundUser)
+  return foundUser
 }
 
 export interface SearchParams {
@@ -96,7 +84,7 @@ export const search = async (
   const totalCount = countResult[0]?.value ?? 0
 
   return {
-    users: users.map(u => toTypeSafeUser(u)!),
+    users,
     pagination: {
       page,
       limit,

--- a/src/data/schema/auth.ts
+++ b/src/data/schema/auth.ts
@@ -19,7 +19,7 @@ export const authProviderEnum = createPgEnum('auth_provider', AuthProvider)
 export const authTable = pgTable('auth', {
   id: serial('id').primaryKey(),
   userId: integer('user_id').notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
-  provider: authProviderEnum('provider').notNull(),
+  provider: authProviderEnum('provider').notNull().$type<AuthProvider>(),
   identifier: varchar('identifier', { length: 255 }).notNull(),
   passwordHash: varchar('password_hash', { length: 255 }),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),

--- a/src/data/schema/tokens.ts
+++ b/src/data/schema/tokens.ts
@@ -19,8 +19,8 @@ export const tokenStatusEnum = createPgEnum('token_status', TokenStatus)
 export const tokensTable = pgTable('tokens', {
   id: serial('id').primaryKey(),
   userId: integer('user_id').notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
-  type: tokenTypeEnum('type').notNull(),
-  status: tokenStatusEnum('status').notNull().default(TokenStatus.Pending),
+  type: tokenTypeEnum('type').notNull().$type<TokenType>(),
+  status: tokenStatusEnum('status').notNull().default(TokenStatus.Pending).$type<TokenStatus>(),
   token: text('token').notNull().unique(),
   expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
   usedAt: timestamp('used_at', { withTimezone: true }),

--- a/src/data/schema/users.ts
+++ b/src/data/schema/users.ts
@@ -17,8 +17,8 @@ export const usersTable = pgTable('users', {
   firstName: varchar('first_name', { length: 100 }).notNull(),
   lastName: varchar('last_name', { length: 100 }),
   email: varchar('email', { length: 255 }).notNull().unique(),
-  role: roleEnum('role').notNull().default(Role.User),
-  status: statusEnum('status').notNull().default(Status.New),
+  role: roleEnum('role').notNull().default(Role.User).$type<Role>(),
+  status: statusEnum('status').notNull().default(Status.New).$type<Status>(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 })

--- a/src/use-cases/auth/__tests__/login.test.ts
+++ b/src/use-cases/auth/__tests__/login.test.ts
@@ -4,7 +4,7 @@ import type { AuthRecord, User } from '@/data'
 
 import { ModuleMocker } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
-import { Role, Status } from '@/types'
+import { AuthProvider, Role, Status } from '@/types'
 
 import type { LoginParams } from '../login'
 
@@ -55,7 +55,7 @@ describe('Login with Email', () => {
     mockAuthRecord = {
       id: 1,
       userId: 1,
-      provider: 'local',
+      provider: AuthProvider.Local,
       identifier: 'test@example.com',
       passwordHash: '$2b$10$hashedPassword123',
       createdAt: new Date('2024-01-01'),

--- a/src/use-cases/auth/__tests__/request-password-reset.test.ts
+++ b/src/use-cases/auth/__tests__/request-password-reset.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { User } from '@/data'
 
 import { ModuleMocker } from '@/__tests__'
-import { toTypeSafeUser } from '@/data/repositories/user/queries'
 import { TokenType } from '@/security/token'
 import { Role, Status } from '@/types'
 import { hour, nowPlus } from '@/utils/chrono'
@@ -25,7 +24,7 @@ describe('Request Password Reset', () => {
   let mockEmailAgent: any
 
   beforeEach(async () => {
-    mockUser = toTypeSafeUser({
+    mockUser = {
       id: 1,
       firstName: 'John',
       lastName: 'Doe',
@@ -34,7 +33,7 @@ describe('Request Password Reset', () => {
       role: Role.User,
       createdAt: new Date(),
       updatedAt: new Date(),
-    })!
+    }
     mockUserRepo = {
       findByEmail: mock(async () => mockUser),
     }

--- a/src/use-cases/auth/__tests__/resend-verification-email.test.ts
+++ b/src/use-cases/auth/__tests__/resend-verification-email.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { User } from '@/data'
 
 import { ModuleMocker } from '@/__tests__'
-import { toTypeSafeUser } from '@/data/repositories/user/queries'
 import { TokenType } from '@/security/token'
 import { Role, Status } from '@/types'
 import { hours, nowPlus } from '@/utils/chrono'
@@ -25,7 +24,7 @@ describe('Resend Verification Email', () => {
   let mockEmailAgent: any
 
   beforeEach(async () => {
-    mockUser = toTypeSafeUser({
+    mockUser = {
       id: 1,
       firstName: 'John',
       lastName: 'Doe',
@@ -34,7 +33,7 @@ describe('Resend Verification Email', () => {
       role: Role.User,
       createdAt: new Date(),
       updatedAt: new Date(),
-    })!
+    }
 
     mockUserRepo = {
       findByEmail: mock(async () => mockUser),

--- a/src/use-cases/auth/__tests__/signup.test.ts
+++ b/src/use-cases/auth/__tests__/signup.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { User } from '@/data'
 
 import { ModuleMocker } from '@/__tests__/module-mocker'
-import { toTypeSafeUser } from '@/data/repositories/user/queries'
 import { AppError, ErrorCode } from '@/errors'
 import { TokenType } from '@/security/token'
 import { AuthProvider, Role, Status } from '@/types'
@@ -55,7 +54,7 @@ describe('Signup with Email', () => {
       userAgent: 'Mozilla/5.0 (Test)',
     }
 
-    mockNewUser = toTypeSafeUser({
+    mockNewUser = {
       id: 1,
       firstName: 'John',
       lastName: 'Doe',
@@ -64,7 +63,7 @@ describe('Signup with Email', () => {
       role: Role.User,
       createdAt: new Date(),
       updatedAt: new Date(),
-    })!
+    }
     mockUserRepo = {
       findByEmail: mock(async () => null),
       create: mock(async () => mockNewUser),


### PR DESCRIPTION
- Add $type<EnumType>() to enum columns in schema definitions
- Remove toTypeSafeAuth, toTypeSafeUser, and toTypeSafeToken functions
- Update query and mutation functions to return inferred types directly
- Update test files to remove conversion function usage
- Fix type errors in token mutations and login test

This change leverages Drizzle's built-in type inference for enums, eliminating the need for manual type conversion functions.