### PR TITLE
Migrate user ID from serial to UUID

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,3 +1,4 @@
 export { createTestApp } from './app'
 export { ModuleMocker } from './module-mocker'
 export { doRequest, get, post } from './request'
+export { createTestUuid, resetTestUuidCounter, testUuids } from './uuid'

--- a/src/__tests__/uuid.ts
+++ b/src/__tests__/uuid.ts
@@ -1,0 +1,67 @@
+/**
+ * Test UUID factory for generating predictable, readable UUIDs in tests
+ *
+ * Format: 00000000-0000-4000-a{type}{counter}
+ * Uses valid UUID v4 format with readable hex patterns
+ */
+
+let counter = 0
+
+// Hex-compatible type codes (readable but valid hex)
+const TYPE_CODES = {
+  user: 'a0', // user
+  admn: 'ad', // admin
+  ownr: '0e', // owner
+  tokn: 'f0', // token
+  test: '00', // generic test
+  none: 'ff', // non-existent
+} as const
+
+/**
+ * Generates a valid UUID v4 format with a type identifier
+ *
+ * @param type - Entity type identifier
+ * @returns Valid UUID string that passes Zod validation
+ *
+ * @example
+ * createTestUuid('user') // 00000000-0000-4000-a0a0-000000000001
+ */
+export const createTestUuid = (type: keyof typeof TYPE_CODES = 'test'): string => {
+  counter++
+  const typeCode = TYPE_CODES[type]
+  const paddedCounter = counter.toString(16).padStart(12, '0')
+
+  return `00000000-0000-4000-${typeCode}${typeCode}-${paddedCounter}`
+}
+
+/**
+ * Resets the UUID counter - call in beforeEach for test isolation
+ */
+export const resetTestUuidCounter = (): void => {
+  counter = 0
+}
+
+/**
+ * Pre-defined UUID constants for common test entities
+ * All UUIDs are valid v4 format that passes Zod .uuid() validation
+ */
+export const testUuids = {
+  // Users (a0a0 = user type)
+  USER_1: '00000000-0000-4000-a0a0-000000000001',
+  USER_2: '00000000-0000-4000-a0a0-000000000002',
+  USER_3: '00000000-0000-4000-a0a0-000000000003',
+
+  // Admins (adad = admin type)
+  ADMIN_1: '00000000-0000-4000-adad-000000000001',
+  ADMIN_2: '00000000-0000-4000-adad-000000000002',
+
+  // Owner (0e0e = owner type)
+  OWNER_1: '00000000-0000-4000-8e0e-000000000001',
+
+  // Tokens (f0f0 = token type)
+  TOKEN_1: '00000000-0000-4000-b0f0-000000000001',
+  TOKEN_2: '00000000-0000-4000-b0f0-000000000002',
+
+  // Non-existent (ffff = none type)
+  NON_EXISTENT: '00000000-0000-4000-bfff-000000000000',
+} as const

