### PR TITLE
Add companies schema, CRUD endpoints, and tests

### DIFF
--- a/postman.json
+++ b/postman.json
@@ -43,6 +43,633 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "companies",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{admin_api_url}}/companies",
+              "host": [
+                "{{admin_api_url}}"
+              ],
+              "path": [
+                "companies"
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "200",
+              "originalRequest": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{admin_api_url}}/companies",
+                  "host": [
+                    "{{admin_api_url}}"
+                  ],
+                  "path": [
+                    "companies"
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": null,
+              "header": [
+                {
+                  "key": "Access-Control-Allow-Origin",
+                  "value": "*"
+                },
+                {
+                  "key": "Access-Control-Allow-Credentials",
+                  "value": "true"
+                },
+                {
+                  "key": "Access-Control-Expose-Headers",
+                  "value": "Content-Length,X-Request-Id"
+                },
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                },
+                {
+                  "key": "Vary",
+                  "value": "Origin"
+                },
+                {
+                  "key": "Cross-Origin-Resource-Policy",
+                  "value": "same-origin"
+                },
+                {
+                  "key": "Cross-Origin-Opener-Policy",
+                  "value": "same-origin"
+                },
+                {
+                  "key": "Referrer-Policy",
+                  "value": "strict-origin-when-cross-origin"
+                },
+                {
+                  "key": "X-Content-Type-Options",
+                  "value": "nosniff"
+                },
+                {
+                  "key": "X-DNS-Prefetch-Control",
+                  "value": "off"
+                },
+                {
+                  "key": "X-Frame-Options",
+                  "value": "DENY"
+                },
+                {
+                  "key": "X-XSS-Protection",
+                  "value": "0"
+                },
+                {
+                  "key": "Content-Security-Policy",
+                  "value": "default-src 'self'; font-src 'self'; connect-src 'self'; media-src 'self'; object-src 'none'; manifest-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:"
+                },
+                {
+                  "key": "X-Request-Id",
+                  "value": "28d3bff2-89a6-417a-a83a-9f18e47a35c4"
+                },
+                {
+                  "key": "RateLimit-Policy",
+                  "value": "1000;w=900"
+                },
+                {
+                  "key": "RateLimit-Limit",
+                  "value": "1000"
+                },
+                {
+                  "key": "RateLimit-Remaining",
+                  "value": "994"
+                },
+                {
+                  "key": "RateLimit-Reset",
+                  "value": "652"
+                },
+                {
+                  "key": "Origin-Agent-Cluster",
+                  "value": "?1"
+                },
+                {
+                  "key": "X-Download-Options",
+                  "value": "noopen"
+                },
+                {
+                  "key": "X-Permitted-Cross-Domain-Policies",
+                  "value": "none"
+                },
+                {
+                  "key": "Permissions-Policy",
+                  "value": "geolocation=(), camera=(), microphone=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()"
+                },
+                {
+                  "key": "Date",
+                  "value": "Thu, 22 Jan 2026 16:56:41 GMT"
+                },
+                {
+                  "key": "Content-Length",
+                  "value": "321"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n    \"companies\": [\n        {\n            \"id\": \"019be609-066b-779c-8ae8-c6211d3ebb44\",\n            \"name\": \"SMELA\",\n            \"website\": \"https://smela.com\",\n            \"description\": \"SMELA - Smart Management and Enterprise Learning Application\",\n            \"createdAt\": \"2026-01-22T14:08:29.803Z\",\n            \"updatedAt\": \"2026-01-22T14:08:29.803Z\"\n        }\n    ],\n    \"pagination\": {\n        \"page\": 1,\n        \"limit\": 25,\n        \"total\": 1,\n        \"totalPages\": 1\n    }\n}"
+            }
+          ]
+        },
+        {
+          "name": "companies",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"name\": \"Test Inc.\",\n    \"website\": \"https://test.inc.com\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{admin_api_url}}/companies",
+              "host": [
+                "{{admin_api_url}}"
+              ],
+              "path": [
+                "companies"
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "201",
+              "originalRequest": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"name\": \"Test Inc.\",\n    \"website\": \"https://test.inc.com\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{admin_api_url}}/companies",
+                  "host": [
+                    "{{admin_api_url}}"
+                  ],
+                  "path": [
+                    "companies"
+                  ]
+                }
+              },
+              "status": "Created",
+              "code": 201,
+              "_postman_previewlanguage": "",
+              "header": [
+                {
+                  "key": "Access-Control-Allow-Origin",
+                  "value": "*"
+                },
+                {
+                  "key": "Access-Control-Allow-Credentials",
+                  "value": "true"
+                },
+                {
+                  "key": "Access-Control-Expose-Headers",
+                  "value": "Content-Length,X-Request-Id"
+                },
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                },
+                {
+                  "key": "Vary",
+                  "value": "Origin"
+                },
+                {
+                  "key": "Cross-Origin-Resource-Policy",
+                  "value": "same-origin"
+                },
+                {
+                  "key": "Cross-Origin-Opener-Policy",
+                  "value": "same-origin"
+                },
+                {
+                  "key": "Referrer-Policy",
+                  "value": "strict-origin-when-cross-origin"
+                },
+                {
+                  "key": "X-Content-Type-Options",
+                  "value": "nosniff"
+                },
+                {
+                  "key": "X-DNS-Prefetch-Control",
+                  "value": "off"
+                },
+                {
+                  "key": "X-Frame-Options",
+                  "value": "DENY"
+                },
+                {
+                  "key": "X-XSS-Protection",
+                  "value": "0"
+                },
+                {
+                  "key": "Content-Security-Policy",
+                  "value": "default-src 'self'; font-src 'self'; connect-src 'self'; media-src 'self'; object-src 'none'; manifest-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:"
+                },
+                {
+                  "key": "X-Request-Id",
+                  "value": "98307196-2df5-485b-b7ad-f87ab9fcf8ee"
+                },
+                {
+                  "key": "RateLimit-Policy",
+                  "value": "1000;w=900"
+                },
+                {
+                  "key": "RateLimit-Limit",
+                  "value": "1000"
+                },
+                {
+                  "key": "RateLimit-Remaining",
+                  "value": "989"
+                },
+                {
+                  "key": "RateLimit-Reset",
+                  "value": "576"
+                },
+                {
+                  "key": "Origin-Agent-Cluster",
+                  "value": "?1"
+                },
+                {
+                  "key": "X-Download-Options",
+                  "value": "noopen"
+                },
+                {
+                  "key": "X-Permitted-Cross-Domain-Policies",
+                  "value": "none"
+                },
+                {
+                  "key": "Permissions-Policy",
+                  "value": "geolocation=(), camera=(), microphone=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()"
+                },
+                {
+                  "key": "Date",
+                  "value": "Thu, 22 Jan 2026 16:57:56 GMT"
+                },
+                {
+                  "key": "Content-Length",
+                  "value": "206"
+                }
+              ],
+              "cookie": [
+                {
+                  "expires": "Invalid Date",
+                  "domain": "",
+                  "path": ""
+                }
+              ],
+              "body": "{\n    \"company\": {\n        \"id\": \"019be6a4-28a7-7eff-99fb-e8bb191d4bd0\",\n        \"name\": \"Test Inc.\",\n        \"website\": \"https://test.inc.com\",\n        \"description\": null,\n        \"createdAt\": \"2026-01-22T16:57:56.647Z\",\n        \"updatedAt\": \"2026-01-22T16:57:56.647Z\"\n    }\n}"
+            }
+          ]
+        },
+        {
+          "name": "companies/:id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{admin_api_url}}/companies/019be609-066b-779c-8ae8-c6211d3ebb44",
+              "host": [
+                "{{admin_api_url}}"
+              ],
+              "path": [
+                "companies",
+                "019be609-066b-779c-8ae8-c6211d3ebb44"
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "200",
+              "originalRequest": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{admin_api_url}}/companies/019be609-066b-779c-8ae8-c6211d3ebb44",
+                  "host": [
+                    "{{admin_api_url}}"
+                  ],
+                  "path": [
+                    "companies",
+                    "019be609-066b-779c-8ae8-c6211d3ebb44"
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": null,
+              "header": [
+                {
+                  "key": "Access-Control-Allow-Origin",
+                  "value": "*"
+                },
+                {
+                  "key": "Access-Control-Allow-Credentials",
+                  "value": "true"
+                },
+                {
+                  "key": "Access-Control-Expose-Headers",
+                  "value": "Content-Length,X-Request-Id"
+                },
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                },
+                {
+                  "key": "Vary",
+                  "value": "Origin"
+                },
+                {
+                  "key": "Cross-Origin-Resource-Policy",
+                  "value": "same-origin"
+                },
+                {
+                  "key": "Cross-Origin-Opener-Policy",
+                  "value": "same-origin"
+                },
+                {
+                  "key": "Referrer-Policy",
+                  "value": "strict-origin-when-cross-origin"
+                },
+                {
+                  "key": "X-Content-Type-Options",
+                  "value": "nosniff"
+                },
+                {
+                  "key": "X-DNS-Prefetch-Control",
+                  "value": "off"
+                },
+                {
+                  "key": "X-Frame-Options",
+                  "value": "DENY"
+                },
+                {
+                  "key": "X-XSS-Protection",
+                  "value": "0"
+                },
+                {
+                  "key": "Content-Security-Policy",
+                  "value": "default-src 'self'; font-src 'self'; connect-src 'self'; media-src 'self'; object-src 'none'; manifest-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:"
+                },
+                {
+                  "key": "X-Request-Id",
+                  "value": "ff46f41a-0f83-4f93-b707-c1d5a2133211"
+                },
+                {
+                  "key": "RateLimit-Policy",
+                  "value": "1000;w=900"
+                },
+                {
+                  "key": "RateLimit-Limit",
+                  "value": "1000"
+                },
+                {
+                  "key": "RateLimit-Remaining",
+                  "value": "986"
+                },
+                {
+                  "key": "RateLimit-Reset",
+                  "value": "396"
+                },
+                {
+                  "key": "Origin-Agent-Cluster",
+                  "value": "?1"
+                },
+                {
+                  "key": "X-Download-Options",
+                  "value": "noopen"
+                },
+                {
+                  "key": "X-Permitted-Cross-Domain-Policies",
+                  "value": "none"
+                },
+                {
+                  "key": "Permissions-Policy",
+                  "value": "geolocation=(), camera=(), microphone=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()"
+                },
+                {
+                  "key": "Date",
+                  "value": "Thu, 22 Jan 2026 17:00:57 GMT"
+                },
+                {
+                  "key": "Content-Length",
+                  "value": "687"
+                }
+              ],
+              "cookie": [],
+              "body": "{\n    \"company\": {\n        \"id\": \"019be609-066b-779c-8ae8-c6211d3ebb44\",\n        \"name\": \"SMELA\",\n        \"website\": \"https://smela.com\",\n        \"description\": \"SMELA - Smart Management and Enterprise Learning Application\",\n        \"createdAt\": \"2026-01-22T14:08:29.803Z\",\n        \"updatedAt\": \"2026-01-22T14:08:29.803Z\",\n        \"members\": [\n            {\n                \"id\": \"019be609-06d6-76a8-9e48-d6f758b76bb4\",\n                \"firstName\": \"Slava\",\n                \"lastName\": \"Owner\",\n                \"email\": \"slava.owner@smela.com\",\n                \"status\": \"active\",\n                \"position\": \"Owner\",\n                \"invitedBy\": null,\n                \"joinedAt\": \"2026-01-22T14:08:29.917Z\"\n            },\n            {\n                \"id\": \"019be609-0747-7d69-99ae-bc9903cb865a\",\n                \"firstName\": \"Slava\",\n                \"lastName\": \"Admin\",\n                \"email\": \"slava.admin@smela.com\",\n                \"status\": \"active\",\n                \"position\": \"Admin\",\n                \"invitedBy\": null,\n                \"joinedAt\": \"2026-01-22T14:08:30.027Z\"\n            }\n        ]\n    }\n}"
+            }
+          ]
+        },
+        {
+          "name": "companies/:id",
+          "request": {
+            "method": "PATCH",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"description\": \"This is the test\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{admin_api_url}}/companies/019be6a4-28a7-7eff-99fb-e8bb191d4bd0",
+              "host": [
+                "{{admin_api_url}}"
+              ],
+              "path": [
+                "companies",
+                "019be6a4-28a7-7eff-99fb-e8bb191d4bd0"
+              ]
+            }
+          },
+          "response": [
+            {
+              "name": "200",
+              "originalRequest": {
+                "method": "PATCH",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"description\": \"This is the test\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{admin_api_url}}/companies/019be6a4-28a7-7eff-99fb-e8bb191d4bd0",
+                  "host": [
+                    "{{admin_api_url}}"
+                  ],
+                  "path": [
+                    "companies",
+                    "019be6a4-28a7-7eff-99fb-e8bb191d4bd0"
+                  ]
+                }
+              },
+              "status": "OK",
+              "code": 200,
+              "_postman_previewlanguage": "",
+              "header": [
+                {
+                  "key": "Access-Control-Allow-Origin",
+                  "value": "*"
+                },
+                {
+                  "key": "Access-Control-Allow-Credentials",
+                  "value": "true"
+                },
+                {
+                  "key": "Access-Control-Expose-Headers",
+                  "value": "Content-Length,X-Request-Id"
+                },
+                {
+                  "key": "Content-Type",
+                  "value": "application/json"
+                },
+                {
+                  "key": "Vary",
+                  "value": "Origin"
+                },
+                {
+                  "key": "Cross-Origin-Resource-Policy",
+                  "value": "same-origin"
+                },
+                {
+                  "key": "Cross-Origin-Opener-Policy",
+                  "value": "same-origin"
+                },
+                {
+                  "key": "Referrer-Policy",
+                  "value": "strict-origin-when-cross-origin"
+                },
+                {
+                  "key": "X-Content-Type-Options",
+                  "value": "nosniff"
+                },
+                {
+                  "key": "X-DNS-Prefetch-Control",
+                  "value": "off"
+                },
+                {
+                  "key": "X-Frame-Options",
+                  "value": "DENY"
+                },
+                {
+                  "key": "X-XSS-Protection",
+                  "value": "0"
+                },
+                {
+                  "key": "Content-Security-Policy",
+                  "value": "default-src 'self'; font-src 'self'; connect-src 'self'; media-src 'self'; object-src 'none'; manifest-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:"
+                },
+                {
+                  "key": "X-Request-Id",
+                  "value": "70e42aa2-3fd2-4e73-8bea-3a4b4a9b0cad"
+                },
+                {
+                  "key": "RateLimit-Policy",
+                  "value": "1000;w=900"
+                },
+                {
+                  "key": "RateLimit-Limit",
+                  "value": "1000"
+                },
+                {
+                  "key": "RateLimit-Remaining",
+                  "value": "987"
+                },
+                {
+                  "key": "RateLimit-Reset",
+                  "value": "509"
+                },
+                {
+                  "key": "Origin-Agent-Cluster",
+                  "value": "?1"
+                },
+                {
+                  "key": "X-Download-Options",
+                  "value": "noopen"
+                },
+                {
+                  "key": "X-Permitted-Cross-Domain-Policies",
+                  "value": "none"
+                },
+                {
+                  "key": "Permissions-Policy",
+                  "value": "geolocation=(), camera=(), microphone=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()"
+                },
+                {
+                  "key": "Date",
+                  "value": "Thu, 22 Jan 2026 16:59:04 GMT"
+                },
+                {
+                  "key": "Content-Length",
+                  "value": "220"
+                }
+              ],
+              "cookie": [
+                {
+                  "expires": "Invalid Date",
+                  "domain": "",
+                  "path": ""
+                }
+              ],
+              "body": "{\n    \"company\": {\n        \"id\": \"019be6a4-28a7-7eff-99fb-e8bb191d4bd0\",\n        \"name\": \"Test Inc.\",\n        \"website\": \"https://test.inc.com\",\n        \"description\": \"This is the test\",\n        \"createdAt\": \"2026-01-22T16:57:56.647Z\",\n        \"updatedAt\": \"2026-01-22T16:57:56.647Z\"\n    }\n}"
+            }
+          ]
+        },
+        {
+          "name": "companies/:id",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{admin_api_url}}/companies/019be6a3-38c2-7127-a5df-7fb9a511c40c",
+              "host": [
+                "{{admin_api_url}}"
+              ],
+              "path": [
+                "companies",
+                "019be6a3-38c2-7127-a5df-7fb9a511c40c"
+              ]
+            }
+          },
+          "response": []
         }
       ]
     },

