### PR TITLE
Add inviter info to admin responses

### DIFF
--- a/src/data/repositories/user-role/index.ts
+++ b/src/data/repositories/user-role/index.ts
@@ -1,10 +1,11 @@
 import { assign, remove } from './mutations'
-import { findByUserId } from './queries'
+import { findByUserId, findInviters } from './queries'
 
 export * from './types'
 
 export const userRoleRepo = {
   assign,
   findByUserId,
+  findInviters,
   remove,
 }

--- a/src/data/repositories/user-role/queries.ts
+++ b/src/data/repositories/user-role/queries.ts
@@ -1,10 +1,10 @@
-import { eq } from 'drizzle-orm'
+import { eq, inArray } from 'drizzle-orm'
 
 import type { Database } from '../../clients'
-import type { UserRoleRecord } from './types'
+import type { InviterInfo, UserRoleRecord } from './types'
 
 import { db } from '../../clients'
-import { userRolesTable } from '../../schema'
+import { userRolesTable, usersTable } from '../../schema'
 
 export const findByUserId = async (
   userId: string,
@@ -18,4 +18,33 @@ export const findByUserId = async (
     .where(eq(userRolesTable.userId, userId))
 
   return found
+}
+
+export const findInviters = async (
+  userIds: string[],
+  tx?: Database,
+): Promise<Map<string, InviterInfo>> => {
+  if (userIds.length === 0) {
+    return new Map()
+  }
+
+  const executor = tx || db
+  const rows = await executor
+    .select({
+      userId: userRolesTable.userId,
+      inviterId: usersTable.id,
+      firstName: usersTable.firstName,
+      lastName: usersTable.lastName,
+      assignedAt: userRolesTable.assignedAt,
+    })
+    .from(userRolesTable)
+    .innerJoin(usersTable, eq(userRolesTable.invitedBy, usersTable.id))
+    .where(inArray(userRolesTable.userId, userIds))
+
+  return new Map(rows.map(r => [r.userId, {
+    id: r.inviterId,
+    firstName: r.firstName,
+    lastName: r.lastName,
+    assignedAt: r.assignedAt,
+  }]))
 }

--- a/src/data/repositories/user-role/types.ts
+++ b/src/data/repositories/user-role/types.ts
@@ -9,3 +9,10 @@ export interface CreateUserRoleInput {
   role: Role
   invitedBy?: string
 }
+
+export interface InviterInfo {
+  id: string
+  firstName: string
+  lastName: string | null
+  assignedAt: Date
+}

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -62,7 +62,7 @@ describe('getAdmins', () => {
 
     expect(result).toEqual({
       data: {
-        admins: mockSearchResult.users.map(u => ({ ...u, invitedBy: null })),
+        admins: mockSearchResult.users.map(u => ({ ...u, inviter: null })),
       },
       pagination: mockSearchResult.pagination,
     })
@@ -94,7 +94,7 @@ describe('getAdmins', () => {
     const result = await getAdmins({ roles: [] }, DEFAULT_PAGINATION)
 
     expect(mockFindInviters).toHaveBeenCalledWith([testUuids.ADMIN_1])
-    expect(result.data.admins[0].invitedBy).toEqual(inviterInfo)
+    expect(result.data.admins[0].inviter).toEqual(inviterInfo)
   })
 })
 

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -16,6 +16,7 @@ describe('getAdmins', () => {
 
   let mockSearchResult: SearchResult
   let mockUserRepoSearch: any
+  let mockFindInviters: any
 
   beforeEach(async () => {
     mockSearchResult = {
@@ -35,9 +36,11 @@ describe('getAdmins', () => {
     }
 
     mockUserRepoSearch = mock(async () => mockSearchResult)
+    mockFindInviters = mock(async () => new Map())
 
     await moduleMocker.mock('@/data', () => ({
       userRepo: { search: mockUserRepoSearch },
+      userRoleRepo: { findInviters: mockFindInviters },
     }))
   })
 
@@ -58,7 +61,9 @@ describe('getAdmins', () => {
     const result = await getAdmins({ roles: [] }, DEFAULT_PAGINATION)
 
     expect(result).toEqual({
-      data: { admins: mockSearchResult.users },
+      data: {
+        admins: mockSearchResult.users.map(u => ({ ...u, invitedBy: null })),
+      },
       pagination: mockSearchResult.pagination,
     })
   })
@@ -73,6 +78,23 @@ describe('getAdmins', () => {
       { roles: [Role.Admin], statuses: [Status.Active] },
       DEFAULT_PAGINATION,
     )
+  })
+
+  it('should include inviter info when available', async () => {
+    const inviterInfo = {
+      id: testUuids.OWNER_1,
+      firstName: 'Owner',
+      lastName: 'User',
+      assignedAt: new Date('2024-01-01'),
+    }
+    mockFindInviters.mockImplementation(
+      async () => new Map([[testUuids.ADMIN_1, inviterInfo]]),
+    )
+
+    const result = await getAdmins({ roles: [] }, DEFAULT_PAGINATION)
+
+    expect(mockFindInviters).toHaveBeenCalledWith([testUuids.ADMIN_1])
+    expect(result.data.admins[0].invitedBy).toEqual(inviterInfo)
   })
 })
 

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -103,6 +103,7 @@ describe('getAdmin', () => {
 
   let mockAdmin: User
   let mockFindById: any
+  let mockFindInviters: any
 
   beforeEach(async () => {
     mockAdmin = {
@@ -117,9 +118,11 @@ describe('getAdmin', () => {
     }
 
     mockFindById = mock(async () => mockAdmin)
+    mockFindInviters = mock(async () => new Map())
 
     await moduleMocker.mock('@/data', () => ({
       userRepo: { findById: mockFindById },
+      userRoleRepo: { findInviters: mockFindInviters },
     }))
   })
 
@@ -131,7 +134,24 @@ describe('getAdmin', () => {
     const result = await getAdmin(testUuids.ADMIN_1)
 
     expect(mockFindById).toHaveBeenCalledWith(testUuids.ADMIN_1)
-    expect(result).toEqual({ admin: mockAdmin })
+    expect(result).toEqual({ admin: { ...mockAdmin, inviter: null } })
+  })
+
+  it('should include inviter info when available', async () => {
+    const inviterInfo = {
+      id: testUuids.OWNER_1,
+      firstName: 'Owner',
+      lastName: 'User',
+      assignedAt: new Date('2024-01-01'),
+    }
+    mockFindInviters.mockImplementation(
+      async () => new Map([[testUuids.ADMIN_1, inviterInfo]]),
+    )
+
+    const result = await getAdmin(testUuids.ADMIN_1)
+
+    expect(mockFindInviters).toHaveBeenCalledWith([testUuids.ADMIN_1])
+    expect(result.admin.inviter).toEqual(inviterInfo)
   })
 
   it('should throw NotFound error when admin does not exist', async () => {

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -62,7 +62,7 @@ describe('getAdmins', () => {
 
     expect(result).toEqual({
       data: {
-        admins: mockSearchResult.users.map(u => ({ ...u, inviter: null })),
+        admins: mockSearchResult.users.map(u => ({ ...u, inviter: undefined })),
       },
       pagination: mockSearchResult.pagination,
     })
@@ -134,7 +134,7 @@ describe('getAdmin', () => {
     const result = await getAdmin(testUuids.ADMIN_1)
 
     expect(mockFindById).toHaveBeenCalledWith(testUuids.ADMIN_1)
-    expect(result).toEqual({ admin: { ...mockAdmin, inviter: null } })
+    expect(result).toEqual({ admin: { ...mockAdmin, inviter: undefined } })
   })
 
   it('should include inviter info when available', async () => {

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -37,7 +37,14 @@ export const getAdmin = async (adminId: string) => {
     throw new AppError(ErrorCode.NotFound, 'Admin not found')
   }
 
-  return { admin }
+  const inviters = await userRoleRepo.findInviters([adminId])
+
+  return {
+    admin: {
+      ...admin,
+      inviter: inviters.get(adminId) ?? null,
+    },
+  }
 }
 
 export interface AdminInvitationParams {

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -21,7 +21,7 @@ export const getAdmins = async (params: SearchParams, pagination: PaginationPara
 
   const admins = result.users.map(admin => ({
     ...admin,
-    inviter: inviters.get(admin.id) ?? null,
+    inviter: inviters.get(admin.id),
   }))
 
   return {
@@ -42,7 +42,7 @@ export const getAdmin = async (adminId: string) => {
   return {
     admin: {
       ...admin,
-      inviter: inviters.get(adminId) ?? null,
+      inviter: inviters.get(adminId),
     },
   }
 }

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -16,8 +16,16 @@ const normalizeRoles = (params: SearchParams): SearchParams => ({
 export const getAdmins = async (params: SearchParams, pagination: PaginationParams) => {
   const result = await userRepo.search(normalizeRoles(params), pagination)
 
+  const adminIds = result.users.map(u => u.id)
+  const inviters = await userRoleRepo.findInviters(adminIds)
+
+  const admins = result.users.map(admin => ({
+    ...admin,
+    invitedBy: inviters.get(admin.id) ?? null,
+  }))
+
   return {
-    data: { admins: result.users },
+    data: { admins },
     pagination: result.pagination,
   }
 }

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -21,7 +21,7 @@ export const getAdmins = async (params: SearchParams, pagination: PaginationPara
 
   const admins = result.users.map(admin => ({
     ...admin,
-    invitedBy: inviters.get(admin.id) ?? null,
+    inviter: inviters.get(admin.id) ?? null,
   }))
 
   return {


### PR DESCRIPTION
1. [Feature]: Add `findInviters` batch query to fetch admin inviter data efficiently
2. [Feature]: Include `inviter` object in `getAdmins` list response with id, name, and assignedAt
3. [Feature]: Include `inviter` object in `getAdmin` single admin response
4. [Improvement]: Use separate query strategy to avoid JOIN overhead on regular user searches

🤖 Generated with [Claude Code](https://claude.ai/code)