### PR TITLE
Rename inviter to invite and simplify info structure

### DIFF
--- a/src/data/repositories/user-role/index.ts
+++ b/src/data/repositories/user-role/index.ts
@@ -1,11 +1,11 @@
 import { assign, remove } from './mutations'
-import { findByUserId, findInviters } from './queries'
+import { findByUserId, findInvites } from './queries'
 
 export * from './types'
 
 export const userRoleRepo = {
   assign,
   findByUserId,
-  findInviters,
+  findInvites,
   remove,
 }

--- a/src/data/repositories/user-role/queries.ts
+++ b/src/data/repositories/user-role/queries.ts
@@ -1,7 +1,7 @@
 import { eq, inArray } from 'drizzle-orm'
 
 import type { Database } from '../../clients'
-import type { InviterInfo, UserRoleRecord } from './types'
+import type { InviteInfo, UserRoleRecord } from './types'
 
 import { db } from '../../clients'
 import { userRolesTable, usersTable } from '../../schema'
@@ -20,10 +20,10 @@ export const findByUserId = async (
   return found
 }
 
-export const findInviters = async (
+export const findInvites = async (
   userIds: string[],
   tx?: Database,
-): Promise<Map<string, InviterInfo>> => {
+): Promise<Map<string, InviteInfo>> => {
   if (userIds.length === 0) {
     return new Map()
   }
@@ -35,16 +35,15 @@ export const findInviters = async (
       inviterId: usersTable.id,
       firstName: usersTable.firstName,
       lastName: usersTable.lastName,
-      assignedAt: userRolesTable.assignedAt,
+      invitedAt: userRolesTable.assignedAt,
     })
     .from(userRolesTable)
     .innerJoin(usersTable, eq(userRolesTable.invitedBy, usersTable.id))
     .where(inArray(userRolesTable.userId, userIds))
 
   return new Map(rows.map(r => [r.userId, {
-    id: r.inviterId,
-    firstName: r.firstName,
-    lastName: r.lastName,
-    assignedAt: r.assignedAt,
+    inviterId: r.inviterId,
+    inviterName: r.lastName ? `${r.firstName} ${r.lastName}` : r.firstName,
+    invitedAt: r.invitedAt,
   }]))
 }

--- a/src/data/repositories/user-role/types.ts
+++ b/src/data/repositories/user-role/types.ts
@@ -10,9 +10,8 @@ export interface CreateUserRoleInput {
   invitedBy?: string
 }
 