--- a/src/__tests__/uuid.ts
+++ b/src/__tests__/uuid.ts
@@ -62,6 +62,10 @@ export const testUuids = {
   TOKEN_1: '00000000-0000-4000-b0f0-000000000001',
   TOKEN_2: '00000000-0000-4000-b0f0-000000000002',
 
+  // Companies (c0c0 = company type)
+  COMPANY_1: '00000000-0000-4000-c0c0-000000000001',
+  COMPANY_2: '00000000-0000-4000-c0c0-000000000002',
+
   // Non-existent (ffff = none type)
   NON_EXISTENT: '00000000-0000-4000-bfff-000000000000',
 } as const

--- a/src/data/migrations/0000_perpetual_marten_broadcloak.sql
+++ b/src/data/migrations/0000_perpetual_marten_broadcloak.sql
@@ -15,6 +15,26 @@ CREATE TABLE "auth" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+CREATE TABLE "companies" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"website" varchar(255),
+	"description" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "companies_name_unique" UNIQUE("name"),
+	CONSTRAINT "companies_website_unique" UNIQUE("website")
+);
+--> statement-breakpoint
+CREATE TABLE "user_companies" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL,
+	"company_id" uuid NOT NULL,
+	"position" varchar(100),
+	"invited_by" uuid,
+	"joined_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
 CREATE TABLE "permissions" (
 	"id" serial PRIMARY KEY NOT NULL,
 	"action" "action" NOT NULL,
@@ -68,11 +88,17 @@ CREATE TABLE "users" (
 );
 --> statement-breakpoint
 ALTER TABLE "auth" ADD CONSTRAINT "auth_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_companies" ADD CONSTRAINT "user_companies_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_companies" ADD CONSTRAINT "user_companies_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_companies" ADD CONSTRAINT "user_companies_invited_by_users_id_fk" FOREIGN KEY ("invited_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "role_permissions" ADD CONSTRAINT "role_permissions_permission_id_permissions_id_fk" FOREIGN KEY ("permission_id") REFERENCES "public"."permissions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "tokens" ADD CONSTRAINT "tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "unique_auth" ON "auth" USING btree ("provider","identifier");--> statement-breakpoint
 CREATE INDEX "auth_user_id_index" ON "auth" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_user_company" ON "user_companies" USING btree ("user_id","company_id");--> statement-breakpoint
+CREATE INDEX "user_companies_company_index" ON "user_companies" USING btree ("company_id");--> statement-breakpoint
+CREATE INDEX "user_companies_user_index" ON "user_companies" USING btree ("user_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "unique_permission" ON "permissions" USING btree ("action","resource");--> statement-breakpoint
 CREATE UNIQUE INDEX "unique_role_permission" ON "role_permissions" USING btree ("role","permission_id");--> statement-breakpoint
 CREATE INDEX "refresh_tokens_user_active_index" ON "refresh_tokens" USING btree ("user_id","revoked_at","expires_at");--> statement-breakpoint

--- a/src/data/migrations/custom/0002_companies_search_index.sql
+++ b/src/data/migrations/custom/0002_companies_search_index.sql
@@ -1,0 +1,8 @@
+-- Migration: Add GIN trigram index for company search
+-- Enables fast ILIKE searches on name, website, and description fields
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_companies_search_trgm ON companies USING gin (
+  (name || ' ' || COALESCE(website, '') || ' ' || COALESCE(description, '')) gin_trgm_ops
+);

--- a/src/data/migrations/meta/0000_snapshot.json
+++ b/src/data/migrations/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "c2e480a4-08f3-4194-a2aa-9e4a0aeafbd3",
+  "id": "787464aa-0497-4873-870a-725565d7a4b1",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -104,6 +104,214 @@
             "id"
           ],
           "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.companies": {
+      "name": "companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "companies_name_unique": {
+          "name": "companies_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "companies_website_unique": {
+          "name": "companies_website_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "website"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_companies": {
+      "name": "user_companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_company": {
+          "name": "unique_user_company",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_companies_company_index": {
+          "name": "user_companies_company_index",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_companies_user_index": {
+          "name": "user_companies_user_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_companies_user_id_users_id_fk": {
+          "name": "user_companies_user_id_users_id_fk",
+          "tableFrom": "user_companies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_companies_company_id_companies_id_fk": {
+          "name": "user_companies_company_id_companies_id_fk",
+          "tableFrom": "user_companies",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_companies_invited_by_users_id_fk": {
+          "name": "user_companies_invited_by_users_id_fk",
+          "tableFrom": "user_companies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },

--- a/src/data/migrations/meta/_journal.json
+++ b/src/data/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1769011785774,
-      "tag": "0000_tired_justice",
+      "when": 1769089883399,
+      "tag": "0000_perpetual_marten_broadcloak",
       "breakpoints": true
     }
   ]

--- a/src/data/repositories/company/index.ts
+++ b/src/data/repositories/company/index.ts
@@ -6,12 +6,16 @@ import {
   updateCompany,
 } from './mutations'
 import {
+  findAllCompanies,
   findCompanyById,
   findCompanyByName,
   findCompanyMembers,
+  findCompanyWithMembers,
   findUserCompanies,
   findUserCompany,
 } from './queries'
+
+export type { CompanySearchParams, CompanySearchResult } from './queries'
 
 export * from './types'
 
@@ -19,9 +23,11 @@ export const companyRepo = {
   addUser: addUserToCompany,
   create: createCompany,
   delete: deleteCompany,
+  findAll: findAllCompanies,
   findById: findCompanyById,
   findByName: findCompanyByName,
   findMembers: findCompanyMembers,
+  findWithMembers: findCompanyWithMembers,
   findUserCompanies,
   findUserCompany,
   removeUser: removeUserFromCompany,

--- a/src/data/repositories/company/index.ts
+++ b/src/data/repositories/company/index.ts
@@ -6,13 +6,13 @@ import {
   updateCompany,
 } from './mutations'
 import {
-  findAllCompanies,
+  findCompany,
   findCompanyById,
   findCompanyByName,
   findCompanyMembers,
-  findCompanyWithMembers,
   findUserCompanies,
   findUserCompany,
+  searchCompanies,
 } from './queries'
 
 export type { CompanySearchParams, CompanySearchResult } from './queries'
@@ -23,13 +23,13 @@ export const companyRepo = {
   addUser: addUserToCompany,
   create: createCompany,
   delete: deleteCompany,
-  findAll: findAllCompanies,
+  find: findCompany,
   findById: findCompanyById,
   findByName: findCompanyByName,
   findMembers: findCompanyMembers,
-  findWithMembers: findCompanyWithMembers,
   findUserCompanies,
   findUserCompany,
   removeUser: removeUserFromCompany,
+  search: searchCompanies,
   update: updateCompany,
 }

--- a/src/data/repositories/company/index.ts
+++ b/src/data/repositories/company/index.ts
@@ -1,0 +1,29 @@
+import {
+  addUserToCompany,
+  createCompany,
+  deleteCompany,
+  removeUserFromCompany,
+  updateCompany,
+} from './mutations'
+import {
+  findCompanyById,
+  findCompanyByName,
+  findCompanyMembers,
+  findUserCompanies,
+  findUserCompany,
+} from './queries'
+
+export * from './types'
+
+export const companyRepo = {
+  addUser: addUserToCompany,
+  create: createCompany,
+  delete: deleteCompany,
+  findById: findCompanyById,
+  findByName: findCompanyByName,
+  findMembers: findCompanyMembers,
+  findUserCompanies,
+  findUserCompany,
+  removeUser: removeUserFromCompany,
+  update: updateCompany,
+}

--- a/src/data/repositories/company/mutations.ts
+++ b/src/data/repositories/company/mutations.ts
@@ -41,7 +41,7 @@ export const updateCompany = async (
 
   const [company] = await executor
     .update(companiesTable)
-    .set(updates)
+    .set({ ...updates, updatedAt: new Date() })
     .where(eq(companiesTable.id, companyId))
     .returning()
 

--- a/src/data/repositories/company/mutations.ts
+++ b/src/data/repositories/company/mutations.ts
@@ -1,0 +1,99 @@
+import { and, eq } from 'drizzle-orm'
+
+import { AppError, ErrorCode } from '@/errors'
+
+import type { Database } from '../../clients'
+import type {
+  Company,
+  CreateCompanyInput,
+  CreateUserCompanyInput,
+  UpdateCompanyInput,
+  UserCompany,
+} from './types'
+
+import { db } from '../../clients'
+import { companiesTable, userCompaniesTable } from '../../schema'
+
+export const createCompany = async (
+  input: CreateCompanyInput,
+  tx?: Database,
+): Promise<Company> => {
+  const executor = tx || db
+
+  const [company] = await executor
+    .insert(companiesTable)
+    .values(input)
+    .returning()
+
+  if (!company) {
+    throw new AppError(ErrorCode.InternalError, 'Failed to create company')
+  }
+
+  return company
+}
+
+export const updateCompany = async (
+  companyId: string,
+  updates: UpdateCompanyInput,
+  tx?: Database,
+): Promise<Company> => {
+  const executor = tx || db
+
+  const [company] = await executor
+    .update(companiesTable)
+    .set(updates)
+    .where(eq(companiesTable.id, companyId))
+    .returning()
+
+  if (!company) {
+    throw new AppError(ErrorCode.InternalError, 'Failed to update company')
+  }
+
+  return company
+}
+
+export const deleteCompany = async (
+  companyId: string,
+  tx?: Database,
+): Promise<void> => {
+  const executor = tx || db
+
+  await executor
+    .delete(companiesTable)
+    .where(eq(companiesTable.id, companyId))
+}
+
+export const addUserToCompany = async (
+  input: CreateUserCompanyInput,
+  tx?: Database,
+): Promise<UserCompany> => {
+  const executor = tx || db
+
+  const [membership] = await executor
+    .insert(userCompaniesTable)
+    .values(input)
+    .returning()
+
+  if (!membership) {
+    throw new AppError(ErrorCode.InternalError, 'Failed to add user to company')
+  }
+
+  return membership
+}
+
+export const removeUserFromCompany = async (
+  userId: string,
+  companyId: string,
+  tx?: Database,
+): Promise<void> => {
+  const executor = tx || db
+
+  await executor
+    .delete(userCompaniesTable)
+    .where(
+      and(
+        eq(userCompaniesTable.userId, userId),
+        eq(userCompaniesTable.companyId, companyId),
+      ),
+    )
+}

--- a/src/data/repositories/company/queries.ts
+++ b/src/data/repositories/company/queries.ts
@@ -1,0 +1,122 @@
+import { and, eq } from 'drizzle-orm'
+
+import type { Database } from '../../clients'
+import type { Company, CompanyMember, UserCompany, UserCompanyWithCompany } from './types'
+
+import { db } from '../../clients'
+import { companiesTable, userCompaniesTable, usersTable } from '../../schema'
+
+export const findCompanyById = async (
+  companyId: string,
+  tx?: Database,
+): Promise<Company | undefined> => {
+  const executor = tx || db
+
+  const [company] = await executor
+    .select()
+    .from(companiesTable)
+    .where(eq(companiesTable.id, companyId))
+
+  return company
+}
+
+export const findCompanyByName = async (
+  name: string,
+  tx?: Database,
+): Promise<Company | undefined> => {
+  const executor = tx || db
+
+  const [company] = await executor
+    .select()
+    .from(companiesTable)
+    .where(eq(companiesTable.name, name))
+
+  return company
+}
+
+export const findUserCompany = async (
+  userId: string,
+  companyId: string,
+  tx?: Database,
+): Promise<UserCompany | undefined> => {
+  const executor = tx || db
+
+  const [membership] = await executor
+    .select()
+    .from(userCompaniesTable)
+    .where(
+      and(
+        eq(userCompaniesTable.userId, userId),
+        eq(userCompaniesTable.companyId, companyId),
+      ),
+    )
+
+  return membership
+}
+
+export const findUserCompanies = async (
+  userId: string,
+  tx?: Database,
+): Promise<UserCompanyWithCompany[]> => {
+  const executor = tx || db
+
+  const results = await executor
+    .select({
+      id: userCompaniesTable.id,
+      userId: userCompaniesTable.userId,
+      companyId: userCompaniesTable.companyId,
+      position: userCompaniesTable.position,
+      invitedBy: userCompaniesTable.invitedBy,
+      joinedAt: userCompaniesTable.joinedAt,
+      company: companiesTable,
+    })
+    .from(userCompaniesTable)
+    .innerJoin(companiesTable, eq(userCompaniesTable.companyId, companiesTable.id))
+    .where(eq(userCompaniesTable.userId, userId))
+
+  return results.map(row => ({
+    id: row.id,
+    userId: row.userId,
+    companyId: row.companyId,
+    position: row.position,
+    invitedBy: row.invitedBy,
+    joinedAt: row.joinedAt,
+    company: row.company,
+  }))
+}
+
+export const findCompanyMembers = async (
+  companyId: string,
+  tx?: Database,
+): Promise<CompanyMember[]> => {
+  const executor = tx || db
+
+  const results = await executor
+    .select({
+      id: userCompaniesTable.id,
+      userId: userCompaniesTable.userId,
+      companyId: userCompaniesTable.companyId,
+      position: userCompaniesTable.position,
+      invitedBy: userCompaniesTable.invitedBy,
+      joinedAt: userCompaniesTable.joinedAt,
+      user: {
+        id: usersTable.id,
+        firstName: usersTable.firstName,
+        lastName: usersTable.lastName,
+        email: usersTable.email,
+      },
+    })
+    .from(userCompaniesTable)
+    .innerJoin(usersTable, eq(userCompaniesTable.userId, usersTable.id))
+    .where(eq(userCompaniesTable.companyId, companyId))
+
+  return results.map(row => ({
+    id: row.id,
+    userId: row.userId,
+    companyId: row.companyId,
+    position: row.position,
+    invitedBy: row.invitedBy,
+    joinedAt: row.joinedAt,
+    user: row.user,
+  }))
+}

--- a/src/data/repositories/company/types.ts
+++ b/src/data/repositories/company/types.ts
@@ -1,0 +1,25 @@
+import type { companiesTable, userCompaniesTable } from '../../schema'
+
+export type CompanyRecord = typeof companiesTable.$inferSelect
+export type UserCompanyRecord = typeof userCompaniesTable.$inferSelect
+
+export type CreateCompanyInput = typeof companiesTable.$inferInsert
+export type UpdateCompanyInput = Partial<Omit<CreateCompanyInput, 'id' | 'createdAt'>>
+
+export type CreateUserCompanyInput = typeof userCompaniesTable.$inferInsert
+
+export type Company = CompanyRecord
+export type UserCompany = UserCompanyRecord
+
+export type CompanyMember = UserCompany & {
+  user: {
+    id: string
+    firstName: string
+    lastName: string | null
+    email: string
+  }
+}
+
+export type UserCompanyWithCompany = UserCompany & {
+  company: Company
+}

--- a/src/data/repositories/company/types.ts
+++ b/src/data/repositories/company/types.ts
@@ -11,13 +11,19 @@ export type CreateUserCompanyInput = typeof userCompaniesTable.$inferInsert
 export type Company = CompanyRecord
 export type UserCompany = UserCompanyRecord
 
-export type CompanyMember = UserCompany & {
-  user: {
-    id: string
-    firstName: string
-    lastName: string | null
-    email: string
-  }
+export interface CompanyMember {
+  id: string
+  firstName: string
+  lastName: string | null
+  email: string
+  status: string
+  position: string | null
+  invitedBy: string | null
+  joinedAt: Date | null
+}
+
+export type CompanyWithMembers = Company & {
+  members: CompanyMember[]
 }
 
 export type UserCompanyWithCompany = UserCompany & {

--- a/src/data/repositories/index.ts
+++ b/src/data/repositories/index.ts
@@ -1,4 +1,5 @@
 export * from './auth'
+export * from './company'
 export * from './pagination'
 export * from './refresh-token'
 export * from './token'

--- a/src/data/schema/companies.ts
+++ b/src/data/schema/companies.ts
@@ -1,0 +1,35 @@
+import { sql } from 'drizzle-orm'
+import {
+  index,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core'
+
+import { usersTable } from './users'
+
+export const companiesTable = pgTable('companies', {
+  id: uuid('id').primaryKey().$defaultFn(() => sql`uuidv7()`),
+  name: varchar('name', { length: 255 }).notNull().unique(),
+  website: varchar('website', { length: 255 }).unique(),
+  description: text('description'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+})
+
+export const userCompaniesTable = pgTable('user_companies', {
+  id: serial('id').primaryKey(),
+  userId: uuid('user_id').notNull().references(() => usersTable.id, { onDelete: 'cascade' }),
+  companyId: uuid('company_id').notNull().references(() => companiesTable.id, { onDelete: 'cascade' }),
+  position: varchar('position', { length: 100 }),
+  invitedBy: uuid('invited_by').references(() => usersTable.id, { onDelete: 'set null' }),
+  joinedAt: timestamp('joined_at', { withTimezone: true }).notNull().defaultNow(),
+}, table => [
+  uniqueIndex('unique_user_company').on(table.userId, table.companyId),
+  index('user_companies_company_index').on(table.companyId),
+  index('user_companies_user_index').on(table.userId),
+])

--- a/src/data/schema/index.ts
+++ b/src/data/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './auth'
+export * from './companies'
 export * from './rbac'
 export * from './refresh-tokens'
 export * from './tokens'

--- a/src/errors/codes.ts
+++ b/src/errors/codes.ts
@@ -22,6 +22,7 @@ enum ErrorCode {
   CaptchaInvalidToken = 'captcha/invalid-token',
   CaptchaValidationFailed = 'captcha/validation-failed',
 
+  Conflict = 'resource/conflict',
   InternalError = 'system/internal-error',
   NotFound = 'resource/not-found',
   ValidationError = 'validation/error',

--- a/src/errors/registry.ts
+++ b/src/errors/registry.ts
@@ -61,12 +61,17 @@ const ErrorRegistry: Record<ErrorCode, ErrorDetails> = {
     error: 'reCAPTCHA token validation failed.',
   },
 
-  // System errors
-  [ErrorCode.InternalError]: {
-    error: 'Internal server error.',
+  // Resource errors
+  [ErrorCode.Conflict]: {
+    error: 'Resource already exists.',
   },
   [ErrorCode.NotFound]: {
     error: 'Resource not found.',
+  },
+
+  // System errors
+  [ErrorCode.InternalError]: {
+    error: 'Internal server error.',
   },
   [ErrorCode.ValidationError]: {
     error: 'Validation error.',

--- a/src/handlers/http-status-mapper.ts
+++ b/src/handlers/http-status-mapper.ts
@@ -26,9 +26,12 @@ const httpStatusMap: Record<ErrorCode, HttpStatus> = {
   [ErrorCode.CaptchaInvalidToken]: HttpStatus.BAD_REQUEST,
   [ErrorCode.CaptchaValidationFailed]: HttpStatus.BAD_REQUEST,
 
+  // Resource errors
+  [ErrorCode.Conflict]: HttpStatus.CONFLICT,
+  [ErrorCode.NotFound]: HttpStatus.NOT_FOUND,
+
   // System errors
   [ErrorCode.InternalError]: HttpStatus.INTERNAL_SERVER_ERROR,
-  [ErrorCode.NotFound]: HttpStatus.NOT_FOUND,
   [ErrorCode.ValidationError]: HttpStatus.BAD_REQUEST,
 
   // Request errors

--- a/src/routes/@shared/company-rules.ts
+++ b/src/routes/@shared/company-rules.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const companyRules = {
+  name: z.string().trim().min(1).max(255),
+  website: z.string().trim().url().max(255),
+  description: z.string().trim().max(2000),
+  search: z.string().trim().max(100),
+}

--- a/src/routes/@shared/handler.ts
+++ b/src/routes/@shared/handler.ts
@@ -79,3 +79,19 @@ interface ParamInput<Param> {
  * }
  */
 export type ValidatedParamCtx<Param> = Context<AppContext, string, ParamInput<Param>>
+
+interface ParamJsonInput<Param, Body> {
+  in: { param: Param, json: Body }
+  out: { param: Param, json: Body }
+}
+
+/**
+ * Context for routes with both path parameter and JSON body validation (PUT, PATCH).
+ * @example
+ * const updateHandler = async (c: ValidatedParamJsonCtx<{ id: string }, UpdateBody>) => {
+ *   const { id } = c.req.valid('param') // typed as { id: string }
+ *   const body = c.req.valid('json') // typed as UpdateBody
+ * }
+ */
+export type ValidatedParamJsonCtx<Param, Body>
+  = Context<AppContext, string, ParamJsonInput<Param, Body>>

--- a/src/routes/@shared/index.ts
+++ b/src/routes/@shared/index.ts
@@ -1,16 +1,18 @@
 import { z } from 'zod'
 
 import { captchaRules } from './captcha-rules'
+import { companyRules } from './company-rules'
 import { dataRules } from './data-rules'
 import { paginationRules } from './pagination-rules'
 import { preferencesRules } from './preferences-rules'
 import { userFilterRules } from './user-filter-rules'
 
-export type { AppCtx, ValidatedJsonCtx, ValidatedParamCtx, ValidatedQueryCtx } from './handler'
+export type { AppCtx, ValidatedJsonCtx, ValidatedParamCtx, ValidatedParamJsonCtx, ValidatedQueryCtx } from './handler'
 
 export const requestValidationRules = {
-  data: dataRules,
   captcha: captchaRules,
+  company: companyRules,
+  data: dataRules,
   pagination: paginationRules,
   preferences: preferencesRules,
   userFilter: userFilterRules,

--- a/src/routes/admin/companies/__tests__/handler.test.ts
+++ b/src/routes/admin/companies/__tests__/handler.test.ts
@@ -1,0 +1,361 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { Company } from '@/data'
+
+import { ModuleMocker, testUuids } from '@/__tests__'
+import { HttpStatus } from '@/net/http'
+
+import {
+  createCompanyHandler,
+  deleteCompanyHandler,
+  getCompaniesHandler,
+  getCompanyHandler,
+  updateCompanyHandler,
+} from '../handler'
+
+const { COMPANY_1 } = testUuids
+
+describe('getCompaniesHandler', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  const DEFAULT_LIMIT = 25
+
+  let mockContext: any
+  let mockJson: any
+  let mockGetCompanies: any
+
+  const mockCompanies: Company[] = [
+    {
+      id: COMPANY_1,
+      name: 'Acme Corp',
+      website: 'https://acme.com',
+      description: 'A test company',
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+    },
+  ]
+
+  beforeEach(async () => {
+    mockJson = mock((data: any, status: number) => ({ data, status }))
+
+    mockContext = {
+      req: {
+        valid: mock(() => ({
+          search: undefined,
+          page: 1,
+          limit: DEFAULT_LIMIT,
+        })),
+      },
+      json: mockJson,
+    }
+
+    mockGetCompanies = mock(async () => ({
+      companies: mockCompanies,
+      pagination: {
+        page: 1,
+        limit: DEFAULT_LIMIT,
+        total: 1,
+        totalPages: 1,
+      },
+    }))
+
+    await moduleMocker.mock('@/use-cases/admin', () => ({
+      getCompanies: mockGetCompanies,
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should call getCompanies with correct parameters', async () => {
+    await getCompaniesHandler(mockContext)
+
+    expect(mockGetCompanies).toHaveBeenCalledWith(
+      { search: undefined },
+      { page: 1, limit: DEFAULT_LIMIT },
+    )
+  })
+
+  it('should return companies and pagination with OK status', async () => {
+    const result = await getCompaniesHandler(mockContext)
+
+    expect(mockJson).toHaveBeenCalledWith(
+      {
+        companies: mockCompanies,
+        pagination: {
+          page: 1,
+          limit: DEFAULT_LIMIT,
+          total: 1,
+          totalPages: 1,
+        },
+      },
+      HttpStatus.OK,
+    )
+    expect(result.status).toBe(HttpStatus.OK)
+  })
+
+  it('should pass search filter when provided', async () => {
+    mockContext.req.valid = mock(() => ({
+      search: 'acme',
+      page: 1,
+      limit: DEFAULT_LIMIT,
+    }))
+
+    await getCompaniesHandler(mockContext)
+
+    expect(mockGetCompanies).toHaveBeenCalledWith(
+      { search: 'acme' },
+      { page: 1, limit: DEFAULT_LIMIT },
+    )
+  })
+
+  it('should propagate error when getCompanies throws', async () => {
+    mockGetCompanies.mockImplementation(async () => {
+      throw new Error('Database connection failed')
+    })
+
+    expect(getCompaniesHandler(mockContext)).rejects.toThrow('Database connection failed')
+  })
+})
+
+describe('getCompanyHandler', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockContext: any
+  let mockJson: any
+  let mockGetCompany: any
+
+  const mockCompany: Company = {
+    id: COMPANY_1,
+    name: 'Acme Corp',
+    website: 'https://acme.com',
+    description: 'A test company',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  }
+
+  beforeEach(async () => {
+    mockJson = mock((data: any, status: number) => ({ data, status }))
+
+    mockContext = {
+      req: {
+        valid: mock(() => ({ id: COMPANY_1 })),
+      },
+      json: mockJson,
+    }
+
+    mockGetCompany = mock(async () => ({ company: mockCompany }))
+
+    await moduleMocker.mock('@/use-cases/admin', () => ({
+      getCompany: mockGetCompany,
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should call getCompany with correct id', async () => {
+    await getCompanyHandler(mockContext)
+
+    expect(mockGetCompany).toHaveBeenCalledWith(COMPANY_1)
+  })
+
+  it('should return company with OK status', async () => {
+    const result = await getCompanyHandler(mockContext)
+
+    expect(mockJson).toHaveBeenCalledWith({ company: mockCompany }, HttpStatus.OK)
+    expect(result.status).toBe(HttpStatus.OK)
+  })
+
+  it('should propagate error when getCompany throws', async () => {
+    mockGetCompany.mockImplementation(async () => {
+      throw new Error('Company not found')
+    })
+
+    expect(getCompanyHandler(mockContext)).rejects.toThrow('Company not found')
+  })
+})
+
+describe('createCompanyHandler', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockContext: any
+  let mockJson: any
+  let mockCreateCompany: any
+
+  const mockCompany: Company = {
+    id: COMPANY_1,
+    name: 'New Company',
+    website: 'https://newcompany.com',
+    description: 'A new company',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  }
+
+  beforeEach(async () => {
+    mockJson = mock((data: any, status: number) => ({ data, status }))
+
+    mockContext = {
+      req: {
+        valid: mock(() => ({
+          name: 'New Company',
+          website: 'https://newcompany.com',
+          description: 'A new company',
+        })),
+      },
+      json: mockJson,
+    }
+
+    mockCreateCompany = mock(async () => ({ company: mockCompany }))
+
+    await moduleMocker.mock('@/use-cases/admin', () => ({
+      createCompany: mockCreateCompany,
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should call createCompany with correct body', async () => {
+    await createCompanyHandler(mockContext)
+
+    expect(mockCreateCompany).toHaveBeenCalledWith({
+      name: 'New Company',
+      website: 'https://newcompany.com',
+      description: 'A new company',
+    })
+  })
+
+  it('should return created company with CREATED status', async () => {
+    const result = await createCompanyHandler(mockContext)
+
+    expect(mockJson).toHaveBeenCalledWith({ company: mockCompany }, HttpStatus.CREATED)
+    expect(result.status).toBe(HttpStatus.CREATED)
+  })
+
+  it('should propagate error when createCompany throws', async () => {
+    mockCreateCompany.mockImplementation(async () => {
+      throw new Error('Company with this name already exists')
+    })
+
+    expect(createCompanyHandler(mockContext)).rejects.toThrow('Company with this name already exists')
+  })
+})
+
+describe('updateCompanyHandler', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockContext: any
+  let mockJson: any
+  let mockUpdateCompany: any
+
+  const mockCompany: Company = {
+    id: COMPANY_1,
+    name: 'Updated Company',
+    website: 'https://updated.com',
+    description: 'An updated company',
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-02'),
+  }
+
+  beforeEach(async () => {
+    mockJson = mock((data: any, status: number) => ({ data, status }))
+
+    mockContext = {
+      req: {
+        valid: mock((type: string) => {
+          if (type === 'param') {
+            return { id: COMPANY_1 }
+          }
+
+          return { name: 'Updated Company' }
+        }),
+      },
+      json: mockJson,
+    }
+
+    mockUpdateCompany = mock(async () => ({ company: mockCompany }))
+
+    await moduleMocker.mock('@/use-cases/admin', () => ({
+      updateCompany: mockUpdateCompany,
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should call updateCompany with correct id and body', async () => {
+    await updateCompanyHandler(mockContext)
+
+    expect(mockUpdateCompany).toHaveBeenCalledWith(COMPANY_1, { name: 'Updated Company' })
+  })
+
+  it('should return updated company with OK status', async () => {
+    const result = await updateCompanyHandler(mockContext)
+
+    expect(mockJson).toHaveBeenCalledWith({ company: mockCompany }, HttpStatus.OK)
+    expect(result.status).toBe(HttpStatus.OK)
+  })
+
+  it('should propagate error when updateCompany throws', async () => {
+    mockUpdateCompany.mockImplementation(async () => {
+      throw new Error('Company not found')
+    })
+
+    expect(updateCompanyHandler(mockContext)).rejects.toThrow('Company not found')
+  })
+})
+
+describe('deleteCompanyHandler', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockContext: any
+  let mockBody: any
+  let mockDeleteCompany: any
+
+  beforeEach(async () => {
+    mockBody = mock((data: any, status: number) => ({ data, status }))
+
+    mockContext = {
+      req: {
+        valid: mock(() => ({ id: COMPANY_1 })),
+      },
+      body: mockBody,
+    }
+
+    mockDeleteCompany = mock(async () => undefined)
+
+    await moduleMocker.mock('@/use-cases/admin', () => ({
+      deleteCompany: mockDeleteCompany,
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should call deleteCompany with correct id', async () => {
+    await deleteCompanyHandler(mockContext)
+
+    expect(mockDeleteCompany).toHaveBeenCalledWith(COMPANY_1)
+  })
+
+  it('should return NO_CONTENT status', async () => {
+    const result = await deleteCompanyHandler(mockContext)
+
+    expect(mockBody).toHaveBeenCalledWith(null, HttpStatus.NO_CONTENT)
+    expect(result.status).toBe(HttpStatus.NO_CONTENT)
+  })
+
+  it('should propagate error when deleteCompany throws', async () => {
+    mockDeleteCompany.mockImplementation(async () => {
+      throw new Error('Company not found')
+    })
+
+    expect(deleteCompanyHandler(mockContext)).rejects.toThrow('Company not found')
+  })
+})

--- a/src/routes/admin/companies/handler.ts
+++ b/src/routes/admin/companies/handler.ts
@@ -1,0 +1,56 @@
+import { HttpStatus } from '@/net/http'
+import {
+  createCompany,
+  deleteCompany,
+  getCompany,
+  searchCompanies,
+  updateCompany,
+} from '@/use-cases/admin'
+
+import type {
+  CompanyParamsCtx,
+  CreateCompanyCtx,
+  GetCompaniesCtx,
+  UpdateCompanyCtx,
+} from './schema'
+
+export const getCompaniesHandler = async (c: GetCompaniesCtx) => {
+  const { search, page, limit } = c.req.valid('query')
+
+  const result = await searchCompanies({ search }, { page, limit })
+
+  return c.json(result, HttpStatus.OK)
+}
+
+export const getCompanyHandler = async (c: CompanyParamsCtx) => {
+  const { id } = c.req.valid('param')
+
+  const result = await getCompany(id)
+
+  return c.json(result.data, HttpStatus.OK)
+}
+
+export const createCompanyHandler = async (c: CreateCompanyCtx) => {
+  const body = c.req.valid('json')
+
+  const result = await createCompany(body)
+
+  return c.json(result.data, HttpStatus.CREATED)
+}
+
+export const updateCompanyHandler = async (c: UpdateCompanyCtx) => {
+  const { id } = c.req.valid('param')
+  const body = c.req.valid('json')
+
+  const result = await updateCompany(id, body)
+
+  return c.json(result.data, HttpStatus.OK)
+}
+
+export const deleteCompanyHandler = async (c: CompanyParamsCtx) => {
+  const { id } = c.req.valid('param')
+
+  await deleteCompany(id)
+
+  return c.body(null, HttpStatus.NO_CONTENT)
+}

--- a/src/routes/admin/companies/handler.ts
+++ b/src/routes/admin/companies/handler.ts
@@ -2,8 +2,8 @@ import { HttpStatus } from '@/net/http'
 import {
   createCompany,
   deleteCompany,
+  getCompanies,
   getCompany,
-  searchCompanies,
   updateCompany,
 } from '@/use-cases/admin'
 
@@ -17,7 +17,9 @@ import type {
 export const getCompaniesHandler = async (c: GetCompaniesCtx) => {
   const { search, page, limit } = c.req.valid('query')
 
-  const result = await searchCompanies({ search }, { page, limit })
+  const filters = { search }
+  const pagination = { page, limit }
+  const result = await getCompanies(filters, pagination)
 
   return c.json(result, HttpStatus.OK)
 }

--- a/src/routes/admin/companies/handler.ts
+++ b/src/routes/admin/companies/handler.ts
@@ -29,7 +29,7 @@ export const getCompanyHandler = async (c: CompanyParamsCtx) => {
 
   const result = await getCompany(id)
 
-  return c.json(result.data, HttpStatus.OK)
+  return c.json(result, HttpStatus.OK)
 }
 
 export const createCompanyHandler = async (c: CreateCompanyCtx) => {
@@ -37,7 +37,7 @@ export const createCompanyHandler = async (c: CreateCompanyCtx) => {
 
   const result = await createCompany(body)
 
-  return c.json(result.data, HttpStatus.CREATED)
+  return c.json(result, HttpStatus.CREATED)
 }
 
 export const updateCompanyHandler = async (c: UpdateCompanyCtx) => {
@@ -46,7 +46,7 @@ export const updateCompanyHandler = async (c: UpdateCompanyCtx) => {
 
   const result = await updateCompany(id, body)
 
-  return c.json(result.data, HttpStatus.OK)
+  return c.json(result, HttpStatus.OK)
 }
 
 export const deleteCompanyHandler = async (c: CompanyParamsCtx) => {

--- a/src/routes/admin/companies/index.ts
+++ b/src/routes/admin/companies/index.ts
@@ -1,0 +1,54 @@
+import { Hono } from 'hono'
+
+import type { AppContext } from '@/context'
+
+import { requestValidator } from '@/middleware'
+
+import {
+  createCompanyHandler,
+  deleteCompanyHandler,
+  getCompaniesHandler,
+  getCompanyHandler,
+  updateCompanyHandler,
+} from './handler'
+import {
+  companyParamsSchema,
+  createCompanyBodySchema,
+  getCompaniesQuerySchema,
+  updateCompanyBodySchema,
+} from './schema'
+
+const adminCompaniesRoute = new Hono<AppContext>()
+
+adminCompaniesRoute.get(
+  '/companies',
+  requestValidator('query', getCompaniesQuerySchema),
+  getCompaniesHandler,
+)
+
+adminCompaniesRoute.get(
+  '/companies/:id',
+  requestValidator('param', companyParamsSchema),
+  getCompanyHandler,
+)
+
+adminCompaniesRoute.post(
+  '/companies',
+  requestValidator('json', createCompanyBodySchema),
+  createCompanyHandler,
+)
+
+adminCompaniesRoute.patch(
+  '/companies/:id',
+  requestValidator('param', companyParamsSchema),
+  requestValidator('json', updateCompanyBodySchema),
+  updateCompanyHandler,
+)
+
+adminCompaniesRoute.delete(
+  '/companies/:id',
+  requestValidator('param', companyParamsSchema),
+  deleteCompanyHandler,
+)
+
+export default adminCompaniesRoute

--- a/src/routes/admin/companies/schema.ts
+++ b/src/routes/admin/companies/schema.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+
+import type { ValidatedJsonCtx, ValidatedParamCtx, ValidatedParamJsonCtx, ValidatedQueryCtx } from '../../@shared'
+
+import { requestValidationRules as rules } from '../../@shared'
+
+export const getCompaniesQuerySchema = z.object({
+  search: rules.company.search.optional(),
+  ...rules.pagination,
+})
+
+export type GetCompaniesQuery = z.infer<typeof getCompaniesQuerySchema>
+export type GetCompaniesCtx = ValidatedQueryCtx<GetCompaniesQuery>
+
+// Used by GET and DELETE endpoints, so no 'Get' prefix
+export const companyParamsSchema = z.object({
+  id: rules.data.id,
+})
+
+export type CompanyParams = z.infer<typeof companyParamsSchema>
+export type CompanyParamsCtx = ValidatedParamCtx<CompanyParams>
+
+export const createCompanyBodySchema = z.object({
+  name: rules.company.name,
+  website: rules.company.website.optional(),
+  description: rules.company.description.optional(),
+})
+
+export type CreateCompanyBody = z.infer<typeof createCompanyBodySchema>
+export type CreateCompanyCtx = ValidatedJsonCtx<CreateCompanyBody>
+
+export const updateCompanyBodySchema = z.object({
+  name: rules.company.name.optional(),
+  website: rules.company.website.nullish(),
+  description: rules.company.description.nullish(),
+})
+
+export type UpdateCompanyBody = z.infer<typeof updateCompanyBodySchema>
+export type UpdateCompanyCtx = ValidatedParamJsonCtx<CompanyParams, UpdateCompanyBody>

--- a/src/routes/admin/index.ts
+++ b/src/routes/admin/index.ts
@@ -1,1 +1,3 @@
+export { default as adminCompaniesRoute } from './companies'
+
 export { default as adminUsersRoute } from './users'

--- a/src/routes/admin/users/__tests__/handler.test.ts
+++ b/src/routes/admin/users/__tests__/handler.test.ts
@@ -132,7 +132,7 @@ describe('adminUserDetailHandler', () => {
       json: mockJson,
     }
 
-    mockGetUser = mock(async () => ({ data: { user: mockUser } }))
+    mockGetUser = mock(async () => ({ user: mockUser }))
 
     await moduleMocker.mock('@/use-cases/admin', () => ({
       getUser: mockGetUser,

--- a/src/routes/admin/users/handler.ts
+++ b/src/routes/admin/users/handler.ts
@@ -18,5 +18,5 @@ export const getUserHandler = async (c: GetUserCtx) => {
 
   const result = await getUser(id)
 
-  return c.json(result.data, HttpStatus.OK)
+  return c.json(result, HttpStatus.OK)
 }

--- a/src/routes/auth/request-password-reset/__tests__/endpoint.test.ts
+++ b/src/routes/auth/request-password-reset/__tests__/endpoint.test.ts
@@ -17,7 +17,7 @@ describe('Request Password Reset Endpoint', () => {
   let mockRequestPasswordReset: any
 
   beforeEach(async () => {
-    mockRequestPasswordReset = mock(async () => ({ data: { success: true } }))
+    mockRequestPasswordReset = mock(async () => ({ success: true }))
 
     await moduleMocker.mock('@/use-cases/auth/request-password-reset', () => ({
       default: mockRequestPasswordReset,

--- a/src/routes/auth/request-password-reset/handler.ts
+++ b/src/routes/auth/request-password-reset/handler.ts
@@ -8,7 +8,7 @@ const requestPasswordResetHandler = async (c: RequestPasswordResetCtx) => {
 
   const result = await requestPasswordReset(payload.data, payload.preferences)
 
-  return c.json(result.data, HttpStatus.ACCEPTED)
+  return c.json(result, HttpStatus.ACCEPTED)
 }
 
 export default requestPasswordResetHandler

--- a/src/routes/auth/resend-verification-email/__tests__/endpoint.test.ts
+++ b/src/routes/auth/resend-verification-email/__tests__/endpoint.test.ts
@@ -17,7 +17,7 @@ describe('Resend Verification Email Endpoint', () => {
   let mockResendVerificationEmail: any
 
   beforeEach(async () => {
-    mockResendVerificationEmail = mock(async () => ({ data: { success: true } }))
+    mockResendVerificationEmail = mock(async () => ({ success: true }))
 
     await moduleMocker.mock('@/use-cases/auth/resend-verification-email', () => ({
       default: mockResendVerificationEmail,

--- a/src/routes/auth/resend-verification-email/handler.ts
+++ b/src/routes/auth/resend-verification-email/handler.ts
@@ -8,7 +8,7 @@ const resendVerificationEmailHandler = async (c: ResendVerificationEmailCtx) => 
 
   const result = await resendVerificationEmail(payload.data, payload.preferences)
 
-  return c.json(result.data, HttpStatus.ACCEPTED)
+  return c.json(result, HttpStatus.ACCEPTED)
 }
 
 export default resendVerificationEmailHandler

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,7 +2,7 @@ import type { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import { adminUsersRoute } from './admin'
+import { adminCompaniesRoute, adminUsersRoute } from './admin'
 import {
   acceptInviteRoute,
   loginRoute,
@@ -33,6 +33,6 @@ export const userRoutesAllowNew: Hono<AppContext>[] = [meRoute]
 
 export const userRoutesVerifiedOnly: Hono<AppContext>[] = []
 
-export const adminRoutes: Hono<AppContext>[] = [adminUsersRoute]
+export const adminRoutes: Hono<AppContext>[] = [adminCompaniesRoute, adminUsersRoute]
 
 export const ownerRoutes: Hono<AppContext>[] = [ownerAdminsRoute]

--- a/src/routes/owner/admins/__tests__/handler.test.ts
+++ b/src/routes/owner/admins/__tests__/handler.test.ts
@@ -131,7 +131,7 @@ describe('ownerGetAdminHandler', () => {
       json: mockJson,
     }
 
-    mockGetAdmin = mock(async () => ({ data: { user: mockAdmin } }))
+    mockGetAdmin = mock(async () => ({ admin: mockAdmin }))
 
     await moduleMocker.mock('@/use-cases/owner', () => ({
       getAdmin: mockGetAdmin,
@@ -151,7 +151,7 @@ describe('ownerGetAdminHandler', () => {
   it('should return admin with OK status', async () => {
     const result = await getAdminHandler(mockContext)
 
-    expect(mockJson).toHaveBeenCalledWith({ user: mockAdmin }, HttpStatus.OK)
+    expect(mockJson).toHaveBeenCalledWith({ admin: mockAdmin }, HttpStatus.OK)
     expect(result.status).toBe(HttpStatus.OK)
   })
 
@@ -206,7 +206,7 @@ describe('inviteAdminHandler', () => {
       json: mockJson,
     }
 
-    mockInviteAdmin = mock(async () => ({ data: { admin: mockAdmin } }))
+    mockInviteAdmin = mock(async () => ({ admin: mockAdmin }))
 
     await moduleMocker.mock('@/use-cases/owner', () => ({
       inviteAdmin: mockInviteAdmin,

--- a/src/routes/owner/admins/handler.ts
+++ b/src/routes/owner/admins/handler.ts
@@ -18,7 +18,7 @@ export const getAdminHandler = async (c: GetAdminCtx) => {
 
   const result = await getAdmin(id)
 
-  return c.json(result.data, HttpStatus.OK)
+  return c.json(result, HttpStatus.OK)
 }
 
 export const inviteAdminHandler = async (c: InviteAdminCtx) => {
@@ -26,5 +26,5 @@ export const inviteAdminHandler = async (c: InviteAdminCtx) => {
 
   const result = await inviteAdmin(body)
 
-  return c.json(result.data, HttpStatus.CREATED)
+  return c.json(result, HttpStatus.CREATED)
 }

--- a/src/routes/user/me/__tests__/endpoint.test.ts
+++ b/src/routes/user/me/__tests__/endpoint.test.ts
@@ -50,7 +50,7 @@ describe('Me Endpoint', () => {
       createdAt: new Date('2024-01-01'),
       updatedAt: new Date('2024-01-01'),
     }
-    mockGetUser = mock(async () => ({ data: { user: mockFullUser } }))
+    mockGetUser = mock(async () => ({ user: mockFullUser }))
     mockUpdatedUser = {
       id: testUuids.USER_1,
       firstName: 'Jane',
@@ -61,7 +61,7 @@ describe('Me Endpoint', () => {
       createdAt: new Date('2024-01-01'),
       updatedAt: new Date('2024-01-02'),
     }
-    mockUpdateUser = mock(async () => ({ data: { user: mockUpdatedUser } }))
+    mockUpdateUser = mock(async () => ({ user: mockUpdatedUser }))
 
     await moduleMocker.mock('@/use-cases/user/me', () => ({
       getUser: mockGetUser,
@@ -257,7 +257,7 @@ describe('Me Endpoint', () => {
     })
 
     it('should handle valid names with minimum length', async () => {
-      mockUpdateUser.mockImplementation(async () => ({ data: { user: mockUpdatedUserMinimal } }))
+      mockUpdateUser.mockImplementation(async () => ({ user: mockUpdatedUserMinimal }))
 
       const res = await post(app, ME_URL, {
         data: {
@@ -291,7 +291,7 @@ describe('Me Endpoint', () => {
           return mockGetUser()
         }
 
-        return { data: { user: mockUpdatedUser } }
+        return { user: mockUpdatedUser }
       })
 
       const res = await post(app, ME_URL, { data: {} }, {

--- a/src/routes/user/me/handler.ts
+++ b/src/routes/user/me/handler.ts
@@ -8,7 +8,7 @@ const getHandler = async (c: AppCtx) => {
 
   const result = await getUser(user.id)
 
-  return c.json(result.data)
+  return c.json(result)
 }
 
 const postHandler = async (c: UpdateProfileCtx) => {
@@ -17,7 +17,7 @@ const postHandler = async (c: UpdateProfileCtx) => {
 
   const result = await updateUser(user.id, payload.data)
 
-  return c.json(result.data)
+  return c.json(result)
 }
 
 export { getHandler, postHandler }

--- a/src/use-cases/admin/__tests__/companies.test.ts
+++ b/src/use-cases/admin/__tests__/companies.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { Company, CompanySearchResult, CompanyWithMembers } from '@/data'
+
+import { ModuleMocker, testUuids } from '@/__tests__'
+import AppError from '@/errors/app-error'
+import ErrorCode from '@/errors/codes'
+
+import {
+  createCompany,
+  deleteCompany,
+  getCompanies,
+  getCompany,
+  updateCompany,
+} from '../companies'
+
+const { COMPANY_1, COMPANY_2 } = testUuids
+
+describe('getCompanies', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  const DEFAULT_PAGINATION = { page: 1, limit: 25 }
+
+  let mockSearchResult: CompanySearchResult
+  let mockCompanyRepoSearch: any
+
+  beforeEach(async () => {
+    mockSearchResult = {
+      companies: [
+        {
+          id: COMPANY_1,
+          name: 'Acme Corp',
+          website: 'https://acme.com',
+          description: 'A test company',
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+        },
+      ],
+      pagination: { page: 1, limit: 25, total: 1, totalPages: 1 },
+    }
+
+    mockCompanyRepoSearch = mock(async () => mockSearchResult)
+
+    await moduleMocker.mock('@/data', () => ({
+      companyRepo: { search: mockCompanyRepoSearch },
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should call companyRepo.search with correct params', async () => {
+    await getCompanies({ search: 'acme' }, DEFAULT_PAGINATION)
+
+    expect(mockCompanyRepoSearch).toHaveBeenCalledWith(
+      { search: 'acme' },
+      DEFAULT_PAGINATION,
+    )
+  })
+
+  it('should return companies and pagination', async () => {
+    const result = await getCompanies({}, DEFAULT_PAGINATION)
+
+    expect(result).toEqual(mockSearchResult)
+  })
+})
+
+describe('getCompany', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockCompany: CompanyWithMembers
+  let mockCompanyRepoFind: any
+
+  beforeEach(async () => {
+    mockCompany = {
+      id: COMPANY_1,
+      name: 'Acme Corp',
+      website: 'https://acme.com',
+      description: 'A test company',
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+      members: [],
+    }
+
+    mockCompanyRepoFind = mock(async () => mockCompany)
+
+    await moduleMocker.mock('@/data', () => ({
+      companyRepo: { find: mockCompanyRepoFind },
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should return company when found', async () => {
+    const result = await getCompany(COMPANY_1)
+
+    expect(mockCompanyRepoFind).toHaveBeenCalledWith(COMPANY_1)
+    expect(result).toEqual({ company: mockCompany })
+  })
+
+  it('should throw NotFound error when company does not exist', async () => {
+    mockCompanyRepoFind.mockImplementation(async () => undefined)
+
+    expect(getCompany(testUuids.NON_EXISTENT)).rejects.toThrow(AppError)
+    expect(getCompany(testUuids.NON_EXISTENT)).rejects.toMatchObject({
+      code: ErrorCode.NotFound,
+      message: 'Company not found',
+    })
+  })
+})
+
+describe('createCompany', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockCompany: Company
+  let mockCompanyRepoFindByName: any
+  let mockCompanyRepoCreate: any
+
+  beforeEach(async () => {
+    mockCompany = {
+      id: COMPANY_1,
+      name: 'New Company',
+      website: 'https://newcompany.com',
+      description: 'A new company',
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+    }
+
+    mockCompanyRepoFindByName = mock(async () => undefined)
+    mockCompanyRepoCreate = mock(async () => mockCompany)
+
+    await moduleMocker.mock('@/data', () => ({
+      companyRepo: {
+        findByName: mockCompanyRepoFindByName,
+        create: mockCompanyRepoCreate,
+      },
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should create company when name is unique', async () => {
+    const params = { name: 'New Company', website: 'https://newcompany.com' }
+
+    const result = await createCompany(params)
+
+    expect(mockCompanyRepoFindByName).toHaveBeenCalledWith('New Company')
+    expect(mockCompanyRepoCreate).toHaveBeenCalledWith(params)
+    expect(result).toEqual({ company: mockCompany })
+  })
+
+  it('should throw Conflict error when company name already exists', async () => {
+    mockCompanyRepoFindByName.mockImplementation(async () => mockCompany)
+
+    expect(createCompany({ name: 'New Company' })).rejects.toThrow(AppError)
+    expect(createCompany({ name: 'New Company' })).rejects.toMatchObject({
+      code: ErrorCode.Conflict,
+      message: 'Company with this name already exists',
+    })
+  })
+})
+
+describe('updateCompany', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockExistingCompany: Company
+  let mockUpdatedCompany: Company
+  let mockCompanyRepoFindById: any
+  let mockCompanyRepoFindByName: any
+  let mockCompanyRepoUpdate: any
+
+  beforeEach(async () => {
+    mockExistingCompany = {
+      id: COMPANY_1,
+      name: 'Old Company',
+      website: 'https://oldcompany.com',
+      description: 'An old company',
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+    }
+
+    mockUpdatedCompany = {
+      ...mockExistingCompany,
+      name: 'Updated Company',
+      updatedAt: new Date('2024-01-02'),
+    }
+
+    mockCompanyRepoFindById = mock(async () => mockExistingCompany)
+    mockCompanyRepoFindByName = mock(async () => undefined)
+    mockCompanyRepoUpdate = mock(async () => mockUpdatedCompany)
+
+    await moduleMocker.mock('@/data', () => ({
+      companyRepo: {
+        findById: mockCompanyRepoFindById,
+        findByName: mockCompanyRepoFindByName,
+        update: mockCompanyRepoUpdate,
+      },
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should update company when it exists', async () => {
+    const params = { name: 'Updated Company' }
+
+    const result = await updateCompany(COMPANY_1, params)
+
+    expect(mockCompanyRepoFindById).toHaveBeenCalledWith(COMPANY_1)
+    expect(mockCompanyRepoUpdate).toHaveBeenCalledWith(COMPANY_1, params)
+    expect(result).toEqual({ company: mockUpdatedCompany })
+  })
+
+  it('should throw NotFound error when company does not exist', async () => {
+    mockCompanyRepoFindById.mockImplementation(async () => undefined)
+
+    expect(updateCompany(testUuids.NON_EXISTENT, { name: 'Test' })).rejects.toThrow(AppError)
+    expect(updateCompany(testUuids.NON_EXISTENT, { name: 'Test' })).rejects.toMatchObject({
+      code: ErrorCode.NotFound,
+      message: 'Company not found',
+    })
+  })
+
+  it('should check name uniqueness when name is being changed', async () => {
+    await updateCompany(COMPANY_1, { name: 'Updated Company' })
+
+    expect(mockCompanyRepoFindByName).toHaveBeenCalledWith('Updated Company')
+  })
+
+  it('should not check name uniqueness when name is unchanged', async () => {
+    await updateCompany(COMPANY_1, { name: 'Old Company' })
+
+    expect(mockCompanyRepoFindByName).not.toHaveBeenCalled()
+  })
+
+  it('should throw Conflict error when new name already exists', async () => {
+    const otherCompany: Company = { ...mockExistingCompany, id: COMPANY_2, name: 'Taken Name' }
+    mockCompanyRepoFindByName.mockImplementation(async () => otherCompany)
+
+    expect(updateCompany(COMPANY_1, { name: 'Taken Name' })).rejects.toThrow(AppError)
+    expect(updateCompany(COMPANY_1, { name: 'Taken Name' })).rejects.toMatchObject({
+      code: ErrorCode.Conflict,
+      message: 'Company with this name already exists',
+    })
+  })
+})
+
+describe('deleteCompany', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockCompany: Company
+  let mockCompanyRepoFindById: any
+  let mockCompanyRepoDelete: any
+
+  beforeEach(async () => {
+    mockCompany = {
+      id: COMPANY_1,
+      name: 'Company to Delete',
+      website: null,
+      description: null,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+    }
+
+    mockCompanyRepoFindById = mock(async () => mockCompany)
+    mockCompanyRepoDelete = mock(async () => undefined)
+
+    await moduleMocker.mock('@/data', () => ({
+      companyRepo: {
+        findById: mockCompanyRepoFindById,
+        delete: mockCompanyRepoDelete,
+      },
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should delete company when it exists', async () => {
+    await deleteCompany(COMPANY_1)
+
+    expect(mockCompanyRepoFindById).toHaveBeenCalledWith(COMPANY_1)
+    expect(mockCompanyRepoDelete).toHaveBeenCalledWith(COMPANY_1)
+  })
+
+  it('should throw NotFound error when company does not exist', async () => {
+    mockCompanyRepoFindById.mockImplementation(async () => undefined)
+
+    expect(deleteCompany(testUuids.NON_EXISTENT)).rejects.toThrow(AppError)
+    expect(deleteCompany(testUuids.NON_EXISTENT)).rejects.toMatchObject({
+      code: ErrorCode.NotFound,
+      message: 'Company not found',
+    })
+  })
+})

--- a/src/use-cases/admin/__tests__/users.test.ts
+++ b/src/use-cases/admin/__tests__/users.test.ts
@@ -118,7 +118,7 @@ describe('getUser', () => {
     const result = await getUser(testUuids.USER_1)
 
     expect(mockFindById).toHaveBeenCalledWith(testUuids.USER_1)
-    expect(result).toEqual({ data: { user: mockUser } })
+    expect(result).toEqual({ user: mockUser })
   })
 
   it('should throw NotFound error when user does not exist', async () => {

--- a/src/use-cases/admin/companies.ts
+++ b/src/use-cases/admin/companies.ts
@@ -1,0 +1,75 @@
+import type { CompanySearchParams, PaginationParams } from '@/data'
+
+import { companyRepo } from '@/data'
+import { AppError, ErrorCode } from '@/errors'
+
+export const searchCompanies = async (
+  params: CompanySearchParams,
+  pagination: PaginationParams,
+) => {
+  return companyRepo.findAll(params, pagination)
+}
+
+export const getCompany = async (companyId: string) => {
+  const company = await companyRepo.findWithMembers(companyId)
+
+  if (!company) {
+    throw new AppError(ErrorCode.NotFound, 'Company not found')
+  }
+
+  return { data: { company } }
+}
+
+export interface CreateCompanyParams {
+  name: string
+  website?: string
+  description?: string
+}
+
+export const createCompany = async (params: CreateCompanyParams) => {
+  const existing = await companyRepo.findByName(params.name)
+
+  if (existing) {
+    throw new AppError(ErrorCode.Conflict, 'Company with this name already exists')
+  }
+
+  const company = await companyRepo.create(params)
+
+  return { data: { company } }
+}
+
+export interface UpdateCompanyParams {
+  name?: string
+  website?: string | null
+  description?: string | null
+}
+
+export const updateCompany = async (companyId: string, params: UpdateCompanyParams) => {
+  const existing = await companyRepo.findById(companyId)
+
+  if (!existing) {
+    throw new AppError(ErrorCode.NotFound, 'Company not found')
+  }
+
+  if (params.name && params.name !== existing.name) {
+    const nameConflict = await companyRepo.findByName(params.name)
+
+    if (nameConflict) {
+      throw new AppError(ErrorCode.Conflict, 'Company with this name already exists')
+    }
+  }
+
+  const company = await companyRepo.update(companyId, params)
+
+  return { data: { company } }
+}
+
+export const deleteCompany = async (companyId: string) => {
+  const existing = await companyRepo.findById(companyId)
+
+  if (!existing) {
+    throw new AppError(ErrorCode.NotFound, 'Company not found')
+  }
+
+  await companyRepo.delete(companyId)
+}

--- a/src/use-cases/admin/companies.ts
+++ b/src/use-cases/admin/companies.ts
@@ -17,7 +17,7 @@ export const getCompany = async (companyId: string) => {
     throw new AppError(ErrorCode.NotFound, 'Company not found')
   }
 
-  return { data: { company } }
+  return { company }
 }
 
 export interface CreateCompanyParams {
@@ -35,7 +35,7 @@ export const createCompany = async (params: CreateCompanyParams) => {
 
   const company = await companyRepo.create(params)
 
-  return { data: { company } }
+  return { company }
 }
 
 export interface UpdateCompanyParams {
@@ -61,7 +61,7 @@ export const updateCompany = async (companyId: string, params: UpdateCompanyPara
 
   const company = await companyRepo.update(companyId, params)
 
-  return { data: { company } }
+  return { company }
 }
 
 export const deleteCompany = async (companyId: string) => {

--- a/src/use-cases/admin/companies.ts
+++ b/src/use-cases/admin/companies.ts
@@ -3,15 +3,15 @@ import type { CompanySearchParams, PaginationParams } from '@/data'
 import { companyRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 
-export const searchCompanies = async (
+export const getCompanies = async (
   params: CompanySearchParams,
   pagination: PaginationParams,
 ) => {
-  return companyRepo.findAll(params, pagination)
+  return companyRepo.search(params, pagination)
 }
 
 export const getCompany = async (companyId: string) => {
-  const company = await companyRepo.findWithMembers(companyId)
+  const company = await companyRepo.find(companyId)
 
   if (!company) {
     throw new AppError(ErrorCode.NotFound, 'Company not found')

--- a/src/use-cases/admin/index.ts
+++ b/src/use-cases/admin/index.ts
@@ -1,1 +1,9 @@
+export {
+  createCompany,
+  deleteCompany,
+  getCompany,
+  searchCompanies,
+  updateCompany,
+} from './companies'
+
 export { getUser, searchUsers } from './users'

--- a/src/use-cases/admin/index.ts
+++ b/src/use-cases/admin/index.ts
@@ -1,8 +1,8 @@
 export {
   createCompany,
   deleteCompany,
+  getCompanies,
   getCompany,
-  searchCompanies,
   updateCompany,
 } from './companies'
 

--- a/src/use-cases/admin/users.ts
+++ b/src/use-cases/admin/users.ts
@@ -30,5 +30,5 @@ export const getUser = async (userId: string) => {
     throw new AppError(ErrorCode.NotFound, 'User not found')
   }
 
-  return { data: { user } }
+  return { user }
 }

--- a/src/use-cases/auth/__tests__/request-password-reset.test.ts
+++ b/src/use-cases/auth/__tests__/request-password-reset.test.ts
@@ -99,7 +99,7 @@ describe('Request Password Reset', () => {
       )
       expect(mockEmailAgent.sendResetPasswordEmail).toHaveBeenCalledTimes(1)
 
-      expect(result).toEqual({ data: { success: true } })
+      expect(result).toEqual({ success: true })
     })
 
     it('should return success when user not found', async () => {
@@ -107,7 +107,7 @@ describe('Request Password Reset', () => {
 
       const result = await requestPasswordReset({ email: 'nonexistent@example.com' })
 
-      expect(result).toEqual({ data: { success: true } })
+      expect(result).toEqual({ success: true })
       expect(mockTokenRepo.issue).not.toHaveBeenCalled()
       expect(mockEmailAgent.sendResetPasswordEmail).not.toHaveBeenCalled()
     })
@@ -123,7 +123,7 @@ describe('Request Password Reset', () => {
 
         const result = await requestPasswordReset({ email: mockUser.email })
 
-        expect(result).toEqual({ data: { success: true } })
+        expect(result).toEqual({ success: true })
         expect(mockTokenRepo.issue).not.toHaveBeenCalled()
         expect(mockEmailAgent.sendResetPasswordEmail).not.toHaveBeenCalled()
       })
@@ -158,7 +158,7 @@ describe('Request Password Reset', () => {
 
       const result = await requestPasswordReset({ email: mockUser.email })
 
-      expect(result).toEqual({ data: { success: true } })
+      expect(result).toEqual({ success: true })
 
       expect(mockTokenRepo.issue).toHaveBeenCalledTimes(1)
       expect(mockEmailAgent.sendResetPasswordEmail).toHaveBeenCalledTimes(1)

--- a/src/use-cases/auth/__tests__/resend-verification-email.test.ts
+++ b/src/use-cases/auth/__tests__/resend-verification-email.test.ts
@@ -90,7 +90,7 @@ describe('Resend Verification Email', () => {
       }, {})
       expect(mockTokenRepo.issue).toHaveBeenCalledTimes(1)
 
-      expect(result).toEqual({ data: { success: true } })
+      expect(result).toEqual({ success: true })
     })
 
     it('should send an email verification email with the new token', async () => {
@@ -112,7 +112,7 @@ describe('Resend Verification Email', () => {
 
       const result = await resendVerificationEmail({ email: 'nonexistent@example.com' })
 
-      expect(result).toEqual({ data: { success: true } })
+      expect(result).toEqual({ success: true })
       expect(mockTokenRepo.issue).not.toHaveBeenCalled()
       expect(mockEmailAgent.sendEmailVerificationEmail).not.toHaveBeenCalled()
     })
@@ -129,7 +129,7 @@ describe('Resend Verification Email', () => {
 
       const result = await resendVerificationEmail({ email: verifiedUser.email })
 
-      expect(result).toEqual({ data: { success: true } })
+      expect(result).toEqual({ success: true })
       expect(mockTokenRepo.issue).not.toHaveBeenCalled()
       expect(mockEmailAgent.sendEmailVerificationEmail).not.toHaveBeenCalled()
     })
@@ -146,7 +146,7 @@ describe('Resend Verification Email', () => {
 
       const result = await resendVerificationEmail({ email: suspendedUser.email })
 
-      expect(result).toEqual({ data: { success: true } })
+      expect(result).toEqual({ success: true })
       expect(mockTokenRepo.issue).not.toHaveBeenCalled()
       expect(mockEmailAgent.sendEmailVerificationEmail).not.toHaveBeenCalled()
     })
@@ -177,7 +177,7 @@ describe('Resend Verification Email', () => {
       const result = await resendVerificationEmail({ email: upperCaseEmail })
 
       expect(mockUserRepo.findByEmail).toHaveBeenCalledWith(upperCaseEmail)
-      expect(result.data.success).toBe(true)
+      expect(result.success).toBe(true)
     })
 
     it('should reject users with ineligible statuses to prevent enumeration', async () => {
@@ -195,7 +195,7 @@ describe('Resend Verification Email', () => {
 
         const result = await resendVerificationEmail({ email: userWithStatus.email })
 
-        expect(result).toEqual({ data: { success: true } })
+        expect(result).toEqual({ success: true })
         expect(mockTokenRepo.issue).not.toHaveBeenCalled()
         expect(mockEmailAgent.sendEmailVerificationEmail).not.toHaveBeenCalled()
       }
@@ -210,7 +210,7 @@ describe('Resend Verification Email', () => {
 
       const result = await resendVerificationEmail({ email: mockUser.email })
 
-      expect(result).toEqual({ data: { success: true } })
+      expect(result).toEqual({ success: true })
 
       expect(mockTokenRepo.issue).toHaveBeenCalled()
       expect(mockEmailAgent.sendEmailVerificationEmail).toHaveBeenCalled()

--- a/src/use-cases/auth/request-password-reset.ts
+++ b/src/use-cases/auth/request-password-reset.ts
@@ -41,7 +41,7 @@ const requestPasswordReset = async (
     })
   }
 
-  return { data: { success: true } }
+  return { success: true }
 }
 
 export default requestPasswordReset

--- a/src/use-cases/auth/resend-verification-email.ts
+++ b/src/use-cases/auth/resend-verification-email.ts
@@ -41,7 +41,7 @@ const resendVerificationEmail = async (
     })
   }
 
-  return { data: { success: true } }
+  return { success: true }
 }
 
 export default resendVerificationEmail

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -109,7 +109,7 @@ describe('getAdmin', () => {
     const result = await getAdmin(testUuids.ADMIN_1)
 
     expect(mockFindById).toHaveBeenCalledWith(testUuids.ADMIN_1)
-    expect(result).toEqual({ data: { admin: mockAdmin } })
+    expect(result).toEqual({ admin: mockAdmin })
   })
 
   it('should throw NotFound error when admin does not exist', async () => {
@@ -259,7 +259,7 @@ describe('inviteAdmin', () => {
       },
       expect.anything(),
     )
-    expect(result).toEqual({ data: { admin: mockAdmin } })
+    expect(result).toEqual({ admin: mockAdmin })
   })
 
   it('should call email agent with correct parameters', async () => {

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -30,7 +30,7 @@ export const getAdmin = async (adminId: string) => {
     throw new AppError(ErrorCode.NotFound, 'Admin not found')
   }
 
-  return { data: { admin } }
+  return { admin }
 }
 
 export interface AdminInvitationParams {
@@ -92,5 +92,5 @@ export const inviteAdmin = async (params: AdminInvitationParams) => {
     env.COMPANY_NAME,
   )
 
-  return { data: { admin } }
+  return { admin }
 }

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -46,9 +46,7 @@ describe('User Me Use Cases', () => {
     it('should return user data when user exists', async () => {
       const result = await getUser(testUuids.USER_1)
 
-      expect(result).toEqual({
-        data: { user: mockUser },
-      })
+      expect(result).toEqual({ user: mockUser })
       expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
       expect(mockUserRepo.findById).toHaveBeenCalledTimes(1)
     })
@@ -67,8 +65,8 @@ describe('User Me Use Cases', () => {
     it('should update user with firstName and lastName', async () => {
       const result = await updateUser(testUuids.USER_1, { firstName: 'Jane', lastName: 'Smith' })
 
-      expect(result.data.user.firstName).toBe('Jane')
-      expect(result.data.user.lastName).toBe('Smith')
+      expect(result.user.firstName).toBe('Jane')
+      expect(result.user.lastName).toBe('Smith')
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: 'Smith',
@@ -79,7 +77,7 @@ describe('User Me Use Cases', () => {
     it('should update user with only firstName', async () => {
       const result = await updateUser(testUuids.USER_1, { firstName: 'Jane' })
 
-      expect(result.data.user.firstName).toBe('Jane')
+      expect(result.user.firstName).toBe('Jane')
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         updatedAt: expect.any(Date),
@@ -89,7 +87,7 @@ describe('User Me Use Cases', () => {
     it('should update user with only lastName', async () => {
       const result = await updateUser(testUuids.USER_1, { lastName: 'Smith' })
 
-      expect(result.data.user.lastName).toBe('Smith')
+      expect(result.user.lastName).toBe('Smith')
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         lastName: 'Smith',
         updatedAt: expect.any(Date),
@@ -99,9 +97,7 @@ describe('User Me Use Cases', () => {
     it('should return current user when no valid updates provided', async () => {
       const result = await updateUser(testUuids.USER_1, {})
 
-      expect(result).toEqual({
-        data: { user: mockUser },
-      })
+      expect(result).toEqual({ user: mockUser })
       expect(mockUserRepo.update).not.toHaveBeenCalled()
       expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
     })
@@ -110,8 +106,8 @@ describe('User Me Use Cases', () => {
       // lastName: '' is valid (clears the field)
       const result = await updateUser(testUuids.USER_1, { firstName: 'Jane', lastName: '' })
 
-      expect(result.data.user.firstName).toBe('Jane')
-      expect(result.data.user.lastName).toBe('')
+      expect(result.user.firstName).toBe('Jane')
+      expect(result.user.lastName).toBe('')
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: '',
@@ -123,7 +119,7 @@ describe('User Me Use Cases', () => {
       // undefined = don't touch, empty string = include
       const result = await updateUser(testUuids.USER_1, { firstName: undefined, lastName: 'Smith' })
 
-      expect(result.data.user.lastName).toBe('Smith')
+      expect(result.user.lastName).toBe('Smith')
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         lastName: 'Smith',
         updatedAt: expect.any(Date),

--- a/src/use-cases/user/me.ts
+++ b/src/use-cases/user/me.ts
@@ -18,7 +18,7 @@ export const getUser = async (userId: string) => {
     throw new AppError(ErrorCode.InternalError)
   }
 
-  return { data: { user } }
+  return { user }
 }
 
 export const updateUser = async (userId: string, updates: UpdateUserInput) => {
@@ -33,5 +33,5 @@ export const updateUser = async (userId: string, updates: UpdateUserInput) => {
     updatedAt: new Date(),
   })
 
-  return { data: { user: updatedUser } }
+  return { user: updatedUser }
 }


### PR DESCRIPTION
1. [Feature]: Add companies and user_companies database schema with migrations
2. [Feature]: Implement admin CRUD endpoints for company management
3. [Feature]: Add company search with GIN index for trigram matching
4. [Improvement]: Include member details when fetching company by ID
5. [Feature]: Add comprehensive unit tests for handlers and use-cases
6. [Refactor]: Simplify use case return patterns across codebase

🤖 Generated with [Claude Code](https://claude.ai/code)