### PR TITLE
Add owner routes for admin management

### DIFF
--- a/postman.json
+++ b/postman.json
@@ -474,6 +474,46 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "owner",
+			"item": [
+				{
+					"name": "admins",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{owner_api_url}}/admins",
+							"host": [
+								"{{owner_api_url}}"
+							],
+							"path": [
+								"admins"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "admins/:id",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{owner_api_url}}/admins/2",
+							"host": [
+								"{{owner_api_url}}"
+							],
+							"path": [
+								"admins",
+								"2"
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"auth": {

--- a/src/data/scripts/seed-fake-users.ts
+++ b/src/data/scripts/seed-fake-users.ts
@@ -17,7 +17,7 @@
 import { faker } from '@faker-js/faker'
 import { like } from 'drizzle-orm'
 
-import { AuthProvider, Role, Status } from '@/types'
+import { AuthProvider, Status, USER_ROLES } from '@/types'
 
 import { db } from '../clients'
 import { authTable, usersTable } from '../schema'
@@ -39,7 +39,7 @@ const generateUser = (index: number) => {
     firstName,
     lastName,
     email: `${sanitizeForEmail(firstName)}.${lastNamePart}+${index}@test.local`,
-    role: faker.helpers.arrayElement([Role.User, Role.Enterprise]),
+    role: faker.helpers.arrayElement(USER_ROLES),
     status: faker.helpers.arrayElement([Status.New, Status.Verified, Status.Active]),
   }
 }

--- a/src/errors/codes.ts
+++ b/src/errors/codes.ts
@@ -4,7 +4,7 @@
 enum ErrorCode {
   AlreadyVerified = 'auth/already-verified',
   EmailAlreadyInUse = 'auth/email-already-in-use',
-  Forbidden = 'auth/unverified-account',
+  Forbidden = 'auth/forbidden',
   InvalidCredentials = 'auth/invalid-credentials',
   Unauthorized = 'auth/unauthorized',
 

--- a/src/errors/registry.ts
+++ b/src/errors/registry.ts
@@ -13,7 +13,7 @@ const ErrorRegistry: Record<ErrorCode, ErrorDetails> = {
     error: 'Email is already in use.',
   },
   [ErrorCode.Forbidden]: {
-    error: 'Unverified account.',
+    error: 'Forbidden.',
   },
   [ErrorCode.InvalidCredentials]: {
     error: 'Invalid email or password.',

--- a/src/routes/@shared/data-rules.ts
+++ b/src/routes/@shared/data-rules.ts
@@ -7,6 +7,8 @@ import { Role } from '@/types'
 const normalizeEmail = (email: string): string => email.trim().toLowerCase()
 
 export const dataRules = {
+  id: z.coerce.number().int().positive(),
+
   email: z
     .string()
     .transform(normalizeEmail)

--- a/src/routes/@shared/index.ts
+++ b/src/routes/@shared/index.ts
@@ -2,14 +2,18 @@ import { z } from 'zod'
 
 import { captchaRules } from './captcha-rules'
 import { dataRules } from './data-rules'
+import { paginationRules } from './pagination-rules'
 import { preferencesRules } from './preferences-rules'
+import { userFilterRules } from './user-filter-rules'
 
 export type { AppCtx, ValidatedJsonCtx, ValidatedParamCtx, ValidatedQueryCtx } from './handler'
 
 export const requestValidationRules = {
   data: dataRules,
   captcha: captchaRules,
+  pagination: paginationRules,
   preferences: preferencesRules,
+  userFilter: userFilterRules,
 }
 
 export const nestedSchemas = {

--- a/src/routes/@shared/pagination-rules.ts
+++ b/src/routes/@shared/pagination-rules.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+const DEFAULT_PAGE = 1
+const DEFAULT_LIMIT = 25
+const MAX_LIMIT = 100
+
+export const paginationRules = {
+  page: z.coerce.number().int().min(1).default(DEFAULT_PAGE),
+  limit: z.coerce.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+}

--- a/src/routes/@shared/user-filter-rules.ts
+++ b/src/routes/@shared/user-filter-rules.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+import { Role, Status } from '@/types'
+
+export const userFilterRules = {
+  search: z.string().trim(),
+
+  statuses: z
+    .string()
+    .transform(val => val.split(','))
+    .pipe(z.array(z.nativeEnum(Status))),
+
+  roles: z
+    .string()
+    .transform(val => val.split(','))
+    .pipe(z.array(z.nativeEnum(Role))),
+}

--- a/src/routes/admin/users/__tests__/endpoint.test.ts
+++ b/src/routes/admin/users/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type { SearchResult, User } from '@/data'
+import type { User } from '@/data'
 import type { UserClaims } from '@/security/jwt'
 
 import { createTestApp, ModuleMocker } from '@/__tests__'
@@ -48,15 +48,13 @@ describe('Admin Users Endpoint', () => {
       },
     ]
 
-    mockSearchUsers = mock(async (): Promise<{ data: SearchResult }> => ({
-      data: {
-        users: mockUsers,
-        pagination: {
-          page: 1,
-          limit: DEFAULT_LIMIT,
-          total: 2,
-          totalPages: 1,
-        },
+    mockSearchUsers = mock(async () => ({
+      data: { users: mockUsers },
+      pagination: {
+        page: 1,
+        limit: DEFAULT_LIMIT,
+        total: 2,
+        totalPages: 1,
       },
     }))
 

--- a/src/routes/admin/users/__tests__/handler.test.ts
+++ b/src/routes/admin/users/__tests__/handler.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type { SearchResult, User } from '@/data'
+import type { User } from '@/data'
 
 import { ModuleMocker } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
-import { Role, Status } from '@/types'
+import { Role, Status, USER_ROLES } from '@/types'
 
 import { adminUserDetailHandler, adminUsersHandler } from '../handler'
 
@@ -38,7 +38,7 @@ describe('adminUsersHandler', () => {
     mockContext = {
       req: {
         valid: mock(() => ({
-          roles: [Role.User, Role.Enterprise],
+          roles: USER_ROLES,
           statuses: undefined,
           page: 1,
           limit: DEFAULT_LIMIT,
@@ -47,15 +47,13 @@ describe('adminUsersHandler', () => {
       json: mockJson,
     }
 
-    mockSearchUsers = mock(async (): Promise<{ data: SearchResult }> => ({
-      data: {
-        users: mockUsers,
-        pagination: {
-          page: 1,
-          limit: DEFAULT_LIMIT,
-          total: 1,
-          totalPages: 1,
-        },
+    mockSearchUsers = mock(async () => ({
+      data: { users: mockUsers },
+      pagination: {
+        page: 1,
+        limit: DEFAULT_LIMIT,
+        total: 1,
+        totalPages: 1,
       },
     }))
 
@@ -72,7 +70,7 @@ describe('adminUsersHandler', () => {
     await adminUsersHandler(mockContext)
 
     expect(mockSearchUsers).toHaveBeenCalledWith(
-      { roles: [Role.User, Role.Enterprise], statuses: undefined },
+      { roles: USER_ROLES, statuses: undefined },
       { page: 1, limit: DEFAULT_LIMIT },
     )
   })

--- a/src/routes/admin/users/handler.ts
+++ b/src/routes/admin/users/handler.ts
@@ -8,9 +8,9 @@ export const adminUsersHandler = async (c: UsersSearchCtx) => {
 
   const filters = { search, roles, statuses }
   const pagination = { page, limit }
-  const result = await searchUsers(filters, pagination)
+  const { data, pagination: paginationResult } = await searchUsers(filters, pagination)
 
-  return c.json(result.data, HttpStatus.OK)
+  return c.json({ ...data, pagination: paginationResult }, HttpStatus.OK)
 }
 
 export const adminUserDetailHandler = async (c: UserDetailCtx) => {

--- a/src/routes/admin/users/schema.ts
+++ b/src/routes/admin/users/schema.ts
@@ -1,34 +1,23 @@
 import { z } from 'zod'
 
-import { Role, Status, USER_ROLES } from '@/types'
+import { USER_ROLES } from '@/types'
 
 import type { ValidatedParamCtx, ValidatedQueryCtx } from '../../@shared'
 
-const DEFAULT_PAGE = 1
-const DEFAULT_LIMIT = 25
-const MAX_LIMIT = 100
+import { requestValidationRules as rules } from '../../@shared'
 
 export const usersSearchSchema = z.object({
-  search: z.string().trim().optional(),
-  roles: z
-    .string()
-    .transform(val => val.split(','))
-    .pipe(z.array(z.nativeEnum(Role)))
-    .default(USER_ROLES.join(',')),
-  statuses: z
-    .string()
-    .transform(val => val.split(','))
-    .pipe(z.array(z.nativeEnum(Status)))
-    .optional(),
-  page: z.coerce.number().int().min(1).default(DEFAULT_PAGE),
-  limit: z.coerce.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+  search: rules.userFilter.search.optional(),
+  roles: rules.userFilter.roles.default(USER_ROLES.join(',')),
+  statuses: rules.userFilter.statuses.optional(),
+  ...rules.pagination,
 })
 
 export type UsersSearchQuery = z.infer<typeof usersSearchSchema>
 export type UsersSearchCtx = ValidatedQueryCtx<UsersSearchQuery>
 
 export const userIdSchema = z.object({
-  id: z.coerce.number().int().positive(),
+  id: rules.data.id,
 })
 
 export type UserIdParam = z.infer<typeof userIdSchema>

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -13,6 +13,7 @@ import {
   signupRoute,
   verifyEmailRoute,
 } from './auth'
+import { ownerAdminsRoute } from './owner'
 import { meRoute } from './user'
 
 export const authPublicRoutes: Hono<AppContext>[] = [
@@ -31,3 +32,5 @@ export const userRoutesAllowNew: Hono<AppContext>[] = [meRoute]
 export const userRoutesVerifiedOnly: Hono<AppContext>[] = []
 
 export const adminRoutes: Hono<AppContext>[] = [adminUsersRoute]
+
+export const ownerRoutes: Hono<AppContext>[] = [ownerAdminsRoute]

--- a/src/routes/owner/admins/__tests__/handler.test.ts
+++ b/src/routes/owner/admins/__tests__/handler.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { User } from '@/data'
+
+import { ModuleMocker } from '@/__tests__'
+import { HttpStatus } from '@/net/http'
+import { Role, Status } from '@/types'
+
+import { ownerAdminDetailHandler, ownerAdminsHandler } from '../handler'
+
+describe('ownerAdminsHandler', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  const DEFAULT_LIMIT = 25
+
+  let mockContext: any
+  let mockJson: any
+
+  let mockAdmins: User[]
+  let mockSearchAdmins: any
+
+  beforeEach(async () => {
+    mockAdmins = [
+      {
+        id: 1,
+        firstName: 'Admin',
+        lastName: 'User',
+        email: 'admin@example.com',
+        role: Role.Admin,
+        status: Status.Active,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      },
+    ]
+
+    mockJson = mock((data: any, status: number) => ({ data, status }))
+
+    mockContext = {
+      req: {
+        valid: mock(() => ({
+          statuses: undefined,
+          page: 1,
+          limit: DEFAULT_LIMIT,
+        })),
+      },
+      json: mockJson,
+    }
+
+    mockSearchAdmins = mock(async () => ({
+      data: { users: mockAdmins },
+      pagination: {
+        page: 1,
+        limit: DEFAULT_LIMIT,
+        total: 1,
+        totalPages: 1,
+      },
+    }))
+
+    await moduleMocker.mock('@/use-cases/owner', () => ({
+      searchAdmins: mockSearchAdmins,
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should call searchAdmins with correct parameters', async () => {
+    await ownerAdminsHandler(mockContext)
+
+    expect(mockSearchAdmins).toHaveBeenCalledWith(
+      { search: undefined, roles: [], statuses: undefined },
+      { page: 1, limit: DEFAULT_LIMIT },
+    )
+  })
+
+  it('should return admins and pagination with OK status', async () => {
+    const result = await ownerAdminsHandler(mockContext)
+
+    expect(mockJson).toHaveBeenCalledWith(
+      {
+        users: mockAdmins,
+        pagination: {
+          page: 1,
+          limit: DEFAULT_LIMIT,
+          total: 1,
+          totalPages: 1,
+        },
+      },
+      HttpStatus.OK,
+    )
+    expect(result.status).toBe(HttpStatus.OK)
+  })
+
+  it('should propagate error when searchAdmins throws', async () => {
+    mockSearchAdmins.mockImplementation(async () => {
+      throw new Error('Database connection failed')
+    })
+
+    expect(ownerAdminsHandler(mockContext)).rejects.toThrow('Database connection failed')
+  })
+})
+
+describe('ownerAdminDetailHandler', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockContext: any
+  let mockJson: any
+
+  let mockAdmin: User
+  let mockGetAdmin: any
+
+  beforeEach(async () => {
+    mockAdmin = {
+      id: 1,
+      firstName: 'Admin',
+      lastName: 'User',
+      email: 'admin@example.com',
+      role: Role.Admin,
+      status: Status.Active,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+    }
+
+    mockJson = mock((data: any, status: number) => ({ data, status }))
+
+    mockContext = {
+      req: {
+        valid: mock(() => ({ id: 1 })),
+      },
+      json: mockJson,
+    }
+
+    mockGetAdmin = mock(async () => ({ data: { user: mockAdmin } }))
+
+    await moduleMocker.mock('@/use-cases/owner', () => ({
+      getAdmin: mockGetAdmin,
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should call getAdmin with correct admin id', async () => {
+    await ownerAdminDetailHandler(mockContext)
+
+    expect(mockGetAdmin).toHaveBeenCalledWith(1)
+  })
+
+  it('should return admin with OK status', async () => {
+    const result = await ownerAdminDetailHandler(mockContext)
+
+    expect(mockJson).toHaveBeenCalledWith({ user: mockAdmin }, HttpStatus.OK)
+    expect(result.status).toBe(HttpStatus.OK)
+  })
+
+  it('should propagate error when getAdmin throws', async () => {
+    mockGetAdmin.mockImplementation(async () => {
+      throw new Error('Admin not found')
+    })
+
+    expect(ownerAdminDetailHandler(mockContext)).rejects.toThrow('Admin not found')
+  })
+})

--- a/src/routes/owner/admins/handler.ts
+++ b/src/routes/owner/admins/handler.ts
@@ -1,0 +1,22 @@
+import { HttpStatus } from '@/net/http'
+import { getAdmin, searchAdmins } from '@/use-cases/owner'
+
+import type { AdminDetailCtx, AdminsSearchCtx } from './schema'
+
+export const ownerAdminsHandler = async (c: AdminsSearchCtx) => {
+  const { search, statuses, page, limit } = c.req.valid('query')
+
+  const filters = { search, roles: [], statuses }
+  const pagination = { page, limit }
+  const { data, pagination: paginationResult } = await searchAdmins(filters, pagination)
+
+  return c.json({ ...data, pagination: paginationResult }, HttpStatus.OK)
+}
+
+export const ownerAdminDetailHandler = async (c: AdminDetailCtx) => {
+  const { id } = c.req.valid('param')
+
+  const result = await getAdmin(id)
+
+  return c.json(result.data, HttpStatus.OK)
+}

--- a/src/routes/owner/admins/index.ts
+++ b/src/routes/owner/admins/index.ts
@@ -1,0 +1,23 @@
+import { Hono } from 'hono'
+
+import type { AppContext } from '@/context'
+
+import { requestValidator } from '@/middleware'
+
+import { ownerAdminDetailHandler, ownerAdminsHandler } from './handler'
+import { adminIdSchema, adminsSearchSchema } from './schema'
+
+const ownerAdminsRoute = new Hono<AppContext>()
+
+ownerAdminsRoute.get(
+  '/admins',
+  requestValidator('query', adminsSearchSchema),
+  ownerAdminsHandler,
+)
+ownerAdminsRoute.get(
+  '/admins/:id',
+  requestValidator('param', adminIdSchema),
+  ownerAdminDetailHandler,
+)
+
+export default ownerAdminsRoute

--- a/src/routes/owner/admins/schema.ts
+++ b/src/routes/owner/admins/schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { Role, Status, USER_ROLES } from '@/types'
+import { Status } from '@/types'
 
 import type { ValidatedParamCtx, ValidatedQueryCtx } from '../../@shared'
 
@@ -8,13 +8,8 @@ const DEFAULT_PAGE = 1
 const DEFAULT_LIMIT = 25
 const MAX_LIMIT = 100
 
-export const usersSearchSchema = z.object({
+export const adminsSearchSchema = z.object({
   search: z.string().trim().optional(),
-  roles: z
-    .string()
-    .transform(val => val.split(','))
-    .pipe(z.array(z.nativeEnum(Role)))
-    .default(USER_ROLES.join(',')),
   statuses: z
     .string()
     .transform(val => val.split(','))
@@ -24,12 +19,12 @@ export const usersSearchSchema = z.object({
   limit: z.coerce.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
 })
 
-export type UsersSearchQuery = z.infer<typeof usersSearchSchema>
-export type UsersSearchCtx = ValidatedQueryCtx<UsersSearchQuery>
+export type AdminsSearchQuery = z.infer<typeof adminsSearchSchema>
+export type AdminsSearchCtx = ValidatedQueryCtx<AdminsSearchQuery>
 
-export const userIdSchema = z.object({
+export const adminIdSchema = z.object({
   id: z.coerce.number().int().positive(),
 })
 
-export type UserIdParam = z.infer<typeof userIdSchema>
-export type UserDetailCtx = ValidatedParamCtx<UserIdParam>
+export type AdminIdParam = z.infer<typeof adminIdSchema>
+export type AdminDetailCtx = ValidatedParamCtx<AdminIdParam>

--- a/src/routes/owner/admins/schema.ts
+++ b/src/routes/owner/admins/schema.ts
@@ -1,29 +1,20 @@
 import { z } from 'zod'
 
-import { Status } from '@/types'
-
 import type { ValidatedParamCtx, ValidatedQueryCtx } from '../../@shared'
 
-const DEFAULT_PAGE = 1
-const DEFAULT_LIMIT = 25
-const MAX_LIMIT = 100
+import { requestValidationRules as rules } from '../../@shared'
 
 export const adminsSearchSchema = z.object({
-  search: z.string().trim().optional(),
-  statuses: z
-    .string()
-    .transform(val => val.split(','))
-    .pipe(z.array(z.nativeEnum(Status)))
-    .optional(),
-  page: z.coerce.number().int().min(1).default(DEFAULT_PAGE),
-  limit: z.coerce.number().int().min(1).max(MAX_LIMIT).default(DEFAULT_LIMIT),
+  search: rules.userFilter.search.optional(),
+  statuses: rules.userFilter.statuses.optional(),
+  ...rules.pagination,
 })
 
 export type AdminsSearchQuery = z.infer<typeof adminsSearchSchema>
 export type AdminsSearchCtx = ValidatedQueryCtx<AdminsSearchQuery>
 
 export const adminIdSchema = z.object({
-  id: z.coerce.number().int().positive(),
+  id: rules.data.id,
 })
 
 export type AdminIdParam = z.infer<typeof adminIdSchema>

--- a/src/routes/owner/index.ts
+++ b/src/routes/owner/index.ts
@@ -1,0 +1,1 @@
+export { default as ownerAdminsRoute } from './admins'

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import {
   generalRateLimiter,
   generalRequestSizeLimiter,
   loggerMiddleware,
+  ownerAuthMiddleware,
   secureHeadersMiddleware,
   userRelaxedAuthMiddleware,
   userStrictAuthMiddleware,
@@ -22,6 +23,7 @@ import {
 import {
   adminRoutes,
   authPublicRoutes,
+  ownerRoutes,
   userRoutesAllowNew,
   userRoutesVerifiedOnly,
 } from '@/routes'
@@ -71,6 +73,11 @@ class Server {
       '/api/v1/admin',
       adminRoutes,
       adminAuthMiddleware,
+    )
+    this.createRouteGroup(
+      '/api/v1/owner',
+      ownerRoutes,
+      ownerAuthMiddleware,
     )
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,6 @@ export { default as Action } from './action'
 export { default as AuthProvider } from './auth-providers'
 
 export { default as Resource } from './resource'
-export { isAdmin, isEnterprise, isOwner, isUser, isUserOrAdmin, default as Role } from './role'
+export { isAdmin, isEnterprise, isOwner, isUser, isUserOrAdmin, default as Role, USER_ROLES } from './role'
 export { isActive, isActiveOnly, isNewOrActive, default as Status } from './status'
 export type { SupportedLocale, Theme, UserPreferences } from './user-preferences'

--- a/src/types/role.ts
+++ b/src/types/role.ts
@@ -7,6 +7,8 @@ enum Role {
 
 export const isUser = (role: Role) => role === Role.User || role === Role.Enterprise
 
+export const USER_ROLES: Role[] = Object.values(Role).filter(isUser)
+
 export const isEnterprise = (role: Role) => role === Role.Enterprise
 
 export const isAdmin = (role: Role) => role === Role.Admin || role === Role.Owner

--- a/src/use-cases/admin/__tests__/users.test.ts
+++ b/src/use-cases/admin/__tests__/users.test.ts
@@ -5,7 +5,7 @@ import type { SearchResult, User } from '@/data'
 import { ModuleMocker } from '@/__tests__'
 import AppError from '@/errors/app-error'
 import ErrorCode from '@/errors/codes'
-import { Role, Status } from '@/types'
+import { Role, Status, USER_ROLES } from '@/types'
 
 import { getUser, searchUsers } from '../users'
 
@@ -58,7 +58,7 @@ describe('searchUsers', () => {
     await searchUsers({ roles: [Role.Admin, Role.Owner] }, DEFAULT_PAGINATION)
 
     expect(mockUserRepoSearch).toHaveBeenCalledWith(
-      { roles: [Role.User, Role.Enterprise] },
+      { roles: USER_ROLES },
       DEFAULT_PAGINATION,
     )
   })
@@ -67,10 +67,8 @@ describe('searchUsers', () => {
     const result = await searchUsers({ roles: [Role.User] }, DEFAULT_PAGINATION)
 
     expect(result).toEqual({
-      data: {
-        users: mockSearchResult.users,
-        pagination: mockSearchResult.pagination,
-      },
+      data: { users: mockSearchResult.users },
+      pagination: mockSearchResult.pagination,
     })
   })
 

--- a/src/use-cases/admin/users.ts
+++ b/src/use-cases/admin/users.ts
@@ -1,13 +1,12 @@
 import type { PaginationParams, SearchParams } from '@/data'
 
 import { userRepo } from '@/data'
-import AppError from '@/errors/app-error'
-import ErrorCode from '@/errors/codes'
-import { isUser, Role } from '@/types'
+import { AppError, ErrorCode } from '@/errors'
+import { isUser, USER_ROLES } from '@/types'
 
 const normalizeRoles = (params: SearchParams): SearchParams => {
   const filteredRoles = params.roles.filter(isUser)
-  const validRoles = filteredRoles.length > 0 ? filteredRoles : [Role.User, Role.Enterprise]
+  const validRoles = filteredRoles.length > 0 ? filteredRoles : USER_ROLES
 
   return {
     ...params,
@@ -19,17 +18,15 @@ export const searchUsers = async (params: SearchParams, pagination: PaginationPa
   const result = await userRepo.search(normalizeRoles(params), pagination)
 
   return {
-    data: {
-      users: result.users,
-      pagination: result.pagination,
-    },
+    data: { users: result.users },
+    pagination: result.pagination,
   }
 }
 
 export const getUser = async (userId: number) => {
   const user = await userRepo.findById(userId)
 
-  if (!user) {
+  if (!user || !isUser(user.role)) {
     throw new AppError(ErrorCode.NotFound, 'User not found')
   }
 

--- a/src/use-cases/index.ts
+++ b/src/use-cases/index.ts
@@ -1,3 +1,4 @@
 export * as admin from './admin'
 export * as auth from './auth'
+export * as owner from './owner'
 export * as user from './user'

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -58,7 +58,7 @@ describe('searchAdmins', () => {
     const result = await searchAdmins({ roles: [] }, DEFAULT_PAGINATION)
 
     expect(result).toEqual({
-      data: { users: mockSearchResult.users },
+      data: { admins: mockSearchResult.users },
       pagination: mockSearchResult.pagination,
     })
   })
@@ -109,7 +109,7 @@ describe('getAdmin', () => {
     const result = await getAdmin(1)
 
     expect(mockFindById).toHaveBeenCalledWith(1)
-    expect(result).toEqual({ data: { user: mockAdmin } })
+    expect(result).toEqual({ data: { admin: mockAdmin } })
   })
 
   it('should throw NotFound error when admin does not exist', async () => {

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { SearchResult, User } from '@/data'
+
+import { ModuleMocker } from '@/__tests__'
+import AppError from '@/errors/app-error'
+import ErrorCode from '@/errors/codes'
+import { Role, Status } from '@/types'
+
+import { getAdmin, searchAdmins } from '../admins'
+
+describe('searchAdmins', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  const DEFAULT_PAGINATION = { page: 1, limit: 25 }
+
+  let mockSearchResult: SearchResult
+  let mockUserRepoSearch: any
+
+  beforeEach(async () => {
+    mockSearchResult = {
+      users: [
+        {
+          id: 1,
+          firstName: 'Admin',
+          lastName: 'User',
+          email: 'admin@example.com',
+          role: Role.Admin,
+          status: Status.Active,
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+        },
+      ],
+      pagination: { page: 1, limit: 25, total: 1, totalPages: 1 },
+    }
+
+    mockUserRepoSearch = mock(async () => mockSearchResult)
+
+    await moduleMocker.mock('@/data', () => ({
+      userRepo: { search: mockUserRepoSearch },
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should always search with Admin role only', async () => {
+    await searchAdmins({ roles: [Role.User, Role.Enterprise] }, DEFAULT_PAGINATION)
+
+    expect(mockUserRepoSearch).toHaveBeenCalledWith(
+      { roles: [Role.Admin] },
+      DEFAULT_PAGINATION,
+    )
+  })
+
+  it('should return admins and pagination data', async () => {
+    const result = await searchAdmins({ roles: [] }, DEFAULT_PAGINATION)
+
+    expect(result).toEqual({
+      data: { users: mockSearchResult.users },
+      pagination: mockSearchResult.pagination,
+    })
+  })
+
+  it('should preserve statuses in search params', async () => {
+    await searchAdmins(
+      { roles: [], statuses: [Status.Active] },
+      DEFAULT_PAGINATION,
+    )
+
+    expect(mockUserRepoSearch).toHaveBeenCalledWith(
+      { roles: [Role.Admin], statuses: [Status.Active] },
+      DEFAULT_PAGINATION,
+    )
+  })
+})
+
+describe('getAdmin', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockAdmin: User
+  let mockFindById: any
+
+  beforeEach(async () => {
+    mockAdmin = {
+      id: 1,
+      firstName: 'Admin',
+      lastName: 'User',
+      email: 'admin@example.com',
+      role: Role.Admin,
+      status: Status.Active,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+    }
+
+    mockFindById = mock(async () => mockAdmin)
+
+    await moduleMocker.mock('@/data', () => ({
+      userRepo: { findById: mockFindById },
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should return admin when found', async () => {
+    const result = await getAdmin(1)
+
+    expect(mockFindById).toHaveBeenCalledWith(1)
+    expect(result).toEqual({ data: { user: mockAdmin } })
+  })
+
+  it('should throw NotFound error when admin does not exist', async () => {
+    mockFindById.mockImplementation(async () => undefined)
+
+    expect(getAdmin(999)).rejects.toThrow(AppError)
+    expect(getAdmin(999)).rejects.toMatchObject({
+      code: ErrorCode.NotFound,
+      message: 'Admin not found',
+    })
+  })
+
+  it('should throw NotFound error when user is not an Admin role', async () => {
+    mockFindById.mockImplementation(async () => ({
+      ...mockAdmin,
+      role: Role.User,
+    }))
+
+    expect(getAdmin(1)).rejects.toThrow(AppError)
+    expect(getAdmin(1)).rejects.toMatchObject({
+      code: ErrorCode.NotFound,
+      message: 'Admin not found',
+    })
+  })
+
+  it('should throw NotFound error when user is Owner role', async () => {
+    mockFindById.mockImplementation(async () => ({
+      ...mockAdmin,
+      role: Role.Owner,
+    }))
+
+    expect(getAdmin(1)).rejects.toThrow(AppError)
+    expect(getAdmin(1)).rejects.toMatchObject({
+      code: ErrorCode.NotFound,
+      message: 'Admin not found',
+    })
+  })
+})

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -13,17 +13,17 @@ export const searchAdmins = async (params: SearchParams, pagination: PaginationP
   const result = await userRepo.search(normalizeRoles(params), pagination)
 
   return {
-    data: { users: result.users },
+    data: { admins: result.users },
     pagination: result.pagination,
   }
 }
 
 export const getAdmin = async (adminId: number) => {
-  const user = await userRepo.findById(adminId)
+  const admin = await userRepo.findById(adminId)
 
-  if (!user || user.role !== Role.Admin) {
+  if (!admin || admin.role !== Role.Admin) {
     throw new AppError(ErrorCode.NotFound, 'Admin not found')
   }
 
-  return { data: { user } }
+  return { data: { admin } }
 }

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -1,0 +1,29 @@
+import type { PaginationParams, SearchParams } from '@/data'
+
+import { userRepo } from '@/data'
+import { AppError, ErrorCode } from '@/errors'
+import { Role } from '@/types'
+
+const normalizeRoles = (params: SearchParams): SearchParams => ({
+  ...params,
+  roles: [Role.Admin],
+})
+
+export const searchAdmins = async (params: SearchParams, pagination: PaginationParams) => {
+  const result = await userRepo.search(normalizeRoles(params), pagination)
+
+  return {
+    data: { users: result.users },
+    pagination: result.pagination,
+  }
+}
+
+export const getAdmin = async (adminId: number) => {
+  const user = await userRepo.findById(adminId)
+
+  if (!user || user.role !== Role.Admin) {
+    throw new AppError(ErrorCode.NotFound, 'Admin not found')
+  }
+
+  return { data: { user } }
+}

--- a/src/use-cases/owner/index.ts
+++ b/src/use-cases/owner/index.ts
@@ -1,0 +1,1 @@
+export { getAdmin, searchAdmins } from './admins'


### PR DESCRIPTION
## Summary

1. [Feature]: Add `/api/v1/owner/admins` routes for owner to manage admin users
2. [Feature]: Add `ownerAuthMiddleware` route group requiring Owner role and Active status
3. [Refactor]: Extract shared validation rules for pagination and user filters to `@shared`
4. [Fix]: Change generic `Forbidden` error code from `auth/unverified-account` to `auth/forbidden`
5. [Improvement]: Rename admin response fields from `users`/`user` to `admins`/`admin`
6. [Improvement]: Move pagination outside `data` object in search responses for cleaner API

## Test plan

- [x] Unit tests for owner use-cases (`searchAdmins`, `getAdmin`)
- [x] Unit tests for owner route handlers
- [x] Existing admin route tests updated and passing
- [ ] Manual test with owner JWT token against `/api/v1/owner/admins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)