--- a/src/data/__tests__/migration.test.ts
+++ b/src/data/__tests__/migration.test.ts
@@ -139,7 +139,7 @@ describe('@with-db Database Migration Tests', () => {
     test('should enforce foreign key constraint on auth.user_id', async () => {
       expect(
         authRepo.create({
-          userId: 999999,
+          userId: '550e8400-e29b-41d4-a716-446655440999',
           provider: AuthProvider.Local,
           identifier: 'nonexistent@example.com',
           passwordHash: '$2b$10$hashedpassword',

--- a/src/data/__tests__/migration.test.ts
+++ b/src/data/__tests__/migration.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 import { sql } from 'drizzle-orm'
 
+import { testUuids } from '@/__tests__'
 import { db } from '@/data/clients/db'
 import { authRepo, userRepo } from '@/data/repositories'
 import { AuthProvider, Role, Status } from '@/types'
@@ -139,7 +140,7 @@ describe('@with-db Database Migration Tests', () => {
     test('should enforce foreign key constraint on auth.user_id', async () => {
       expect(
         authRepo.create({
-          userId: '550e8400-e29b-41d4-a716-446655440999',
+          userId: testUuids.NON_EXISTENT,
           provider: AuthProvider.Local,
           identifier: 'nonexistent@example.com',
           passwordHash: '$2b$10$hashedpassword',

--- a/src/data/migrations/0000_tired_justice.sql
+++ b/src/data/migrations/0000_tired_justice.sql
@@ -3,11 +3,11 @@ CREATE TYPE "public"."action" AS ENUM('view', 'create', 'edit', 'delete');--> st
 CREATE TYPE "public"."resource" AS ENUM('users', 'admins');--> statement-breakpoint
 CREATE TYPE "public"."role" AS ENUM('owner', 'admin', 'user', 'enterprise');--> statement-breakpoint
 CREATE TYPE "public"."token_status" AS ENUM('pending', 'used', 'deprecated');--> statement-breakpoint
-CREATE TYPE "public"."token_type" AS ENUM('email_verification', 'password_reset', 'refresh_token');--> statement-breakpoint
+CREATE TYPE "public"."token_type" AS ENUM('email_verification', 'password_reset', 'refresh_token', 'user_invitation');--> statement-breakpoint
 CREATE TYPE "public"."status" AS ENUM('new', 'verified', 'trial', 'active', 'suspended', 'archived', 'pending');--> statement-breakpoint
 CREATE TABLE "auth" (
 	"id" serial PRIMARY KEY NOT NULL,
-	"user_id" integer NOT NULL,
+	"user_id" uuid NOT NULL,
 	"provider" "auth_provider" NOT NULL,
 	"identifier" varchar(255) NOT NULL,
 	"password_hash" varchar(255),
@@ -31,7 +31,7 @@ CREATE TABLE "role_permissions" (
 --> statement-breakpoint
 CREATE TABLE "refresh_tokens" (
 	"id" serial PRIMARY KEY NOT NULL,
-	"user_id" integer NOT NULL,
+	"user_id" uuid NOT NULL,
 	"token_hash" varchar(64) NOT NULL,
 	"ip_address" varchar(45),
 	"user_agent" varchar(512),
@@ -44,7 +44,7 @@ CREATE TABLE "refresh_tokens" (
 --> statement-breakpoint
 CREATE TABLE "tokens" (
 	"id" serial PRIMARY KEY NOT NULL,
-	"user_id" integer NOT NULL,
+	"user_id" uuid NOT NULL,
 	"type" "token_type" NOT NULL,
 	"status" "token_status" DEFAULT 'pending' NOT NULL,
 	"token" text NOT NULL,
@@ -56,7 +56,7 @@ CREATE TABLE "tokens" (
 );
 --> statement-breakpoint
 CREATE TABLE "users" (
-	"id" serial PRIMARY KEY NOT NULL,
+	"id" uuid PRIMARY KEY NOT NULL,
 	"first_name" varchar(100) NOT NULL,
 	"last_name" varchar(100),
 	"email" varchar(255) NOT NULL,

--- a/src/data/migrations/custom/0001_users_search_index.sql
+++ b/src/data/migrations/custom/0001_users_search_index.sql
@@ -1,8 +1,8 @@
 -- Migration: Add pg_trgm index for user search
--- This enables fast ILIKE searches on firstName, lastName, and email fields
+-- Enables fast ILIKE searches on firstName, lastName, email, and id (UUID) fields
 
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 CREATE INDEX IF NOT EXISTS idx_users_search_trgm ON users USING gin (
-  (first_name || ' ' || COALESCE(last_name, '') || ' ' || email) gin_trgm_ops
+  (first_name || ' ' || COALESCE(last_name, '') || ' ' || email || ' ' || id::text) gin_trgm_ops
 );

--- a/src/data/migrations/custom/0002_add_user_invitation_token_type.sql
+++ b/src/data/migrations/custom/0002_add_user_invitation_token_type.sql
@@ -1,4 +1,0 @@
--- Migration: Add user_invitation to token_type enum
--- This enables invitation tokens for admin and enterprise user invitations
-
-ALTER TYPE token_type ADD VALUE IF NOT EXISTS 'user_invitation';

--- a/src/data/migrations/meta/0000_snapshot.json
+++ b/src/data/migrations/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "b481b91f-5ded-4ce7-8497-6df722ef3ade",
+  "id": "c2e480a4-08f3-4194-a2aa-9e4a0aeafbd3",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -16,7 +16,7 @@
         },
         "user_id": {
           "name": "user_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         },
@@ -262,7 +262,7 @@
         },
         "user_id": {
           "name": "user_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         },
@@ -402,7 +402,7 @@
         },
         "user_id": {
           "name": "user_id",
-          "type": "integer",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         },
@@ -532,7 +532,7 @@
       "columns": {
         "id": {
           "name": "id",
-          "type": "serial",
+          "type": "uuid",
           "primaryKey": true,
           "notNull": true
         },
@@ -655,7 +655,8 @@
       "values": [
         "email_verification",
         "password_reset",
-        "refresh_token"
+        "refresh_token",
+        "user_invitation"
       ]
     },
     "public.status": {

--- a/src/data/migrations/meta/_journal.json
+++ b/src/data/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1765979417946,
-      "tag": "0000_gray_the_anarchist",
+      "when": 1769011785774,
+      "tag": "0000_tired_justice",
       "breakpoints": true
     }
   ]

--- a/src/data/repositories/auth/mutations.ts
+++ b/src/data/repositories/auth/mutations.ts
@@ -18,7 +18,7 @@ export const createAuth = async (auth: CreateAuthInput, tx?: Database): Promise<
 }
 
 export const updateAuth = async (
-  userId: number,
+  userId: string,
   updates: UpdateAuthInput,
   tx?: Database,
 ): Promise<void> => {

--- a/src/data/repositories/auth/queries.ts
+++ b/src/data/repositories/auth/queries.ts
@@ -7,7 +7,7 @@ import { db } from '../../clients'
 import { authTable } from '../../schema'
 
 export const findByUserId = async (
-  userId: number,
+  userId: string,
   tx?: Database,
 ): Promise<Auth | undefined> => {
   const executor = tx || db

--- a/src/data/repositories/refresh-token/__tests__/refresh-token-repo.test.ts
+++ b/src/data/repositories/refresh-token/__tests__/refresh-token-repo.test.ts
@@ -7,7 +7,7 @@ import { Role, Status } from '@/types'
 import { refreshTokenRepo } from '../index'
 
 describe('Refresh Token Repository @with-db', () => {
-  let userId: number
+  let userId: string
   let tokenHash: string
   let expiresAt: Date
 

--- a/src/data/repositories/refresh-token/mutations.ts
+++ b/src/data/repositories/refresh-token/mutations.ts
@@ -44,7 +44,7 @@ export const revokeByHash = async (
 }
 
 export const revokeAllUserTokens = async (
-  userId: number,
+  userId: string,
   tx?: Database,
 ): Promise<void> => {
   const executor = tx || db

--- a/src/data/repositories/refresh-token/queries.ts
+++ b/src/data/repositories/refresh-token/queries.ts
@@ -21,7 +21,7 @@ export const findByTokenHash = async (
 }
 
 export const findActiveByUserId = async (
-  userId: number,
+  userId: string,
   tx?: Database,
 ): Promise<RefreshToken[]> => {
   const executor = tx || db
@@ -39,7 +39,7 @@ export const findActiveByUserId = async (
 }
 
 export const countActiveByUserId = async (
-  userId: number,
+  userId: string,
   tx?: Database,
 ): Promise<number> => {
   const executor = tx || db

--- a/src/data/repositories/token/mutations.ts
+++ b/src/data/repositories/token/mutations.ts
@@ -11,7 +11,7 @@ import { db } from '../../clients'
 import { tokensTable } from '../../schema'
 
 export const deprecateOldTokens = async (
-  userId: number,
+  userId: string,
   tokenType: TokenType,
   tx?: Database,
 ) => {
@@ -45,7 +45,7 @@ export const createToken = async (token: CreateTokenInput, tx?: Database): Promi
 }
 
 export const issueToken = async (
-  userId: number,
+  userId: string,
   token: CreateTokenInput,
   tx: Database,
 ): Promise<void> => {

--- a/src/data/repositories/user/mutations.ts
+++ b/src/data/repositories/user/mutations.ts
@@ -24,7 +24,7 @@ export const createUser = async (user: CreateUserInput, tx?: Database): Promise<
 }
 
 export const updateUser = async (
-  userId: number,
+  userId: string,
   updates: UpdateUserInput,
   tx?: Database,
 ): Promise<User> => {

--- a/src/data/repositories/user/queries.ts
+++ b/src/data/repositories/user/queries.ts
@@ -11,7 +11,7 @@ import { usersTable } from '../../schema'
 import { calcOffset } from '../pagination'
 
 export const findUserById = async (
-  userId: number,
+  userId: string,
   tx?: Database,
 ): Promise<User | undefined> => {
   const executor = tx || db

--- a/src/data/repositories/user/queries.ts
+++ b/src/data/repositories/user/queries.ts
@@ -69,7 +69,7 @@ export const search = async (
     if (search && search.length > 0) {
       // Use concatenated expression to leverage GIN index (idx_users_search_trgm)
       conditions.push(
-        sql`(first_name || ' ' || COALESCE(last_name, '') || ' ' || email) ILIKE ${`%${search}%`}`,
+        sql`(first_name || ' ' || COALESCE(last_name, '') || ' ' || email || ' ' || id::text) ILIKE ${`%${search}%`}`,
       )
     }
 

--- a/src/data/schema/auth.ts
+++ b/src/data/schema/auth.ts
@@ -1,11 +1,11 @@
 import { sql } from 'drizzle-orm'
 import {
   index,
-  integer,
   pgTable,
   serial,
   timestamp,
   uniqueIndex,
+  uuid,
   varchar,
 } from 'drizzle-orm/pg-core'
 
@@ -18,7 +18,7 @@ export const authProviderEnum = createPgEnum('auth_provider', AuthProvider)
 
 export const authTable = pgTable('auth', {
   id: serial('id').primaryKey(),
-  userId: integer('user_id').notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
+  userId: uuid('user_id').notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
   provider: authProviderEnum('provider').notNull().$type<AuthProvider>(),
   identifier: varchar('identifier', { length: 255 }).notNull(),
   passwordHash: varchar('password_hash', { length: 255 }),

--- a/src/data/schema/refresh-tokens.ts
+++ b/src/data/schema/refresh-tokens.ts
@@ -1,9 +1,9 @@
 import {
   index,
-  integer,
   pgTable,
   serial,
   timestamp,
+  uuid,
   varchar,
 } from 'drizzle-orm/pg-core'
 
@@ -11,7 +11,7 @@ import { usersTable } from './users'
 
 export const refreshTokensTable = pgTable('refresh_tokens', {
   id: serial('id').primaryKey(),
-  userId: integer('user_id').notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
+  userId: uuid('user_id').notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
   tokenHash: varchar('token_hash', { length: 64 }).notNull().unique(),
   ipAddress: varchar('ip_address', { length: 45 }),
   userAgent: varchar('user_agent', { length: 512 }),

--- a/src/data/schema/tokens.ts
+++ b/src/data/schema/tokens.ts
@@ -1,11 +1,11 @@
 import {
   index,
-  integer,
   json,
   pgTable,
   serial,
   text,
   timestamp,
+  uuid,
 } from 'drizzle-orm/pg-core'
 
 import { TokenStatus, TokenType } from '@/security/token'
@@ -18,7 +18,7 @@ export const tokenStatusEnum = createPgEnum('token_status', TokenStatus)
 
 export const tokensTable = pgTable('tokens', {
   id: serial('id').primaryKey(),
-  userId: integer('user_id').notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
+  userId: uuid('user_id').notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
   type: tokenTypeEnum('type').notNull().$type<TokenType>(),
   status: tokenStatusEnum('status').notNull().default(TokenStatus.Pending).$type<TokenStatus>(),
   token: text('token').notNull().unique(),

--- a/src/data/schema/users.ts
+++ b/src/data/schema/users.ts
@@ -1,7 +1,8 @@
+import { sql } from 'drizzle-orm'
 import {
   pgTable,
-  serial,
   timestamp,
+  uuid,
   varchar,
 } from 'drizzle-orm/pg-core'
 
@@ -13,7 +14,7 @@ import { roleEnum } from './rbac'
 export const statusEnum = createPgEnum('status', Status)
 
 export const usersTable = pgTable('users', {
-  id: serial('id').primaryKey(),
+  id: uuid('id').primaryKey().$defaultFn(() => sql`uuidv7()`),
   firstName: varchar('first_name', { length: 100 }).notNull(),
   lastName: varchar('last_name', { length: 100 }),
   email: varchar('email', { length: 255 }).notNull().unique(),

--- a/src/middleware/auth/__tests__/admin-auth.test.ts
+++ b/src/middleware/auth/__tests__/admin-auth.test.ts
@@ -23,7 +23,7 @@ describe('Admin Authentication Middleware', () => {
   describe('Role Validation', () => {
     it('should allow Owner with Active status', async () => {
       const ownerToken = await signJwt(
-        { id: 1, email: 'owner@example.com', role: Role.Owner, status: Status.Active },
+        { id: '550e8400-e29b-41d4-a716-446655440001', email: 'owner@example.com', role: Role.Owner, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -43,7 +43,7 @@ describe('Admin Authentication Middleware', () => {
 
     it('should allow Admin with Active status', async () => {
       const adminToken = await signJwt(
-        { id: 2, email: 'admin@example.com', role: Role.Admin, status: Status.Active },
+        { id: '550e8400-e29b-41d4-a716-446655440002', email: 'admin@example.com', role: Role.Admin, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -63,7 +63,7 @@ describe('Admin Authentication Middleware', () => {
 
     it('should reject User role with Active status', async () => {
       const userToken = await signJwt(
-        { id: 3, email: 'user@example.com', role: Role.User, status: Status.Active },
+        { id: '550e8400-e29b-41d4-a716-446655440003', email: 'user@example.com', role: Role.User, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -84,7 +84,7 @@ describe('Admin Authentication Middleware', () => {
 
     it('should reject Enterprise role with Active status', async () => {
       const enterpriseToken = await signJwt(
-        { id: 4, email: 'enterprise@example.com', role: Role.Enterprise, status: Status.Active },
+        { id: '550e8400-e29b-41d4-a716-446655440004', email: 'enterprise@example.com', role: Role.Enterprise, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -113,7 +113,7 @@ describe('Admin Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: 5, email: 'admin@example.com', role: Role.Admin, status },
+          { id: '550e8400-e29b-41d4-a716-446655440005', email: 'admin@example.com', role: Role.Admin, status },
           { secret: env.JWT_SECRET },
         )
 

--- a/src/middleware/auth/__tests__/admin-auth.test.ts
+++ b/src/middleware/auth/__tests__/admin-auth.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
+import { testUuids } from '@/__tests__'
 import env from '@/env'
 import { ErrorCode } from '@/errors'
 import { onError } from '@/handlers'
@@ -23,7 +24,7 @@ describe('Admin Authentication Middleware', () => {
   describe('Role Validation', () => {
     it('should allow Owner with Active status', async () => {
       const ownerToken = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440001', email: 'owner@example.com', role: Role.Owner, status: Status.Active },
+        { id: testUuids.OWNER_1, email: 'owner@example.com', role: Role.Owner, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -43,7 +44,7 @@ describe('Admin Authentication Middleware', () => {
 
     it('should allow Admin with Active status', async () => {
       const adminToken = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440002', email: 'admin@example.com', role: Role.Admin, status: Status.Active },
+        { id: testUuids.ADMIN_1, email: 'admin@example.com', role: Role.Admin, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -63,7 +64,7 @@ describe('Admin Authentication Middleware', () => {
 
     it('should reject User role with Active status', async () => {
       const userToken = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440003', email: 'user@example.com', role: Role.User, status: Status.Active },
+        { id: testUuids.USER_1, email: 'user@example.com', role: Role.User, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -84,7 +85,7 @@ describe('Admin Authentication Middleware', () => {
 
     it('should reject Enterprise role with Active status', async () => {
       const enterpriseToken = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440004', email: 'enterprise@example.com', role: Role.Enterprise, status: Status.Active },
+        { id: testUuids.USER_2, email: 'enterprise@example.com', role: Role.Enterprise, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -113,7 +114,7 @@ describe('Admin Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: '550e8400-e29b-41d4-a716-446655440005', email: 'admin@example.com', role: Role.Admin, status },
+          { id: testUuids.ADMIN_1, email: 'admin@example.com', role: Role.Admin, status },
           { secret: env.JWT_SECRET },
         )
 

--- a/src/middleware/auth/__tests__/enterprise-auth.test.ts
+++ b/src/middleware/auth/__tests__/enterprise-auth.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
+import { testUuids } from '@/__tests__'
 import env from '@/env'
 import { ErrorCode } from '@/errors'
 import { onError } from '@/handlers'
@@ -23,7 +24,7 @@ describe('Enterprise Authentication Middleware', () => {
   describe('Role Validation', () => {
     it('should allow Enterprise with Active status', async () => {
       const enterpriseToken = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440001', email: 'enterprise@example.com', role: Role.Enterprise, status: Status.Active },
+        { id: testUuids.USER_1, email: 'enterprise@example.com', role: Role.Enterprise, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -43,7 +44,7 @@ describe('Enterprise Authentication Middleware', () => {
 
     it('should reject User role even with Active status', async () => {
       const userToken = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440004', email: 'user@example.com', role: Role.User, status: Status.Active },
+        { id: testUuids.USER_2, email: 'user@example.com', role: Role.User, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -64,7 +65,7 @@ describe('Enterprise Authentication Middleware', () => {
 
     it('should reject Admin role with Active status', async () => {
       const adminToken = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440005', email: 'admin@example.com', role: Role.Admin, status: Status.Active },
+        { id: testUuids.ADMIN_1, email: 'admin@example.com', role: Role.Admin, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -85,7 +86,7 @@ describe('Enterprise Authentication Middleware', () => {
 
     it('should reject Owner role with Active status', async () => {
       const ownerToken = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440006', email: 'owner@example.com', role: Role.Owner, status: Status.Active },
+        { id: testUuids.OWNER_1, email: 'owner@example.com', role: Role.Owner, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -114,7 +115,7 @@ describe('Enterprise Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: '550e8400-e29b-41d4-a716-446655440007', email: 'enterprise@example.com', role: Role.Enterprise, status },
+          { id: testUuids.USER_3, email: 'enterprise@example.com', role: Role.Enterprise, status },
           { secret: env.JWT_SECRET },
         )
 

--- a/src/middleware/auth/__tests__/enterprise-auth.test.ts
+++ b/src/middleware/auth/__tests__/enterprise-auth.test.ts
@@ -23,7 +23,7 @@ describe('Enterprise Authentication Middleware', () => {
   describe('Role Validation', () => {
     it('should allow Enterprise with Active status', async () => {
       const enterpriseToken = await signJwt(
-        { id: 1, email: 'enterprise@example.com', role: Role.Enterprise, status: Status.Active },
+        { id: '550e8400-e29b-41d4-a716-446655440001', email: 'enterprise@example.com', role: Role.Enterprise, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -43,7 +43,7 @@ describe('Enterprise Authentication Middleware', () => {
 
     it('should reject User role even with Active status', async () => {
       const userToken = await signJwt(
-        { id: 4, email: 'user@example.com', role: Role.User, status: Status.Active },
+        { id: '550e8400-e29b-41d4-a716-446655440004', email: 'user@example.com', role: Role.User, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -64,7 +64,7 @@ describe('Enterprise Authentication Middleware', () => {
 
     it('should reject Admin role with Active status', async () => {
       const adminToken = await signJwt(
-        { id: 5, email: 'admin@example.com', role: Role.Admin, status: Status.Active },
+        { id: '550e8400-e29b-41d4-a716-446655440005', email: 'admin@example.com', role: Role.Admin, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -85,7 +85,7 @@ describe('Enterprise Authentication Middleware', () => {
 
     it('should reject Owner role with Active status', async () => {
       const ownerToken = await signJwt(
-        { id: 6, email: 'owner@example.com', role: Role.Owner, status: Status.Active },
+        { id: '550e8400-e29b-41d4-a716-446655440006', email: 'owner@example.com', role: Role.Owner, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -114,7 +114,7 @@ describe('Enterprise Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: 7, email: 'enterprise@example.com', role: Role.Enterprise, status },
+          { id: '550e8400-e29b-41d4-a716-446655440007', email: 'enterprise@example.com', role: Role.Enterprise, status },
           { secret: env.JWT_SECRET },
         )
 

--- a/src/middleware/auth/__tests__/factory.test.ts
+++ b/src/middleware/auth/__tests__/factory.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
+import { testUuids } from '@/__tests__'
 import env from '@/env'
 import { ErrorCode } from '@/errors'
 import { onError } from '@/handlers'
@@ -16,7 +17,7 @@ describe('Auth Middleware Factory', () => {
   let app: Hono<AppContext>
 
   const mockUser = {
-    id: '550e8400-e29b-41d4-a716-446655440000',
+    id: testUuids.USER_1,
     email: 'test@example.com',
     role: Role.User,
     status: Status.Verified,

--- a/src/middleware/auth/__tests__/factory.test.ts
+++ b/src/middleware/auth/__tests__/factory.test.ts
@@ -16,7 +16,7 @@ describe('Auth Middleware Factory', () => {
   let app: Hono<AppContext>
 
   const mockUser = {
-    id: 123,
+    id: '550e8400-e29b-41d4-a716-446655440000',
     email: 'test@example.com',
     role: Role.User,
     status: Status.Verified,

--- a/src/middleware/auth/__tests__/new-user-access.test.ts
+++ b/src/middleware/auth/__tests__/new-user-access.test.ts
@@ -23,7 +23,7 @@ describe('Auth Middleware - New User Access', () => {
   describe('Strict Auth - Status Validation', () => {
     it('should reject New status', async () => {
       const token = await signJwt(
-        { id: 1, email: 'user@example.com', role: Role.User, status: Status.New },
+        { id: '550e8400-e29b-41d4-a716-446655440001', email: 'user@example.com', role: Role.User, status: Status.New },
         { secret: env.JWT_SECRET },
       )
 
@@ -50,7 +50,7 @@ describe('Auth Middleware - New User Access', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: 2, email: 'user@example.com', role: Role.User, status },
+          { id: '550e8400-e29b-41d4-a716-446655440002', email: 'user@example.com', role: Role.User, status },
           { secret: env.JWT_SECRET },
         )
 
@@ -79,7 +79,7 @@ describe('Auth Middleware - New User Access', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: 5, email: 'user@example.com', role: Role.User, status },
+          { id: '550e8400-e29b-41d4-a716-446655440005', email: 'user@example.com', role: Role.User, status },
           { secret: env.JWT_SECRET },
         )
 
@@ -100,7 +100,7 @@ describe('Auth Middleware - New User Access', () => {
 
     it('should reject Suspended status', async () => {
       const token = await signJwt(
-        { id: 9, email: 'user@example.com', role: Role.User, status: Status.Suspended },
+        { id: '550e8400-e29b-41d4-a716-446655440009', email: 'user@example.com', role: Role.User, status: Status.Suspended },
         { secret: env.JWT_SECRET },
       )
 

--- a/src/middleware/auth/__tests__/new-user-access.test.ts
+++ b/src/middleware/auth/__tests__/new-user-access.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
+import { testUuids } from '@/__tests__'
 import env from '@/env'
 import { ErrorCode } from '@/errors'
 import { onError } from '@/handlers'
@@ -23,7 +24,7 @@ describe('Auth Middleware - New User Access', () => {
   describe('Strict Auth - Status Validation', () => {
     it('should reject New status', async () => {
       const token = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440001', email: 'user@example.com', role: Role.User, status: Status.New },
+        { id: testUuids.USER_1, email: 'user@example.com', role: Role.User, status: Status.New },
         { secret: env.JWT_SECRET },
       )
 
@@ -50,7 +51,7 @@ describe('Auth Middleware - New User Access', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: '550e8400-e29b-41d4-a716-446655440002', email: 'user@example.com', role: Role.User, status },
+          { id: testUuids.USER_1, email: 'user@example.com', role: Role.User, status },
           { secret: env.JWT_SECRET },
         )
 
@@ -79,7 +80,7 @@ describe('Auth Middleware - New User Access', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: '550e8400-e29b-41d4-a716-446655440005', email: 'user@example.com', role: Role.User, status },
+          { id: testUuids.USER_2, email: 'user@example.com', role: Role.User, status },
           { secret: env.JWT_SECRET },
         )
 
@@ -100,7 +101,7 @@ describe('Auth Middleware - New User Access', () => {
 
     it('should reject Suspended status', async () => {
       const token = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440009', email: 'user@example.com', role: Role.User, status: Status.Suspended },
+        { id: testUuids.USER_3, email: 'user@example.com', role: Role.User, status: Status.Suspended },
         { secret: env.JWT_SECRET },
       )
 

--- a/src/middleware/auth/__tests__/owner-auth.test.ts
+++ b/src/middleware/auth/__tests__/owner-auth.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
+import { testUuids } from '@/__tests__'
 import env from '@/env'
 import { ErrorCode } from '@/errors'
 import { onError } from '@/handlers'
@@ -23,7 +24,7 @@ describe('Owner Authentication Middleware', () => {
   describe('Role Validation', () => {
     it('should allow Owner with Active status', async () => {
       const ownerToken = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440001', email: 'owner@example.com', role: Role.Owner, status: Status.Active },
+        { id: testUuids.OWNER_1, email: 'owner@example.com', role: Role.Owner, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -43,7 +44,7 @@ describe('Owner Authentication Middleware', () => {
 
     it('should reject Admin even with Active status', async () => {
       const adminToken = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440002', email: 'admin@example.com', role: Role.Admin, status: Status.Active },
+        { id: testUuids.ADMIN_1, email: 'admin@example.com', role: Role.Admin, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -64,7 +65,7 @@ describe('Owner Authentication Middleware', () => {
 
     it('should reject User role with Active status', async () => {
       const userToken = await signJwt(
-        { id: '550e8400-e29b-41d4-a716-446655440003', email: 'user@example.com', role: Role.User, status: Status.Active },
+        { id: testUuids.USER_1, email: 'user@example.com', role: Role.User, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -93,7 +94,7 @@ describe('Owner Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: '550e8400-e29b-41d4-a716-446655440004', email: 'owner@example.com', role: Role.Owner, status },
+          { id: testUuids.OWNER_1, email: 'owner@example.com', role: Role.Owner, status },
           { secret: env.JWT_SECRET },
         )
 

--- a/src/middleware/auth/__tests__/owner-auth.test.ts
+++ b/src/middleware/auth/__tests__/owner-auth.test.ts
@@ -23,7 +23,7 @@ describe('Owner Authentication Middleware', () => {
   describe('Role Validation', () => {
     it('should allow Owner with Active status', async () => {
       const ownerToken = await signJwt(
-        { id: 1, email: 'owner@example.com', role: Role.Owner, status: Status.Active },
+        { id: '550e8400-e29b-41d4-a716-446655440001', email: 'owner@example.com', role: Role.Owner, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -43,7 +43,7 @@ describe('Owner Authentication Middleware', () => {
 
     it('should reject Admin even with Active status', async () => {
       const adminToken = await signJwt(
-        { id: 2, email: 'admin@example.com', role: Role.Admin, status: Status.Active },
+        { id: '550e8400-e29b-41d4-a716-446655440002', email: 'admin@example.com', role: Role.Admin, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -64,7 +64,7 @@ describe('Owner Authentication Middleware', () => {
 
     it('should reject User role with Active status', async () => {
       const userToken = await signJwt(
-        { id: 3, email: 'user@example.com', role: Role.User, status: Status.Active },
+        { id: '550e8400-e29b-41d4-a716-446655440003', email: 'user@example.com', role: Role.User, status: Status.Active },
         { secret: env.JWT_SECRET },
       )
 
@@ -93,7 +93,7 @@ describe('Owner Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: 4, email: 'owner@example.com', role: Role.Owner, status },
+          { id: '550e8400-e29b-41d4-a716-446655440004', email: 'owner@example.com', role: Role.Owner, status },
           { secret: env.JWT_SECRET },
         )
 

--- a/src/middleware/auth/__tests__/user-relaxed-auth.test.ts
+++ b/src/middleware/auth/__tests__/user-relaxed-auth.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
+import { testUuids } from '@/__tests__'
 import env from '@/env'
 import { ErrorCode } from '@/errors'
 import { onError } from '@/handlers'
@@ -29,7 +30,7 @@ describe('User Relaxed Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: '550e8400-e29b-41d4-a716-446655440001', email: 'test@example.com', role, status: Status.Active },
+          { id: testUuids.USER_1, email: 'test@example.com', role, status: Status.Active },
           { secret: env.JWT_SECRET },
         )
 
@@ -58,7 +59,7 @@ describe('User Relaxed Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: '550e8400-e29b-41d4-a716-446655440005', email: 'user@example.com', role: Role.User, status },
+          { id: testUuids.USER_2, email: 'user@example.com', role: Role.User, status },
           { secret: env.JWT_SECRET },
         )
 
@@ -85,7 +86,7 @@ describe('User Relaxed Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: '550e8400-e29b-41d4-a716-446655440006', email: 'user@example.com', role: Role.User, status },
+          { id: testUuids.USER_3, email: 'user@example.com', role: Role.User, status },
           { secret: env.JWT_SECRET },
         )
 

--- a/src/middleware/auth/__tests__/user-relaxed-auth.test.ts
+++ b/src/middleware/auth/__tests__/user-relaxed-auth.test.ts
@@ -29,7 +29,7 @@ describe('User Relaxed Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: 1, email: 'test@example.com', role, status: Status.Active },
+          { id: '550e8400-e29b-41d4-a716-446655440001', email: 'test@example.com', role, status: Status.Active },
           { secret: env.JWT_SECRET },
         )
 
@@ -58,7 +58,7 @@ describe('User Relaxed Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: 5, email: 'user@example.com', role: Role.User, status },
+          { id: '550e8400-e29b-41d4-a716-446655440005', email: 'user@example.com', role: Role.User, status },
           { secret: env.JWT_SECRET },
         )
 
@@ -85,7 +85,7 @@ describe('User Relaxed Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: 6, email: 'user@example.com', role: Role.User, status },
+          { id: '550e8400-e29b-41d4-a716-446655440006', email: 'user@example.com', role: Role.User, status },
           { secret: env.JWT_SECRET },
         )
 

--- a/src/middleware/auth/factory.ts
+++ b/src/middleware/auth/factory.ts
@@ -40,7 +40,7 @@ const createAuthMiddleware = (
 
     c.set('user', userClaims)
 
-    getErrorTracker().setUser({ id: String(userClaims.id) })
+    getErrorTracker().setUser({ id: userClaims.id })
   } catch (error) {
     if (error instanceof AppError) {
       throw error

--- a/src/routes/@shared/data-rules.ts
+++ b/src/routes/@shared/data-rules.ts
@@ -7,7 +7,7 @@ import { Role } from '@/types'
 const normalizeEmail = (email: string): string => email.trim().toLowerCase()
 
 export const dataRules = {
-  id: z.coerce.number().int().positive(),
+  id: z.string().uuid(),
 
   email: z
     .string()

--- a/src/routes/admin/users/__tests__/endpoint.test.ts
+++ b/src/routes/admin/users/__tests__/endpoint.test.ts
@@ -27,7 +27,7 @@ describe('Admin Users Endpoint', () => {
   beforeEach(async () => {
     mockUsers = [
       {
-        id: 1,
+        id: '550e8400-e29b-41d4-a716-446655440001',
         firstName: 'John',
         lastName: 'Doe',
         email: 'john@example.com',
@@ -37,7 +37,7 @@ describe('Admin Users Endpoint', () => {
         updatedAt: new Date('2024-01-01'),
       },
       {
-        id: 2,
+        id: '550e8400-e29b-41d4-a716-446655440002',
         firstName: 'Jane',
         lastName: 'Smith',
         email: 'jane@example.com',
@@ -63,7 +63,7 @@ describe('Admin Users Endpoint', () => {
     }))
 
     mockAdminClaims = {
-      id: 100,
+      id: '550e8400-e29b-41d4-a716-446655440100',
       email: 'admin@example.com',
       role: Role.Admin,
       status: Status.Active,
@@ -91,7 +91,7 @@ describe('Admin Users Endpoint', () => {
       expect(data).toEqual({
         users: [
           {
-            id: 1,
+            id: '550e8400-e29b-41d4-a716-446655440001',
             firstName: 'John',
             lastName: 'Doe',
             email: 'john@example.com',
@@ -101,7 +101,7 @@ describe('Admin Users Endpoint', () => {
             updatedAt: '2024-01-01T00:00:00.000Z',
           },
           {
-            id: 2,
+            id: '550e8400-e29b-41d4-a716-446655440002',
             firstName: 'Jane',
             lastName: 'Smith',
             email: 'jane@example.com',

--- a/src/routes/admin/users/__tests__/endpoint.test.ts
+++ b/src/routes/admin/users/__tests__/endpoint.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { User } from '@/data'
 import type { UserClaims } from '@/security/jwt'
 
-import { createTestApp, ModuleMocker } from '@/__tests__'
+import { createTestApp, ModuleMocker, testUuids } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { Role, Status } from '@/types'
 
@@ -27,7 +27,7 @@ describe('Admin Users Endpoint', () => {
   beforeEach(async () => {
     mockUsers = [
       {
-        id: '550e8400-e29b-41d4-a716-446655440001',
+        id: testUuids.USER_1,
         firstName: 'John',
         lastName: 'Doe',
         email: 'john@example.com',
@@ -37,7 +37,7 @@ describe('Admin Users Endpoint', () => {
         updatedAt: new Date('2024-01-01'),
       },
       {
-        id: '550e8400-e29b-41d4-a716-446655440002',
+        id: testUuids.USER_2,
         firstName: 'Jane',
         lastName: 'Smith',
         email: 'jane@example.com',
@@ -63,7 +63,7 @@ describe('Admin Users Endpoint', () => {
     }))
 
     mockAdminClaims = {
-      id: '550e8400-e29b-41d4-a716-446655440100',
+      id: testUuids.ADMIN_1,
       email: 'admin@example.com',
       role: Role.Admin,
       status: Status.Active,
@@ -91,7 +91,7 @@ describe('Admin Users Endpoint', () => {
       expect(data).toEqual({
         users: [
           {
-            id: '550e8400-e29b-41d4-a716-446655440001',
+            id: testUuids.USER_1,
             firstName: 'John',
             lastName: 'Doe',
             email: 'john@example.com',
@@ -101,7 +101,7 @@ describe('Admin Users Endpoint', () => {
             updatedAt: '2024-01-01T00:00:00.000Z',
           },
           {
-            id: '550e8400-e29b-41d4-a716-446655440002',
+            id: testUuids.USER_2,
             firstName: 'Jane',
             lastName: 'Smith',
             email: 'jane@example.com',

--- a/src/routes/admin/users/__tests__/handler.test.ts
+++ b/src/routes/admin/users/__tests__/handler.test.ts
@@ -22,7 +22,7 @@ describe('adminUsersHandler', () => {
   beforeEach(async () => {
     mockUsers = [
       {
-        id: 1,
+        id: '550e8400-e29b-41d4-a716-446655440001',
         firstName: 'John',
         lastName: 'Doe',
         email: 'john@example.com',
@@ -113,7 +113,7 @@ describe('adminUserDetailHandler', () => {
 
   beforeEach(async () => {
     mockUser = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',
@@ -127,7 +127,7 @@ describe('adminUserDetailHandler', () => {
 
     mockContext = {
       req: {
-        valid: mock(() => ({ id: 1 })),
+        valid: mock(() => ({ id: '550e8400-e29b-41d4-a716-446655440001' })),
       },
       json: mockJson,
     }
@@ -146,7 +146,7 @@ describe('adminUserDetailHandler', () => {
   it('should call getUser with correct user id', async () => {
     await getUserHandler(mockContext)
 
-    expect(mockGetUser).toHaveBeenCalledWith(1)
+    expect(mockGetUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
   })
 
   it('should return user with OK status', async () => {

--- a/src/routes/admin/users/__tests__/handler.test.ts
+++ b/src/routes/admin/users/__tests__/handler.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import type { User } from '@/data'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { Role, Status, USER_ROLES } from '@/types'
 
@@ -22,7 +22,7 @@ describe('adminUsersHandler', () => {
   beforeEach(async () => {
     mockUsers = [
       {
-        id: '550e8400-e29b-41d4-a716-446655440001',
+        id: testUuids.USER_1,
         firstName: 'John',
         lastName: 'Doe',
         email: 'john@example.com',
@@ -113,7 +113,7 @@ describe('adminUserDetailHandler', () => {
 
   beforeEach(async () => {
     mockUser = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',
@@ -127,7 +127,7 @@ describe('adminUserDetailHandler', () => {
 
     mockContext = {
       req: {
-        valid: mock(() => ({ id: '550e8400-e29b-41d4-a716-446655440001' })),
+        valid: mock(() => ({ id: testUuids.USER_1 })),
       },
       json: mockJson,
     }
@@ -146,7 +146,7 @@ describe('adminUserDetailHandler', () => {
   it('should call getUser with correct user id', async () => {
     await getUserHandler(mockContext)
 
-    expect(mockGetUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
+    expect(mockGetUser).toHaveBeenCalledWith(testUuids.USER_1)
   })
 
   it('should return user with OK status', async () => {

--- a/src/routes/auth/accept-invite/__tests__/endpoint.test.ts
+++ b/src/routes/auth/accept-invite/__tests__/endpoint.test.ts
@@ -18,7 +18,7 @@ describe('Accept Invite Endpoint', () => {
 
   beforeEach(async () => {
     mockAcceptInvite = mock(async () => ({
-      data: { user: { id: 1 }, accessToken: 'test-token' },
+      data: { user: { id: '550e8400-e29b-41d4-a716-446655440001' }, accessToken: 'test-token' },
       refreshToken: 'refresh-token',
     }))
 
@@ -47,7 +47,7 @@ describe('Accept Invite Endpoint', () => {
       expect(res.status).toBe(HttpStatus.OK)
 
       const data = await res.json()
-      expect(data).toEqual({ user: { id: 1 }, accessToken: 'test-token' })
+      expect(data).toEqual({ user: { id: '550e8400-e29b-41d4-a716-446655440001' }, accessToken: 'test-token' })
 
       expect(mockAcceptInvite).toHaveBeenCalledWith({
         token: validPayload.data.token,

--- a/src/routes/auth/accept-invite/__tests__/endpoint.test.ts
+++ b/src/routes/auth/accept-invite/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post, testUuids } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { TOKEN_LENGTH } from '@/security/token'
 
@@ -18,7 +18,7 @@ describe('Accept Invite Endpoint', () => {
 
   beforeEach(async () => {
     mockAcceptInvite = mock(async () => ({
-      data: { user: { id: '550e8400-e29b-41d4-a716-446655440001' }, accessToken: 'test-token' },
+      data: { user: { id: testUuids.USER_1 }, accessToken: 'test-token' },
       refreshToken: 'refresh-token',
     }))
 
@@ -47,7 +47,7 @@ describe('Accept Invite Endpoint', () => {
       expect(res.status).toBe(HttpStatus.OK)
 
       const data = await res.json()
-      expect(data).toEqual({ user: { id: '550e8400-e29b-41d4-a716-446655440001' }, accessToken: 'test-token' })
+      expect(data).toEqual({ user: { id: testUuids.USER_1 }, accessToken: 'test-token' })
 
       expect(mockAcceptInvite).toHaveBeenCalledWith({
         token: validPayload.data.token,

--- a/src/routes/auth/login/__tests__/endpoint.test.ts
+++ b/src/routes/auth/login/__tests__/endpoint.test.ts
@@ -22,7 +22,7 @@ describe('Login Endpoint', () => {
     mockLogInWithEmail = mock(async () => ({
       data: {
         user: {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'Test',
           lastName: 'User',
           email: 'test@example.com',
@@ -83,7 +83,7 @@ describe('Login Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({
         user: {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'Test',
           lastName: 'User',
           email: 'test@example.com',

--- a/src/routes/auth/login/__tests__/endpoint.test.ts
+++ b/src/routes/auth/login/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post, testUuids } from '@/__tests__'
 import { mockCaptchaSuccess, VALID_CAPTCHA_TOKEN } from '@/middleware/captcha/__tests__'
 import { HttpStatus } from '@/net/http'
 
@@ -22,7 +22,7 @@ describe('Login Endpoint', () => {
     mockLogInWithEmail = mock(async () => ({
       data: {
         user: {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'Test',
           lastName: 'User',
           email: 'test@example.com',
@@ -83,7 +83,7 @@ describe('Login Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({
         user: {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'Test',
           lastName: 'User',
           email: 'test@example.com',

--- a/src/routes/auth/refresh-token/__tests__/endpoint.test.ts
+++ b/src/routes/auth/refresh-token/__tests__/endpoint.test.ts
@@ -22,7 +22,7 @@ describe('Refresh Token Endpoint', () => {
     mockRefreshAuthTokens = mock(async () => ({
       data: {
         user: {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',
@@ -68,7 +68,7 @@ describe('Refresh Token Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({
         user: {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',

--- a/src/routes/auth/refresh-token/__tests__/endpoint.test.ts
+++ b/src/routes/auth/refresh-token/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post, testUuids } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { Role, Status } from '@/types'
 
@@ -22,7 +22,7 @@ describe('Refresh Token Endpoint', () => {
     mockRefreshAuthTokens = mock(async () => ({
       data: {
         user: {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',
@@ -68,7 +68,7 @@ describe('Refresh Token Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({
         user: {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',

--- a/src/routes/auth/refresh-token/__tests__/handler.test.ts
+++ b/src/routes/auth/refresh-token/__tests__/handler.test.ts
@@ -48,7 +48,7 @@ describe('Refresh Token Handler', () => {
     mockRefreshAuthTokens = mock(async () => ({
       data: {
         user: {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',
@@ -84,7 +84,7 @@ describe('Refresh Token Handler', () => {
       expect(mockSetRefreshCookie).toHaveBeenCalledWith(mockContext, 'new_refresh_token_456')
       expect(mockJson).toHaveBeenCalledWith({
         user: {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',
@@ -203,7 +203,7 @@ describe('Refresh Token Handler', () => {
         return {
           data: {
             user: {
-              id: 1,
+              id: '550e8400-e29b-41d4-a716-446655440001',
               firstName: 'John',
               lastName: 'Doe',
               email: 'test@example.com',

--- a/src/routes/auth/refresh-token/__tests__/handler.test.ts
+++ b/src/routes/auth/refresh-token/__tests__/handler.test.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { Role, Status } from '@/types'
 
@@ -48,7 +48,7 @@ describe('Refresh Token Handler', () => {
     mockRefreshAuthTokens = mock(async () => ({
       data: {
         user: {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',
@@ -84,7 +84,7 @@ describe('Refresh Token Handler', () => {
       expect(mockSetRefreshCookie).toHaveBeenCalledWith(mockContext, 'new_refresh_token_456')
       expect(mockJson).toHaveBeenCalledWith({
         user: {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',
@@ -203,7 +203,7 @@ describe('Refresh Token Handler', () => {
         return {
           data: {
             user: {
-              id: '550e8400-e29b-41d4-a716-446655440001',
+              id: testUuids.USER_1,
               firstName: 'John',
               lastName: 'Doe',
               email: 'test@example.com',

--- a/src/routes/auth/reset-password/__tests__/endpoint.test.ts
+++ b/src/routes/auth/reset-password/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post, testUuids } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { TOKEN_LENGTH } from '@/security/token'
 
@@ -18,7 +18,7 @@ describe('Reset Password Endpoint', () => {
 
   beforeEach(async () => {
     mockResetPassword = mock(async () => ({
-      data: { user: { id: '550e8400-e29b-41d4-a716-446655440001' }, accessToken: 'test-token' },
+      data: { user: { id: testUuids.USER_1 }, accessToken: 'test-token' },
       refreshToken: 'refresh-token',
     }))
 
@@ -47,7 +47,7 @@ describe('Reset Password Endpoint', () => {
       expect(res.status).toBe(HttpStatus.OK)
 
       const data = await res.json()
-      expect(data).toEqual({ user: { id: '550e8400-e29b-41d4-a716-446655440001' }, accessToken: 'test-token' })
+      expect(data).toEqual({ user: { id: testUuids.USER_1 }, accessToken: 'test-token' })
 
       expect(mockResetPassword).toHaveBeenCalledWith({
         token: validPayload.data.token,

--- a/src/routes/auth/reset-password/__tests__/endpoint.test.ts
+++ b/src/routes/auth/reset-password/__tests__/endpoint.test.ts
@@ -18,7 +18,7 @@ describe('Reset Password Endpoint', () => {
 
   beforeEach(async () => {
     mockResetPassword = mock(async () => ({
-      data: { user: { id: 1 }, accessToken: 'test-token' },
+      data: { user: { id: '550e8400-e29b-41d4-a716-446655440001' }, accessToken: 'test-token' },
       refreshToken: 'refresh-token',
     }))
 
@@ -47,7 +47,7 @@ describe('Reset Password Endpoint', () => {
       expect(res.status).toBe(HttpStatus.OK)
 
       const data = await res.json()
-      expect(data).toEqual({ user: { id: 1 }, accessToken: 'test-token' })
+      expect(data).toEqual({ user: { id: '550e8400-e29b-41d4-a716-446655440001' }, accessToken: 'test-token' })
 
       expect(mockResetPassword).toHaveBeenCalledWith({
         token: validPayload.data.token,

--- a/src/routes/auth/signup/__tests__/endpoint.test.ts
+++ b/src/routes/auth/signup/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post, testUuids } from '@/__tests__'
 import { mockCaptchaSuccess, VALID_CAPTCHA_TOKEN } from '@/middleware/captcha/__tests__'
 import { HttpStatus } from '@/net/http'
 import { Role, Status } from '@/types'
@@ -23,7 +23,7 @@ describe('Signup Endpoint', () => {
     mockSignUpWithEmail = mock(async () => ({
       data: {
         user: {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',
@@ -87,7 +87,7 @@ describe('Signup Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({
         user: {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',

--- a/src/routes/auth/signup/__tests__/endpoint.test.ts
+++ b/src/routes/auth/signup/__tests__/endpoint.test.ts
@@ -23,7 +23,7 @@ describe('Signup Endpoint', () => {
     mockSignUpWithEmail = mock(async () => ({
       data: {
         user: {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',
@@ -87,7 +87,7 @@ describe('Signup Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({
         user: {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',

--- a/src/routes/auth/verify-email/__tests__/endpoint.test.ts
+++ b/src/routes/auth/verify-email/__tests__/endpoint.test.ts
@@ -20,7 +20,7 @@ describe('Verify Email Endpoint', () => {
     mockVerifyEmail = mock(async () => ({
       data: {
         user: {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'John',
           lastName: 'Doe',
           email: 'john@example.com',
@@ -56,7 +56,7 @@ describe('Verify Email Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({
         user: {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'John',
           lastName: 'Doe',
           email: 'john@example.com',

--- a/src/routes/auth/verify-email/__tests__/endpoint.test.ts
+++ b/src/routes/auth/verify-email/__tests__/endpoint.test.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import { createTestApp, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post, testUuids } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { Role, Status } from '@/types'
 
@@ -20,7 +20,7 @@ describe('Verify Email Endpoint', () => {
     mockVerifyEmail = mock(async () => ({
       data: {
         user: {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'John',
           lastName: 'Doe',
           email: 'john@example.com',
@@ -56,7 +56,7 @@ describe('Verify Email Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({
         user: {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'John',
           lastName: 'Doe',
           email: 'john@example.com',

--- a/src/routes/owner/admins/__tests__/handler.test.ts
+++ b/src/routes/owner/admins/__tests__/handler.test.ts
@@ -22,7 +22,7 @@ describe('ownerGetAdminsHandler', () => {
   beforeEach(async () => {
     mockAdmins = [
       {
-        id: 1,
+        id: '550e8400-e29b-41d4-a716-446655440001',
         firstName: 'Admin',
         lastName: 'User',
         email: 'admin@example.com',
@@ -112,7 +112,7 @@ describe('ownerGetAdminHandler', () => {
 
   beforeEach(async () => {
     mockAdmin = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'Admin',
       lastName: 'User',
       email: 'admin@example.com',
@@ -126,7 +126,7 @@ describe('ownerGetAdminHandler', () => {
 
     mockContext = {
       req: {
-        valid: mock(() => ({ id: 1 })),
+        valid: mock(() => ({ id: '550e8400-e29b-41d4-a716-446655440001' })),
       },
       json: mockJson,
     }
@@ -145,7 +145,7 @@ describe('ownerGetAdminHandler', () => {
   it('should call getAdmin with correct admin id', async () => {
     await getAdminHandler(mockContext)
 
-    expect(mockGetAdmin).toHaveBeenCalledWith(1)
+    expect(mockGetAdmin).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
   })
 
   it('should return admin with OK status', async () => {
@@ -187,7 +187,7 @@ describe('inviteAdminHandler', () => {
 
   beforeEach(async () => {
     mockAdmin = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'New',
       lastName: 'Admin',
       email: 'newadmin@example.com',

--- a/src/routes/owner/admins/__tests__/handler.test.ts
+++ b/src/routes/owner/admins/__tests__/handler.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import type { User } from '@/data'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { Role, Status } from '@/types'
 
@@ -22,7 +22,7 @@ describe('ownerGetAdminsHandler', () => {
   beforeEach(async () => {
     mockAdmins = [
       {
-        id: '550e8400-e29b-41d4-a716-446655440001',
+        id: testUuids.ADMIN_1,
         firstName: 'Admin',
         lastName: 'User',
         email: 'admin@example.com',
@@ -112,7 +112,7 @@ describe('ownerGetAdminHandler', () => {
 
   beforeEach(async () => {
     mockAdmin = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.ADMIN_1,
       firstName: 'Admin',
       lastName: 'User',
       email: 'admin@example.com',
@@ -126,7 +126,7 @@ describe('ownerGetAdminHandler', () => {
 
     mockContext = {
       req: {
-        valid: mock(() => ({ id: '550e8400-e29b-41d4-a716-446655440001' })),
+        valid: mock(() => ({ id: testUuids.ADMIN_1 })),
       },
       json: mockJson,
     }
@@ -145,7 +145,7 @@ describe('ownerGetAdminHandler', () => {
   it('should call getAdmin with correct admin id', async () => {
     await getAdminHandler(mockContext)
 
-    expect(mockGetAdmin).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
+    expect(mockGetAdmin).toHaveBeenCalledWith(testUuids.ADMIN_1)
   })
 
   it('should return admin with OK status', async () => {
@@ -187,7 +187,7 @@ describe('inviteAdminHandler', () => {
 
   beforeEach(async () => {
     mockAdmin = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.ADMIN_1,
       firstName: 'New',
       lastName: 'Admin',
       email: 'newadmin@example.com',

--- a/src/routes/user/me/__tests__/endpoint.test.ts
+++ b/src/routes/user/me/__tests__/endpoint.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { User } from '@/data'
 import type { UserClaims } from '@/security/jwt'
 
-import { createTestApp, ModuleMocker, post } from '@/__tests__'
+import { createTestApp, ModuleMocker, post, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { HttpStatus } from '@/net/http'
 import { Role, Status } from '@/types'
@@ -30,7 +30,7 @@ describe('Me Endpoint', () => {
 
   beforeEach(async () => {
     mockUpdatedUserMinimal = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       firstName: 'Jo',
       lastName: 'Do',
       email: 'test@example.com',
@@ -41,7 +41,7 @@ describe('Me Endpoint', () => {
     }
 
     mockFullUser = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       firstName: 'John',
       lastName: 'Doe',
       email: 'test@example.com',
@@ -52,7 +52,7 @@ describe('Me Endpoint', () => {
     }
     mockGetUser = mock(async () => ({ data: { user: mockFullUser } }))
     mockUpdatedUser = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       firstName: 'Jane',
       lastName: 'Smith',
       email: 'test@example.com',
@@ -69,7 +69,7 @@ describe('Me Endpoint', () => {
     }))
 
     mockUserClaims = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       email: 'test@example.com',
       role: Role.User,
       status: Status.Active,
@@ -101,7 +101,7 @@ describe('Me Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({
         user: {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',
@@ -127,7 +127,7 @@ describe('Me Endpoint', () => {
 
       // Verify getUser was called with correct user ID
       const { getUser } = await import('@/use-cases/user/me')
-      expect(getUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
+      expect(getUser).toHaveBeenCalledWith(testUuids.USER_1)
       expect(getUser).toHaveBeenCalledTimes(1)
     })
 
@@ -186,7 +186,7 @@ describe('Me Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({
         user: {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'Jane',
           lastName: 'Smith',
           email: 'test@example.com',
@@ -202,7 +202,7 @@ describe('Me Endpoint', () => {
 
       // Verify updateUser was called with correct parameters
       const { updateUser } = await import('@/use-cases/user/me')
-      expect(updateUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
+      expect(updateUser).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: 'Smith',
       })
@@ -251,7 +251,7 @@ describe('Me Endpoint', () => {
 
       // Verify updateUser was called with only firstName
       const { updateUser } = await import('@/use-cases/user/me')
-      expect(updateUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
+      expect(updateUser).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
       })
     })
@@ -308,7 +308,7 @@ describe('Me Endpoint', () => {
 
       // Verify updateUser was called
       const { updateUser } = await import('@/use-cases/user/me')
-      expect(updateUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {})
+      expect(updateUser).toHaveBeenCalledWith(testUuids.USER_1, {})
     })
 
     it('should normalize null lastName to empty string', async () => {
@@ -321,7 +321,7 @@ describe('Me Endpoint', () => {
 
       // Verify updateUser was called with lastName normalized to ""
       const { updateUser } = await import('@/use-cases/user/me')
-      expect(updateUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
+      expect(updateUser).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: '',
       })
@@ -340,7 +340,7 @@ describe('Me Endpoint', () => {
 
       // Verify updateUser was called only with lastName
       const { updateUser } = await import('@/use-cases/user/me')
-      expect(updateUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
+      expect(updateUser).toHaveBeenCalledWith(testUuids.USER_1, {
         lastName: 'Smith',
       })
     })
@@ -381,7 +381,7 @@ describe('Me Endpoint', () => {
 
       // Verify updateUser was called with already trimmed values (trimming happens at schema layer)
       const { updateUser } = await import('@/use-cases/user/me')
-      expect(updateUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
+      expect(updateUser).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: 'Smith',
       })

--- a/src/routes/user/me/__tests__/endpoint.test.ts
+++ b/src/routes/user/me/__tests__/endpoint.test.ts
@@ -30,7 +30,7 @@ describe('Me Endpoint', () => {
 
   beforeEach(async () => {
     mockUpdatedUserMinimal = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'Jo',
       lastName: 'Do',
       email: 'test@example.com',
@@ -41,7 +41,7 @@ describe('Me Endpoint', () => {
     }
 
     mockFullUser = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'John',
       lastName: 'Doe',
       email: 'test@example.com',
@@ -52,7 +52,7 @@ describe('Me Endpoint', () => {
     }
     mockGetUser = mock(async () => ({ data: { user: mockFullUser } }))
     mockUpdatedUser = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'Jane',
       lastName: 'Smith',
       email: 'test@example.com',
@@ -69,7 +69,7 @@ describe('Me Endpoint', () => {
     }))
 
     mockUserClaims = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       email: 'test@example.com',
       role: Role.User,
       status: Status.Active,
@@ -101,7 +101,7 @@ describe('Me Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({
         user: {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'John',
           lastName: 'Doe',
           email: 'test@example.com',
@@ -127,7 +127,7 @@ describe('Me Endpoint', () => {
 
       // Verify getUser was called with correct user ID
       const { getUser } = await import('@/use-cases/user/me')
-      expect(getUser).toHaveBeenCalledWith(1)
+      expect(getUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
       expect(getUser).toHaveBeenCalledTimes(1)
     })
 
@@ -186,7 +186,7 @@ describe('Me Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({
         user: {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'Jane',
           lastName: 'Smith',
           email: 'test@example.com',
@@ -202,7 +202,7 @@ describe('Me Endpoint', () => {
 
       // Verify updateUser was called with correct parameters
       const { updateUser } = await import('@/use-cases/user/me')
-      expect(updateUser).toHaveBeenCalledWith(1, {
+      expect(updateUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
         firstName: 'Jane',
         lastName: 'Smith',
       })
@@ -251,7 +251,7 @@ describe('Me Endpoint', () => {
 
       // Verify updateUser was called with only firstName
       const { updateUser } = await import('@/use-cases/user/me')
-      expect(updateUser).toHaveBeenCalledWith(1, {
+      expect(updateUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
         firstName: 'Jane',
       })
     })
@@ -277,7 +277,7 @@ describe('Me Endpoint', () => {
     })
 
     it('should handle empty body (no updates)', async () => {
-      mockUpdateUser.mockImplementation(async (_userId: number, updates: any) => {
+      mockUpdateUser.mockImplementation(async (_userId: string, updates: any) => {
         const validUpdates: any = {}
         if (updates.firstName && updates.firstName.trim()) {
           validUpdates.firstName = updates.firstName.trim()
@@ -308,7 +308,7 @@ describe('Me Endpoint', () => {
 
       // Verify updateUser was called
       const { updateUser } = await import('@/use-cases/user/me')
-      expect(updateUser).toHaveBeenCalledWith(1, {})
+      expect(updateUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {})
     })
 
     it('should normalize null lastName to empty string', async () => {
@@ -321,7 +321,7 @@ describe('Me Endpoint', () => {
 
       // Verify updateUser was called with lastName normalized to ""
       const { updateUser } = await import('@/use-cases/user/me')
-      expect(updateUser).toHaveBeenCalledWith(1, {
+      expect(updateUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
         firstName: 'Jane',
         lastName: '',
       })
@@ -340,7 +340,7 @@ describe('Me Endpoint', () => {
 
       // Verify updateUser was called only with lastName
       const { updateUser } = await import('@/use-cases/user/me')
-      expect(updateUser).toHaveBeenCalledWith(1, {
+      expect(updateUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
         lastName: 'Smith',
       })
     })
@@ -381,7 +381,7 @@ describe('Me Endpoint', () => {
 
       // Verify updateUser was called with already trimmed values (trimming happens at schema layer)
       const { updateUser } = await import('@/use-cases/user/me')
-      expect(updateUser).toHaveBeenCalledWith(1, {
+      expect(updateUser).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
         firstName: 'Jane',
         lastName: 'Smith',
       })

--- a/src/security/jwt/__tests__/jwt.integration.test.ts
+++ b/src/security/jwt/__tests__/jwt.integration.test.ts
@@ -7,7 +7,7 @@ import { signJwt, verifyJwt } from '../jwt'
 
 describe('JWT Integration Tests', () => {
   const testUserClaims = {
-    id: 1,
+    id: '550e8400-e29b-41d4-a716-446655440000',
     email: 'test@example.com',
     role: Role.User,
     status: Status.Active,
@@ -110,8 +110,8 @@ describe('JWT Integration Tests', () => {
 
     it('should create different tokens for different users', async () => {
       const secret = 'test-secret'
-      const user1 = { ...testUserClaims, id: 1 }
-      const user2 = { ...testUserClaims, id: 2 }
+      const user1 = { ...testUserClaims, id: '550e8400-e29b-41d4-a716-446655440001' }
+      const user2 = { ...testUserClaims, id: '550e8400-e29b-41d4-a716-446655440002' }
 
       const token1 = await signJwt(user1, { secret })
       const token2 = await signJwt(user2, { secret })

--- a/src/security/jwt/__tests__/jwt.integration.test.ts
+++ b/src/security/jwt/__tests__/jwt.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 
+import { testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { Role, Status } from '@/types'
 
@@ -7,7 +8,7 @@ import { signJwt, verifyJwt } from '../jwt'
 
 describe('JWT Integration Tests', () => {
   const testUserClaims = {
-    id: '550e8400-e29b-41d4-a716-446655440000',
+    id: testUuids.USER_1,
     email: 'test@example.com',
     role: Role.User,
     status: Status.Active,
@@ -110,8 +111,8 @@ describe('JWT Integration Tests', () => {
 
     it('should create different tokens for different users', async () => {
       const secret = 'test-secret'
-      const user1 = { ...testUserClaims, id: '550e8400-e29b-41d4-a716-446655440001' }
-      const user2 = { ...testUserClaims, id: '550e8400-e29b-41d4-a716-446655440002' }
+      const user1 = { ...testUserClaims, id: testUuids.USER_2 }
+      const user2 = { ...testUserClaims, id: testUuids.USER_3 }
 
       const token1 = await signJwt(user1, { secret })
       const token2 = await signJwt(user2, { secret })

--- a/src/security/jwt/__tests__/jwt.test.ts
+++ b/src/security/jwt/__tests__/jwt.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { ZodError } from 'zod'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { Role, Status } from '@/types'
 import { nowInSeconds } from '@/utils/chrono'
@@ -35,7 +35,7 @@ describe('JWT Unit Tests', () => {
     it('should transform user claims to JWT payload format', async () => {
       await signJwt(
         {
-          id: '550e8400-e29b-41d4-a716-446655440000',
+          id: testUuids.USER_1,
           email: 'test@example.com',
           role: Role.User,
           status: Status.Active,
@@ -49,7 +49,7 @@ describe('JWT Unit Tests', () => {
       const now = nowInSeconds()
 
       expect(payload).toMatchObject({
-        id: '550e8400-e29b-41d4-a716-446655440000',
+        id: testUuids.USER_1,
         email: 'test@example.com',
         role: Role.User,
         status: Status.Active,
@@ -65,7 +65,7 @@ describe('JWT Unit Tests', () => {
 
     beforeEach(async () => {
       mockVerify = mock(async () => ({
-        id: '550e8400-e29b-41d4-a716-446655440000',
+        id: testUuids.USER_1,
         email: 'test@example.com',
         role: Role.User,
         status: Status.Active,
@@ -118,7 +118,7 @@ describe('JWT Unit Tests', () => {
     describe('Secret Rotation', () => {
       it('should verify token with current secret successfully', async () => {
         const mockPayload = {
-          id: '550e8400-e29b-41d4-a716-446655440000',
+          id: testUuids.USER_1,
           email: 'test@example.com',
           role: Role.User,
           status: Status.Active,
@@ -148,7 +148,7 @@ describe('JWT Unit Tests', () => {
 
       it('should fallback to previous secret when current secret fails', async () => {
         const mockPayload = {
-          id: '550e8400-e29b-41d4-a716-446655440000',
+          id: testUuids.USER_1,
           email: 'test@example.com',
           role: Role.User,
           status: Status.Active,

--- a/src/security/jwt/__tests__/jwt.test.ts
+++ b/src/security/jwt/__tests__/jwt.test.ts
@@ -35,7 +35,7 @@ describe('JWT Unit Tests', () => {
     it('should transform user claims to JWT payload format', async () => {
       await signJwt(
         {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440000',
           email: 'test@example.com',
           role: Role.User,
           status: Status.Active,
@@ -49,7 +49,7 @@ describe('JWT Unit Tests', () => {
       const now = nowInSeconds()
 
       expect(payload).toMatchObject({
-        id: 1,
+        id: '550e8400-e29b-41d4-a716-446655440000',
         email: 'test@example.com',
         role: Role.User,
         status: Status.Active,
@@ -65,7 +65,7 @@ describe('JWT Unit Tests', () => {
 
     beforeEach(async () => {
       mockVerify = mock(async () => ({
-        id: 1,
+        id: '550e8400-e29b-41d4-a716-446655440000',
         email: 'test@example.com',
         role: Role.User,
         status: Status.Active,
@@ -118,7 +118,7 @@ describe('JWT Unit Tests', () => {
     describe('Secret Rotation', () => {
       it('should verify token with current secret successfully', async () => {
         const mockPayload = {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440000',
           email: 'test@example.com',
           role: Role.User,
           status: Status.Active,
@@ -148,7 +148,7 @@ describe('JWT Unit Tests', () => {
 
       it('should fallback to previous secret when current secret fails', async () => {
         const mockPayload = {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440000',
           email: 'test@example.com',
           role: Role.User,
           status: Status.Active,

--- a/src/security/jwt/claims/user.ts
+++ b/src/security/jwt/claims/user.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { Role, Status } from '@/types'
 
 export const userClaimsSchema = z.object({
-  id: z.number(),
+  id: z.string().uuid(),
   email: z.string().email(),
   role: z.nativeEnum(Role),
   status: z.nativeEnum(Status),

--- a/src/security/token/__tests__/validator.test.ts
+++ b/src/security/token/__tests__/validator.test.ts
@@ -10,7 +10,7 @@ import TokenValidator from '../validator'
 describe('TokenValidator', () => {
   const createValidToken = (overrides?: Partial<TokenRecord>): TokenRecord => ({
     id: 1,
-    userId: 1,
+    userId: '550e8400-e29b-41d4-a716-446655440001',
     type: TokenType.EmailVerification,
     status: TokenStatus.Pending,
     token: 'valid-token-123',

--- a/src/security/token/__tests__/validator.test.ts
+++ b/src/security/token/__tests__/validator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 
 import type { TokenRecord } from '@/data'
 
+import { testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 
 import { TokenStatus, TokenType } from '../types'
@@ -10,7 +11,7 @@ import TokenValidator from '../validator'
 describe('TokenValidator', () => {
   const createValidToken = (overrides?: Partial<TokenRecord>): TokenRecord => ({
     id: 1,
-    userId: '550e8400-e29b-41d4-a716-446655440001',
+    userId: testUuids.USER_1,
     type: TokenType.EmailVerification,
     status: TokenStatus.Pending,
     token: 'valid-token-123',

--- a/src/use-cases/admin/__tests__/users.test.ts
+++ b/src/use-cases/admin/__tests__/users.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import type { SearchResult, User } from '@/data'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import AppError from '@/errors/app-error'
 import ErrorCode from '@/errors/codes'
 import { Role, Status, USER_ROLES } from '@/types'
@@ -21,7 +21,7 @@ describe('searchUsers', () => {
     mockSearchResult = {
       users: [
         {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.USER_1,
           firstName: 'John',
           lastName: 'Doe',
           email: 'john@example.com',
@@ -93,7 +93,7 @@ describe('getUser', () => {
 
   beforeEach(async () => {
     mockUser = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',
@@ -115,17 +115,17 @@ describe('getUser', () => {
   })
 
   it('should return user when found', async () => {
-    const result = await getUser('550e8400-e29b-41d4-a716-446655440001')
+    const result = await getUser(testUuids.USER_1)
 
-    expect(mockFindById).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
+    expect(mockFindById).toHaveBeenCalledWith(testUuids.USER_1)
     expect(result).toEqual({ data: { user: mockUser } })
   })
 
   it('should throw NotFound error when user does not exist', async () => {
     mockFindById.mockImplementation(async () => undefined)
 
-    expect(getUser('550e8400-e29b-41d4-a716-446655440999')).rejects.toThrow(AppError)
-    expect(getUser('550e8400-e29b-41d4-a716-446655440999')).rejects.toMatchObject({
+    expect(getUser(testUuids.NON_EXISTENT)).rejects.toThrow(AppError)
+    expect(getUser(testUuids.NON_EXISTENT)).rejects.toMatchObject({
       code: ErrorCode.NotFound,
       message: 'User not found',
     })

--- a/src/use-cases/admin/__tests__/users.test.ts
+++ b/src/use-cases/admin/__tests__/users.test.ts
@@ -21,7 +21,7 @@ describe('searchUsers', () => {
     mockSearchResult = {
       users: [
         {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'John',
           lastName: 'Doe',
           email: 'john@example.com',
@@ -93,7 +93,7 @@ describe('getUser', () => {
 
   beforeEach(async () => {
     mockUser = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',
@@ -115,17 +115,17 @@ describe('getUser', () => {
   })
 
   it('should return user when found', async () => {
-    const result = await getUser(1)
+    const result = await getUser('550e8400-e29b-41d4-a716-446655440001')
 
-    expect(mockFindById).toHaveBeenCalledWith(1)
+    expect(mockFindById).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
     expect(result).toEqual({ data: { user: mockUser } })
   })
 
   it('should throw NotFound error when user does not exist', async () => {
     mockFindById.mockImplementation(async () => undefined)
 
-    expect(getUser(999)).rejects.toThrow(AppError)
-    expect(getUser(999)).rejects.toMatchObject({
+    expect(getUser('550e8400-e29b-41d4-a716-446655440999')).rejects.toThrow(AppError)
+    expect(getUser('550e8400-e29b-41d4-a716-446655440999')).rejects.toMatchObject({
       code: ErrorCode.NotFound,
       message: 'User not found',
     })

--- a/src/use-cases/admin/users.ts
+++ b/src/use-cases/admin/users.ts
@@ -23,7 +23,7 @@ export const searchUsers = async (params: SearchParams, pagination: PaginationPa
   }
 }
 
-export const getUser = async (userId: number) => {
+export const getUser = async (userId: string) => {
   const user = await userRepo.findById(userId)
 
   if (!user || !isUser(user.role)) {

--- a/src/use-cases/auth/__tests__/accept-invite.test.ts
+++ b/src/use-cases/auth/__tests__/accept-invite.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { TokenRecord, User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { TOKEN_LENGTH, TokenStatus, TokenType } from '@/security/token'
 import Role from '@/types/role'
@@ -45,7 +45,7 @@ describe('Accept Invite', () => {
     mockTokenString = `mock-invite-token-${'1'.repeat(TOKEN_LENGTH - 18)}`
     mockTokenRecord = {
       id: 1,
-      userId: '550e8400-e29b-41d4-a716-446655440123',
+      userId: testUuids.ADMIN_1,
       type: TokenType.UserInvitation,
       token: mockTokenString,
       status: TokenStatus.Pending,
@@ -56,7 +56,7 @@ describe('Accept Invite', () => {
     }
 
     mockUser = {
-      id: '550e8400-e29b-41d4-a716-446655440123',
+      id: testUuids.ADMIN_1,
       email: 'admin@example.com',
       firstName: 'Admin',
       lastName: 'User',

--- a/src/use-cases/auth/__tests__/accept-invite.test.ts
+++ b/src/use-cases/auth/__tests__/accept-invite.test.ts
@@ -45,7 +45,7 @@ describe('Accept Invite', () => {
     mockTokenString = `mock-invite-token-${'1'.repeat(TOKEN_LENGTH - 18)}`
     mockTokenRecord = {
       id: 1,
-      userId: 123,
+      userId: '550e8400-e29b-41d4-a716-446655440123',
       type: TokenType.UserInvitation,
       token: mockTokenString,
       status: TokenStatus.Pending,
@@ -56,7 +56,7 @@ describe('Accept Invite', () => {
     }
 
     mockUser = {
-      id: 123,
+      id: '550e8400-e29b-41d4-a716-446655440123',
       email: 'admin@example.com',
       firstName: 'Admin',
       lastName: 'User',

--- a/src/use-cases/auth/__tests__/login.test.ts
+++ b/src/use-cases/auth/__tests__/login.test.ts
@@ -40,7 +40,7 @@ describe('Login with Email', () => {
     }
 
     mockUser = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'John',
       lastName: 'Doe',
       email: 'test@example.com',
@@ -54,7 +54,7 @@ describe('Login with Email', () => {
     }
     mockAuthRecord = {
       id: 1,
-      userId: 1,
+      userId: '550e8400-e29b-41d4-a716-446655440001',
       provider: AuthProvider.Local,
       identifier: 'test@example.com',
       passwordHash: '$2b$10$hashedPassword123',

--- a/src/use-cases/auth/__tests__/login.test.ts
+++ b/src/use-cases/auth/__tests__/login.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import type { AuthRecord, User } from '@/data'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { AuthProvider, Role, Status } from '@/types'
 
@@ -40,7 +40,7 @@ describe('Login with Email', () => {
     }
 
     mockUser = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       firstName: 'John',
       lastName: 'Doe',
       email: 'test@example.com',
@@ -54,7 +54,7 @@ describe('Login with Email', () => {
     }
     mockAuthRecord = {
       id: 1,
-      userId: '550e8400-e29b-41d4-a716-446655440001',
+      userId: testUuids.USER_1,
       provider: AuthProvider.Local,
       identifier: 'test@example.com',
       passwordHash: '$2b$10$hashedPassword123',

--- a/src/use-cases/auth/__tests__/refresh-token.test.ts
+++ b/src/use-cases/auth/__tests__/refresh-token.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import type { RefreshToken, User } from '@/data'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { ErrorCode } from '@/errors'
 import { Role, Status } from '@/types'
 
@@ -35,7 +35,7 @@ describe('Refresh Auth Tokens', () => {
     }
 
     mockUser = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       firstName: 'John',
       lastName: 'Doe',
       email: 'test@example.com',
@@ -49,7 +49,7 @@ describe('Refresh Auth Tokens', () => {
     }
     mockStoredToken = {
       id: 1,
-      userId: '550e8400-e29b-41d4-a716-446655440001',
+      userId: testUuids.USER_1,
       tokenHash: 'hashed_token_123',
       ipAddress: '192.168.1.1',
       userAgent: 'Mozilla/5.0 (Test)',

--- a/src/use-cases/auth/__tests__/refresh-token.test.ts
+++ b/src/use-cases/auth/__tests__/refresh-token.test.ts
@@ -35,7 +35,7 @@ describe('Refresh Auth Tokens', () => {
     }
 
     mockUser = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'John',
       lastName: 'Doe',
       email: 'test@example.com',
@@ -49,7 +49,7 @@ describe('Refresh Auth Tokens', () => {
     }
     mockStoredToken = {
       id: 1,
-      userId: 1,
+      userId: '550e8400-e29b-41d4-a716-446655440001',
       tokenHash: 'hashed_token_123',
       ipAddress: '192.168.1.1',
       userAgent: 'Mozilla/5.0 (Test)',

--- a/src/use-cases/auth/__tests__/request-password-reset.test.ts
+++ b/src/use-cases/auth/__tests__/request-password-reset.test.ts
@@ -25,7 +25,7 @@ describe('Request Password Reset', () => {
 
   beforeEach(async () => {
     mockUser = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',

--- a/src/use-cases/auth/__tests__/request-password-reset.test.ts
+++ b/src/use-cases/auth/__tests__/request-password-reset.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import type { User } from '@/data'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { TokenType } from '@/security/token'
 import { Role, Status } from '@/types'
 import { hour, nowPlus } from '@/utils/chrono'
@@ -25,7 +25,7 @@ describe('Request Password Reset', () => {
 
   beforeEach(async () => {
     mockUser = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',

--- a/src/use-cases/auth/__tests__/resend-verification-email.test.ts
+++ b/src/use-cases/auth/__tests__/resend-verification-email.test.ts
@@ -25,7 +25,7 @@ describe('Resend Verification Email', () => {
 
   beforeEach(async () => {
     mockUser = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',

--- a/src/use-cases/auth/__tests__/resend-verification-email.test.ts
+++ b/src/use-cases/auth/__tests__/resend-verification-email.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import type { User } from '@/data'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { TokenType } from '@/security/token'
 import { Role, Status } from '@/types'
 import { hours, nowPlus } from '@/utils/chrono'
@@ -25,7 +25,7 @@ describe('Resend Verification Email', () => {
 
   beforeEach(async () => {
     mockUser = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',

--- a/src/use-cases/auth/__tests__/reset-password.test.ts
+++ b/src/use-cases/auth/__tests__/reset-password.test.ts
@@ -44,7 +44,7 @@ describe('Reset Password', () => {
     mockTokenString = `mock-reset-token-${'1'.repeat(TOKEN_LENGTH - 18)}`
     mockTokenRecord = {
       id: 1,
-      userId: 123,
+      userId: '550e8400-e29b-41d4-a716-446655440123',
       type: TokenType.PasswordReset,
       token: mockTokenString,
       status: TokenStatus.Pending,
@@ -55,7 +55,7 @@ describe('Reset Password', () => {
     }
 
     mockUser = {
-      id: 123,
+      id: '550e8400-e29b-41d4-a716-446655440123',
       email: 'test@example.com',
       firstName: 'Test',
       lastName: 'User',

--- a/src/use-cases/auth/__tests__/reset-password.test.ts
+++ b/src/use-cases/auth/__tests__/reset-password.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { TokenRecord, User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { TOKEN_LENGTH, TokenStatus, TokenType } from '@/security/token'
 import Role from '@/types/role'
@@ -44,7 +44,7 @@ describe('Reset Password', () => {
     mockTokenString = `mock-reset-token-${'1'.repeat(TOKEN_LENGTH - 18)}`
     mockTokenRecord = {
       id: 1,
-      userId: '550e8400-e29b-41d4-a716-446655440123',
+      userId: testUuids.USER_1,
       type: TokenType.PasswordReset,
       token: mockTokenString,
       status: TokenStatus.Pending,
@@ -55,7 +55,7 @@ describe('Reset Password', () => {
     }
 
     mockUser = {
-      id: '550e8400-e29b-41d4-a716-446655440123',
+      id: testUuids.USER_1,
       email: 'test@example.com',
       firstName: 'Test',
       lastName: 'User',

--- a/src/use-cases/auth/__tests__/signup.test.ts
+++ b/src/use-cases/auth/__tests__/signup.test.ts
@@ -55,7 +55,7 @@ describe('Signup with Email', () => {
     }
 
     mockNewUser = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',
@@ -274,7 +274,7 @@ describe('Signup with Email', () => {
   describe('when email is already in use', () => {
     it('should throw EmailAlreadyInUse error', async () => {
       const existingUser = {
-        id: 2,
+        id: '550e8400-e29b-41d4-a716-446655440002',
         firstName: 'Jane',
         lastName: 'Smith',
         email: 'john@example.com',

--- a/src/use-cases/auth/__tests__/signup.test.ts
+++ b/src/use-cases/auth/__tests__/signup.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import type { User } from '@/data'
 
-import { ModuleMocker } from '@/__tests__/module-mocker'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { TokenType } from '@/security/token'
 import { AuthProvider, Role, Status } from '@/types'
@@ -55,7 +55,7 @@ describe('Signup with Email', () => {
     }
 
     mockNewUser = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',
@@ -274,7 +274,7 @@ describe('Signup with Email', () => {
   describe('when email is already in use', () => {
     it('should throw EmailAlreadyInUse error', async () => {
       const existingUser = {
-        id: '550e8400-e29b-41d4-a716-446655440002',
+        id: testUuids.USER_2,
         firstName: 'Jane',
         lastName: 'Smith',
         email: 'john@example.com',

--- a/src/use-cases/auth/__tests__/verify-email.test.ts
+++ b/src/use-cases/auth/__tests__/verify-email.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { TokenRecord, UserRecord } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { TOKEN_LENGTH, TokenStatus, TokenType } from '@/security/token'
 import { Role, Status } from '@/types'
@@ -41,7 +41,7 @@ describe('Verify Email', () => {
     mockTokenString = 'a'.repeat(TOKEN_LENGTH)
     mockTokenRecord = {
       id: 1,
-      userId: '550e8400-e29b-41d4-a716-446655440001',
+      userId: testUuids.USER_1,
       type: TokenType.EmailVerification,
       token: mockTokenString,
       status: TokenStatus.Pending,
@@ -55,7 +55,7 @@ describe('Verify Email', () => {
       update: mock(async () => {}),
     }
     mockUser = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',
@@ -361,7 +361,7 @@ describe('Verify Email', () => {
     it('should handle token with different user ID', async () => {
       const differentUserTokenRecord = {
         ...mockTokenRecord,
-        userId: '550e8400-e29b-41d4-a716-446655440999',
+        userId: testUuids.NON_EXISTENT,
       }
 
       mockTokenRepo.findByToken.mockImplementation(async () => differentUserTokenRecord)
@@ -374,7 +374,7 @@ describe('Verify Email', () => {
       expect(result.data).toHaveProperty('user')
       expect(result.data).toHaveProperty('accessToken')
       expect(result.data.user.email).toBe(mockUser.email)
-      expect(mockUserRepo.update).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440999', {
+      expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.NON_EXISTENT, {
         status: Status.Verified,
       }, {})
     })

--- a/src/use-cases/auth/__tests__/verify-email.test.ts
+++ b/src/use-cases/auth/__tests__/verify-email.test.ts
@@ -41,7 +41,7 @@ describe('Verify Email', () => {
     mockTokenString = 'a'.repeat(TOKEN_LENGTH)
     mockTokenRecord = {
       id: 1,
-      userId: 1,
+      userId: '550e8400-e29b-41d4-a716-446655440001',
       type: TokenType.EmailVerification,
       token: mockTokenString,
       status: TokenStatus.Pending,
@@ -55,7 +55,7 @@ describe('Verify Email', () => {
       update: mock(async () => {}),
     }
     mockUser = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'John',
       lastName: 'Doe',
       email: 'john@example.com',
@@ -361,7 +361,7 @@ describe('Verify Email', () => {
     it('should handle token with different user ID', async () => {
       const differentUserTokenRecord = {
         ...mockTokenRecord,
-        userId: 999,
+        userId: '550e8400-e29b-41d4-a716-446655440999',
       }
 
       mockTokenRepo.findByToken.mockImplementation(async () => differentUserTokenRecord)
@@ -374,7 +374,7 @@ describe('Verify Email', () => {
       expect(result.data).toHaveProperty('user')
       expect(result.data).toHaveProperty('accessToken')
       expect(result.data.user.email).toBe(mockUser.email)
-      expect(mockUserRepo.update).toHaveBeenCalledWith(999, {
+      expect(mockUserRepo.update).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440999', {
         status: Status.Verified,
       }, {})
     })

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -32,7 +32,7 @@ const createAccessToken = async (user: User) => signJwt({
   status: user.status,
 })
 
-const createRefreshToken = async (userId: number, deviceInfo: DeviceInfo) => {
+const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
   const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
     TokenType.RefreshToken,
   )

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -21,7 +21,7 @@ const createAccessToken = async (user: User) => signJwt(
   },
 )
 
-const createRefreshToken = async (userId: number, deviceInfo: DeviceInfo) => {
+const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
   const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
     TokenType.RefreshToken,
   )

--- a/src/use-cases/auth/refresh-token.ts
+++ b/src/use-cases/auth/refresh-token.ts
@@ -40,7 +40,7 @@ const createAccessToken = async (user: User) => signJwt(
 )
 
 const createRefreshToken = async (
-  userId: number,
+  userId: string,
   deviceInfo: DeviceInfo,
   tx?: Database,
 ) => {
@@ -62,7 +62,7 @@ const createRefreshToken = async (
 const validateDevice = (
   storedToken: { ipAddress: string | null, userAgent: string | null },
   deviceInfo: DeviceInfo,
-  userId: number,
+  userId: string,
 ) => {
   const ipChanged = storedToken.ipAddress !== deviceInfo.ipAddress
   const userAgentChanged = storedToken.userAgent !== deviceInfo.userAgent

--- a/src/use-cases/auth/request-password-reset.ts
+++ b/src/use-cases/auth/request-password-reset.ts
@@ -10,7 +10,7 @@ export interface RequestPasswordResetParams {
   email: string
 }
 
-const createPasswordResetToken = async (userId: number) => {
+const createPasswordResetToken = async (userId: string) => {
   const { type, token, expiresAt } = generateToken(TokenType.PasswordReset)
 
   await db.transaction(async (tx) => {

--- a/src/use-cases/auth/resend-verification-email.ts
+++ b/src/use-cases/auth/resend-verification-email.ts
@@ -10,7 +10,7 @@ export interface ResendVerificationEmailParams {
   email: string
 }
 
-const createEmailVerificationToken = async (userId: number) => {
+const createEmailVerificationToken = async (userId: string) => {
   const { type, token, expiresAt } = generateToken(TokenType.EmailVerification)
 
   await db.transaction(async (tx) => {

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -31,7 +31,7 @@ const createAccessToken = async (user: User) => signJwt({
   status: user.status,
 })
 
-const createRefreshToken = async (userId: number, deviceInfo: DeviceInfo) => {
+const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
   const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
     TokenType.RefreshToken,
   )

--- a/src/use-cases/auth/signup.ts
+++ b/src/use-cases/auth/signup.ts
@@ -66,7 +66,7 @@ const createAccessToken = async (user: User) => signJwt(
   },
 )
 
-const createRefreshToken = async (userId: number, deviceInfo: DeviceInfo) => {
+const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
   const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
     TokenType.RefreshToken,
   )

--- a/src/use-cases/auth/verify-email.ts
+++ b/src/use-cases/auth/verify-email.ts
@@ -25,7 +25,7 @@ const createAccessToken = async (user: User) => signJwt(
   },
 )
 
-const createRefreshToken = async (userId: number, deviceInfo: DeviceInfo) => {
+const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
   const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
     TokenType.RefreshToken,
   )

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import type { SearchResult, User } from '@/data'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import AppError from '@/errors/app-error'
 import ErrorCode from '@/errors/codes'
 import { Role, Status } from '@/types'
@@ -21,7 +21,7 @@ describe('getAdmins', () => {
     mockSearchResult = {
       users: [
         {
-          id: '550e8400-e29b-41d4-a716-446655440001',
+          id: testUuids.ADMIN_1,
           firstName: 'Admin',
           lastName: 'User',
           email: 'admin@example.com',
@@ -84,7 +84,7 @@ describe('getAdmin', () => {
 
   beforeEach(async () => {
     mockAdmin = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.ADMIN_1,
       firstName: 'Admin',
       lastName: 'User',
       email: 'admin@example.com',
@@ -106,17 +106,17 @@ describe('getAdmin', () => {
   })
 
   it('should return admin when found', async () => {
-    const result = await getAdmin('550e8400-e29b-41d4-a716-446655440001')
+    const result = await getAdmin(testUuids.ADMIN_1)
 
-    expect(mockFindById).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
+    expect(mockFindById).toHaveBeenCalledWith(testUuids.ADMIN_1)
     expect(result).toEqual({ data: { admin: mockAdmin } })
   })
 
   it('should throw NotFound error when admin does not exist', async () => {
     mockFindById.mockImplementation(async () => undefined)
 
-    expect(getAdmin('550e8400-e29b-41d4-a716-446655440999')).rejects.toThrow(AppError)
-    expect(getAdmin('550e8400-e29b-41d4-a716-446655440999')).rejects.toMatchObject({
+    expect(getAdmin(testUuids.NON_EXISTENT)).rejects.toThrow(AppError)
+    expect(getAdmin(testUuids.NON_EXISTENT)).rejects.toMatchObject({
       code: ErrorCode.NotFound,
       message: 'Admin not found',
     })
@@ -128,8 +128,8 @@ describe('getAdmin', () => {
       role: Role.User,
     }))
 
-    expect(getAdmin('550e8400-e29b-41d4-a716-446655440001')).rejects.toThrow(AppError)
-    expect(getAdmin('550e8400-e29b-41d4-a716-446655440001')).rejects.toMatchObject({
+    expect(getAdmin(testUuids.ADMIN_1)).rejects.toThrow(AppError)
+    expect(getAdmin(testUuids.ADMIN_1)).rejects.toMatchObject({
       code: ErrorCode.NotFound,
       message: 'Admin not found',
     })
@@ -141,8 +141,8 @@ describe('getAdmin', () => {
       role: Role.Owner,
     }))
 
-    expect(getAdmin('550e8400-e29b-41d4-a716-446655440001')).rejects.toThrow(AppError)
-    expect(getAdmin('550e8400-e29b-41d4-a716-446655440001')).rejects.toMatchObject({
+    expect(getAdmin(testUuids.ADMIN_1)).rejects.toThrow(AppError)
+    expect(getAdmin(testUuids.ADMIN_1)).rejects.toMatchObject({
       code: ErrorCode.NotFound,
       message: 'Admin not found',
     })
@@ -174,7 +174,7 @@ describe('inviteAdmin', () => {
 
   beforeEach(async () => {
     mockAdmin = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.ADMIN_1,
       firstName: 'New',
       lastName: 'Admin',
       email: 'newadmin@example.com',

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -21,7 +21,7 @@ describe('getAdmins', () => {
     mockSearchResult = {
       users: [
         {
-          id: 1,
+          id: '550e8400-e29b-41d4-a716-446655440001',
           firstName: 'Admin',
           lastName: 'User',
           email: 'admin@example.com',
@@ -84,7 +84,7 @@ describe('getAdmin', () => {
 
   beforeEach(async () => {
     mockAdmin = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'Admin',
       lastName: 'User',
       email: 'admin@example.com',
@@ -106,17 +106,17 @@ describe('getAdmin', () => {
   })
 
   it('should return admin when found', async () => {
-    const result = await getAdmin(1)
+    const result = await getAdmin('550e8400-e29b-41d4-a716-446655440001')
 
-    expect(mockFindById).toHaveBeenCalledWith(1)
+    expect(mockFindById).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
     expect(result).toEqual({ data: { admin: mockAdmin } })
   })
 
   it('should throw NotFound error when admin does not exist', async () => {
     mockFindById.mockImplementation(async () => undefined)
 
-    expect(getAdmin(999)).rejects.toThrow(AppError)
-    expect(getAdmin(999)).rejects.toMatchObject({
+    expect(getAdmin('550e8400-e29b-41d4-a716-446655440999')).rejects.toThrow(AppError)
+    expect(getAdmin('550e8400-e29b-41d4-a716-446655440999')).rejects.toMatchObject({
       code: ErrorCode.NotFound,
       message: 'Admin not found',
     })
@@ -128,8 +128,8 @@ describe('getAdmin', () => {
       role: Role.User,
     }))
 
-    expect(getAdmin(1)).rejects.toThrow(AppError)
-    expect(getAdmin(1)).rejects.toMatchObject({
+    expect(getAdmin('550e8400-e29b-41d4-a716-446655440001')).rejects.toThrow(AppError)
+    expect(getAdmin('550e8400-e29b-41d4-a716-446655440001')).rejects.toMatchObject({
       code: ErrorCode.NotFound,
       message: 'Admin not found',
     })
@@ -141,8 +141,8 @@ describe('getAdmin', () => {
       role: Role.Owner,
     }))
 
-    expect(getAdmin(1)).rejects.toThrow(AppError)
-    expect(getAdmin(1)).rejects.toMatchObject({
+    expect(getAdmin('550e8400-e29b-41d4-a716-446655440001')).rejects.toThrow(AppError)
+    expect(getAdmin('550e8400-e29b-41d4-a716-446655440001')).rejects.toMatchObject({
       code: ErrorCode.NotFound,
       message: 'Admin not found',
     })
@@ -174,7 +174,7 @@ describe('inviteAdmin', () => {
 
   beforeEach(async () => {
     mockAdmin = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'New',
       lastName: 'Admin',
       email: 'newadmin@example.com',

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -23,7 +23,7 @@ export const getAdmins = async (params: SearchParams, pagination: PaginationPara
   }
 }
 
-export const getAdmin = async (adminId: number) => {
+export const getAdmin = async (adminId: string) => {
   const admin = await userRepo.findById(adminId)
 
   if (!admin || admin.role !== Role.Admin) {

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import type { UpdateUserInput, User } from '@/data'
 
-import { ModuleMocker } from '@/__tests__'
+import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { Role, Status } from '@/types'
 
@@ -16,7 +16,7 @@ describe('User Me Use Cases', () => {
 
   beforeEach(async () => {
     mockUser = {
-      id: '550e8400-e29b-41d4-a716-446655440001',
+      id: testUuids.USER_1,
       firstName: 'John',
       lastName: 'Doe',
       email: 'test@example.com',
@@ -44,20 +44,20 @@ describe('User Me Use Cases', () => {
 
   describe('getUser', () => {
     it('should return user data when user exists', async () => {
-      const result = await getUser('550e8400-e29b-41d4-a716-446655440001')
+      const result = await getUser(testUuids.USER_1)
 
       expect(result).toEqual({
         data: { user: mockUser },
       })
-      expect(mockUserRepo.findById).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
+      expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
       expect(mockUserRepo.findById).toHaveBeenCalledTimes(1)
     })
 
     it('should throw InternalError when user not found', async () => {
       mockUserRepo.findById.mockImplementation(async () => null)
 
-      expect(getUser('550e8400-e29b-41d4-a716-446655440999')).rejects.toThrow(AppError)
-      expect(getUser('550e8400-e29b-41d4-a716-446655440999')).rejects.toMatchObject({
+      expect(getUser(testUuids.NON_EXISTENT)).rejects.toThrow(AppError)
+      expect(getUser(testUuids.NON_EXISTENT)).rejects.toMatchObject({
         code: ErrorCode.InternalError,
       })
     })
@@ -65,11 +65,11 @@ describe('User Me Use Cases', () => {
 
   describe('updateUser', () => {
     it('should update user with firstName and lastName', async () => {
-      const result = await updateUser('550e8400-e29b-41d4-a716-446655440001', { firstName: 'Jane', lastName: 'Smith' })
+      const result = await updateUser(testUuids.USER_1, { firstName: 'Jane', lastName: 'Smith' })
 
       expect(result.data.user.firstName).toBe('Jane')
       expect(result.data.user.lastName).toBe('Smith')
-      expect(mockUserRepo.update).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
+      expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: 'Smith',
         updatedAt: expect.any(Date),
@@ -77,42 +77,42 @@ describe('User Me Use Cases', () => {
     })
 
     it('should update user with only firstName', async () => {
-      const result = await updateUser('550e8400-e29b-41d4-a716-446655440001', { firstName: 'Jane' })
+      const result = await updateUser(testUuids.USER_1, { firstName: 'Jane' })
 
       expect(result.data.user.firstName).toBe('Jane')
-      expect(mockUserRepo.update).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
+      expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         updatedAt: expect.any(Date),
       })
     })
 
     it('should update user with only lastName', async () => {
-      const result = await updateUser('550e8400-e29b-41d4-a716-446655440001', { lastName: 'Smith' })
+      const result = await updateUser(testUuids.USER_1, { lastName: 'Smith' })
 
       expect(result.data.user.lastName).toBe('Smith')
-      expect(mockUserRepo.update).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
+      expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         lastName: 'Smith',
         updatedAt: expect.any(Date),
       })
     })
 
     it('should return current user when no valid updates provided', async () => {
-      const result = await updateUser('550e8400-e29b-41d4-a716-446655440001', {})
+      const result = await updateUser(testUuids.USER_1, {})
 
       expect(result).toEqual({
         data: { user: mockUser },
       })
       expect(mockUserRepo.update).not.toHaveBeenCalled()
-      expect(mockUserRepo.findById).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
+      expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
     })
 
     it('should allow clearing lastName with empty string', async () => {
       // lastName: '' is valid (clears the field)
-      const result = await updateUser('550e8400-e29b-41d4-a716-446655440001', { firstName: 'Jane', lastName: '' })
+      const result = await updateUser(testUuids.USER_1, { firstName: 'Jane', lastName: '' })
 
       expect(result.data.user.firstName).toBe('Jane')
       expect(result.data.user.lastName).toBe('')
-      expect(mockUserRepo.update).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
+      expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: '',
         updatedAt: expect.any(Date),
@@ -121,10 +121,10 @@ describe('User Me Use Cases', () => {
 
     it('should filter undefined values only', async () => {
       // undefined = don't touch, empty string = include
-      const result = await updateUser('550e8400-e29b-41d4-a716-446655440001', { firstName: undefined, lastName: 'Smith' })
+      const result = await updateUser(testUuids.USER_1, { firstName: undefined, lastName: 'Smith' })
 
       expect(result.data.user.lastName).toBe('Smith')
-      expect(mockUserRepo.update).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
+      expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         lastName: 'Smith',
         updatedAt: expect.any(Date),
       })

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -16,7 +16,7 @@ describe('User Me Use Cases', () => {
 
   beforeEach(async () => {
     mockUser = {
-      id: 1,
+      id: '550e8400-e29b-41d4-a716-446655440001',
       firstName: 'John',
       lastName: 'Doe',
       email: 'test@example.com',
@@ -27,7 +27,7 @@ describe('User Me Use Cases', () => {
     }
     mockUserRepo = {
       findById: mock(async () => mockUser),
-      update: mock(async (_id: number, updates: UpdateUserInput) => ({
+      update: mock(async (_id: string, updates: UpdateUserInput) => ({
         ...mockUser,
         ...updates,
       })),
@@ -44,20 +44,20 @@ describe('User Me Use Cases', () => {
 
   describe('getUser', () => {
     it('should return user data when user exists', async () => {
-      const result = await getUser(1)
+      const result = await getUser('550e8400-e29b-41d4-a716-446655440001')
 
       expect(result).toEqual({
         data: { user: mockUser },
       })
-      expect(mockUserRepo.findById).toHaveBeenCalledWith(1)
+      expect(mockUserRepo.findById).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
       expect(mockUserRepo.findById).toHaveBeenCalledTimes(1)
     })
 
     it('should throw InternalError when user not found', async () => {
       mockUserRepo.findById.mockImplementation(async () => null)
 
-      expect(getUser(999)).rejects.toThrow(AppError)
-      expect(getUser(999)).rejects.toMatchObject({
+      expect(getUser('550e8400-e29b-41d4-a716-446655440999')).rejects.toThrow(AppError)
+      expect(getUser('550e8400-e29b-41d4-a716-446655440999')).rejects.toMatchObject({
         code: ErrorCode.InternalError,
       })
     })
@@ -65,11 +65,11 @@ describe('User Me Use Cases', () => {
 
   describe('updateUser', () => {
     it('should update user with firstName and lastName', async () => {
-      const result = await updateUser(1, { firstName: 'Jane', lastName: 'Smith' })
+      const result = await updateUser('550e8400-e29b-41d4-a716-446655440001', { firstName: 'Jane', lastName: 'Smith' })
 
       expect(result.data.user.firstName).toBe('Jane')
       expect(result.data.user.lastName).toBe('Smith')
-      expect(mockUserRepo.update).toHaveBeenCalledWith(1, {
+      expect(mockUserRepo.update).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
         firstName: 'Jane',
         lastName: 'Smith',
         updatedAt: expect.any(Date),
@@ -77,42 +77,42 @@ describe('User Me Use Cases', () => {
     })
 
     it('should update user with only firstName', async () => {
-      const result = await updateUser(1, { firstName: 'Jane' })
+      const result = await updateUser('550e8400-e29b-41d4-a716-446655440001', { firstName: 'Jane' })
 
       expect(result.data.user.firstName).toBe('Jane')
-      expect(mockUserRepo.update).toHaveBeenCalledWith(1, {
+      expect(mockUserRepo.update).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
         firstName: 'Jane',
         updatedAt: expect.any(Date),
       })
     })
 
     it('should update user with only lastName', async () => {
-      const result = await updateUser(1, { lastName: 'Smith' })
+      const result = await updateUser('550e8400-e29b-41d4-a716-446655440001', { lastName: 'Smith' })
 
       expect(result.data.user.lastName).toBe('Smith')
-      expect(mockUserRepo.update).toHaveBeenCalledWith(1, {
+      expect(mockUserRepo.update).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
         lastName: 'Smith',
         updatedAt: expect.any(Date),
       })
     })
 
     it('should return current user when no valid updates provided', async () => {
-      const result = await updateUser(1, {})
+      const result = await updateUser('550e8400-e29b-41d4-a716-446655440001', {})
 
       expect(result).toEqual({
         data: { user: mockUser },
       })
       expect(mockUserRepo.update).not.toHaveBeenCalled()
-      expect(mockUserRepo.findById).toHaveBeenCalledWith(1)
+      expect(mockUserRepo.findById).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001')
     })
 
     it('should allow clearing lastName with empty string', async () => {
       // lastName: '' is valid (clears the field)
-      const result = await updateUser(1, { firstName: 'Jane', lastName: '' })
+      const result = await updateUser('550e8400-e29b-41d4-a716-446655440001', { firstName: 'Jane', lastName: '' })
 
       expect(result.data.user.firstName).toBe('Jane')
       expect(result.data.user.lastName).toBe('')
-      expect(mockUserRepo.update).toHaveBeenCalledWith(1, {
+      expect(mockUserRepo.update).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
         firstName: 'Jane',
         lastName: '',
         updatedAt: expect.any(Date),
@@ -121,10 +121,10 @@ describe('User Me Use Cases', () => {
 
     it('should filter undefined values only', async () => {
       // undefined = don't touch, empty string = include
-      const result = await updateUser(1, { firstName: undefined, lastName: 'Smith' })
+      const result = await updateUser('550e8400-e29b-41d4-a716-446655440001', { firstName: undefined, lastName: 'Smith' })
 
       expect(result.data.user.lastName).toBe('Smith')
-      expect(mockUserRepo.update).toHaveBeenCalledWith(1, {
+      expect(mockUserRepo.update).toHaveBeenCalledWith('550e8400-e29b-41d4-a716-446655440001', {
         lastName: 'Smith',
         updatedAt: expect.any(Date),
       })

--- a/src/use-cases/user/me.ts
+++ b/src/use-cases/user/me.ts
@@ -9,7 +9,7 @@ const prepareValidUpdates = (updates: UpdateUserInput): UpdateUserInput => {
   ) as UpdateUserInput
 }
 
-export const getUser = async (userId: number) => {
+export const getUser = async (userId: string) => {
   const user = await userRepo.findById(userId)
 
   if (!user) {
@@ -21,7 +21,7 @@ export const getUser = async (userId: number) => {
   return { data: { user } }
 }
 
-export const updateUser = async (userId: number, updates: UpdateUserInput) => {
+export const updateUser = async (userId: string, updates: UpdateUserInput) => {
   const validUpdates = prepareValidUpdates(updates)
 
   if (Object.keys(validUpdates).length === 0) {


### PR DESCRIPTION
1. [Breaking]: Change user ID type from serial integer to UUID across entire codebase
2. [Improvement]: Add UUID to user search index for direct ID-based searches
3. [Improvement]: Consolidate custom migrations by removing redundant token type migration
4. [Improvement]: Add test UUID factory for consistent, readable test identifiers
5. [Refactor]: Update all repositories, schemas, and use-cases to handle UUID format
6. [Refactor]: Update JWT claims and middleware to use string-based user IDs

🤖 Generated with [Claude Code](https://claude.ai/code)