### PR TITLE
Add auto-login after password reset

### DIFF
--- a/src/routes/auth/reset-password/handler.ts
+++ b/src/routes/auth/reset-password/handler.ts
@@ -1,12 +1,15 @@
-import { HttpStatus } from '@/net/http'
+import { getDeviceInfo, HttpStatus, setRefreshCookie } from '@/net/http'
 import resetPassword from '@/use-cases/auth/reset-password'
 
 import type { ResetPasswordCtx } from './schema'
 
 const resetPasswordHandler = async (c: ResetPasswordCtx) => {
   const payload = c.req.valid('json')
+  const deviceInfo = getDeviceInfo(c)
 
-  const result = await resetPassword(payload.data)
+  const result = await resetPassword({ ...payload.data, deviceInfo })
+
+  setRefreshCookie(c, result.refreshToken)
 
   return c.json(result.data, HttpStatus.OK)
 }


### PR DESCRIPTION
1. [Feature]: Return user and access token after successful password reset
2. [Feature]: Set refresh token cookie to enable seamless session creation
3. [Improvement]: Allow frontend to navigate directly to /home instead of /login

🤖 Generated with [Claude Code](https://claude.ai/code)