-export interface InviterInfo {
-  id: string
-  firstName: string
-  lastName: string | null
-  assignedAt: Date
+export interface InviteInfo {
+  inviterId: string
+  inviterName: string
+  invitedAt: Date
 }

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -16,7 +16,7 @@ describe('getAdmins', () => {
 
   let mockSearchResult: SearchResult
   let mockUserRepoSearch: any
-  let mockFindInviters: any
+  let mockFindInvites: any
 
   beforeEach(async () => {
     mockSearchResult = {
@@ -36,11 +36,11 @@ describe('getAdmins', () => {
     }
 
     mockUserRepoSearch = mock(async () => mockSearchResult)
-    mockFindInviters = mock(async () => new Map())
+    mockFindInvites = mock(async () => new Map())
 
     await moduleMocker.mock('@/data', () => ({
       userRepo: { search: mockUserRepoSearch },
-      userRoleRepo: { findInviters: mockFindInviters },
+      userRoleRepo: { findInvites: mockFindInvites },
     }))
   })
 
@@ -62,7 +62,7 @@ describe('getAdmins', () => {
 
     expect(result).toEqual({
       data: {
-        admins: mockSearchResult.users.map(u => ({ ...u, inviter: undefined })),
+        admins: mockSearchResult.users.map(u => ({ ...u, invite: undefined })),
       },
       pagination: mockSearchResult.pagination,
     })
@@ -80,21 +80,20 @@ describe('getAdmins', () => {
     )
   })
 
-  it('should include inviter info when available', async () => {
-    const inviterInfo = {
-      id: testUuids.OWNER_1,
-      firstName: 'Owner',
-      lastName: 'User',
-      assignedAt: new Date('2024-01-01'),
+  it('should include invite info when available', async () => {
+    const inviteInfo = {
+      inviterId: testUuids.OWNER_1,
+      inviterName: 'Owner User',
+      invitedAt: new Date('2024-01-01'),
     }
-    mockFindInviters.mockImplementation(
-      async () => new Map([[testUuids.ADMIN_1, inviterInfo]]),
+    mockFindInvites.mockImplementation(
+      async () => new Map([[testUuids.ADMIN_1, inviteInfo]]),
     )
 
     const result = await getAdmins({ roles: [] }, DEFAULT_PAGINATION)
 
-    expect(mockFindInviters).toHaveBeenCalledWith([testUuids.ADMIN_1])
-    expect(result.data.admins[0].inviter).toEqual(inviterInfo)
+    expect(mockFindInvites).toHaveBeenCalledWith([testUuids.ADMIN_1])
+    expect(result.data.admins[0].invite).toEqual(inviteInfo)
   })
 })
 
@@ -103,7 +102,7 @@ describe('getAdmin', () => {
 
   let mockAdmin: User
   let mockFindById: any
-  let mockFindInviters: any
+  let mockFindInvites: any
 
   beforeEach(async () => {
     mockAdmin = {
@@ -118,11 +117,11 @@ describe('getAdmin', () => {
     }
 
     mockFindById = mock(async () => mockAdmin)
-    mockFindInviters = mock(async () => new Map())
+    mockFindInvites = mock(async () => new Map())
 
     await moduleMocker.mock('@/data', () => ({
       userRepo: { findById: mockFindById },
-      userRoleRepo: { findInviters: mockFindInviters },
+      userRoleRepo: { findInvites: mockFindInvites },
     }))
   })
 
@@ -134,24 +133,23 @@ describe('getAdmin', () => {
     const result = await getAdmin(testUuids.ADMIN_1)
 
     expect(mockFindById).toHaveBeenCalledWith(testUuids.ADMIN_1)
-    expect(result).toEqual({ admin: { ...mockAdmin, inviter: undefined } })
+    expect(result).toEqual({ admin: { ...mockAdmin, invite: undefined } })
   })
 
-  it('should include inviter info when available', async () => {
-    const inviterInfo = {
-      id: testUuids.OWNER_1,
-      firstName: 'Owner',
-      lastName: 'User',
-      assignedAt: new Date('2024-01-01'),
+  it('should include invite info when available', async () => {
+    const inviteInfo = {
+      inviterId: testUuids.OWNER_1,
+      inviterName: 'Owner User',
+      invitedAt: new Date('2024-01-01'),
     }
-    mockFindInviters.mockImplementation(
-      async () => new Map([[testUuids.ADMIN_1, inviterInfo]]),
+    mockFindInvites.mockImplementation(
+      async () => new Map([[testUuids.ADMIN_1, inviteInfo]]),
     )
 
     const result = await getAdmin(testUuids.ADMIN_1)
 
-    expect(mockFindInviters).toHaveBeenCalledWith([testUuids.ADMIN_1])
-    expect(result.admin.inviter).toEqual(inviterInfo)
+    expect(mockFindInvites).toHaveBeenCalledWith([testUuids.ADMIN_1])
+    expect(result.admin.invite).toEqual(inviteInfo)
   })
 
   it('should throw NotFound error when admin does not exist', async () => {

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -17,11 +17,11 @@ export const getAdmins = async (params: SearchParams, pagination: PaginationPara
   const result = await userRepo.search(normalizeRoles(params), pagination)
 
   const adminIds = result.users.map(u => u.id)
-  const inviters = await userRoleRepo.findInviters(adminIds)
+  const invites = await userRoleRepo.findInvites(adminIds)
 
   const admins = result.users.map(admin => ({
     ...admin,
-    inviter: inviters.get(admin.id),
+    invite: invites.get(admin.id),
   }))
 
   return {
@@ -37,12 +37,12 @@ export const getAdmin = async (adminId: string) => {
     throw new AppError(ErrorCode.NotFound, 'Admin not found')
   }
 
-  const inviters = await userRoleRepo.findInviters([adminId])
+  const invites = await userRoleRepo.findInvites([adminId])
 
   return {
     admin: {
       ...admin,
-      inviter: inviters.get(adminId),
+      invite: invites.get(adminId),
     },
   }
 }


### PR DESCRIPTION
1. [Refactor]: Rename `findInviters` to `findInvites` for clearer API naming
2. [Refactor]: Rename `InviterInfo` type to `InviteInfo` for consistency
3. [Improvement]: Simplify invite info structure with combined `inviterName` field
4. [Improvement]: Update admin responses to use `invite` instead of `inviter` property