### PR TITLE
Update prerequisites and fix documentation references

### DIFF
--- a/.claude/skills/bun-testing/SKILL.md
+++ b/.claude/skills/bun-testing/SKILL.md
@@ -48,16 +48,6 @@ const response = await post(app, '/api/v1/auth/signup', {
 3. Boundary inputs
 4. Failure scenarios
 
-## Database Testing
-
-For integration tests requiring real database:
-
-- Use `bun run db:up:test` (starts test DB on port 5433)
-- Use `bun run db:down:test` (stops test DB)
-- Use `bun run test:with-db` (starts DB + runs tests)
-- Test DB uses separate Docker container (`smela-db-test`) and `.env.test` config
-- Reset DB state between test suites if needed using `bun run db:reset:test`
-
 ## Environment Setup
 
 - Use `.env.test` for test-specific variables

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,7 @@ All available commands are defined in [package.json](package.json). Key commands
 
 - **Development**: `bun run dev` (hot reload on port 3000), `bun run start` (production), `bun run staging`
 - **Testing**: `bun test` (all tests), `bun test [file]` (specific test file), `bun run coverage`, `bun run test:with-db` (start test DB and run tests)
-- **Database Dev**: `bun run db:up:dev` (start dev DB), `bun run db:down:dev` (stop dev DB), `bun run db:reset:dev` (reset dev DB), `bun run db:init` (generate + migrate + seed), `bun run db:ui` (Drizzle Studio)
-- **Database Test**: `bun run db:up:test` (start test DB on port 5433), `bun run db:down:test` (stop test DB), `bun run db:reset:test` (reset test DB)
+- **Database Dev**: `bun run db:dev:up` (start dev DB), `bun run db:dev:down` (stop dev DB), `bun run db:dev:reset` (reset dev DB), `bun run db:init` (generate + migrate + seed), `bun run db:ui` (Drizzle Studio)
 - **Code Quality**: `bun run lint`, `bun run lint:fix`, `bun run check` (lint + test)
 - **Email Dev**: `bun run emails` (React Email dev server on port 3001)
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Layered monolithic REST API with authentication and RBAC, focused on security an
 ## 📋 Prerequisites
 
 - [Git](https://git-scm.com/) version control
+- [Python](https://www.python.org/) for Husky git hooks
 - [Docker](https://www.docker.com/) for running PostgreSQL
 - [Bun](https://bun.sh/) runtime (latest version)
 - Email service account ([Resend](https://resend.com/) for production, [Ethereal](https://ethereal.email/) for development)
@@ -52,4 +53,4 @@ Server will start on <http://localhost:3000> by default.
 
 ## 🔌 API Endpoints
 
-See [src/routes/README.md](src/routes/README.md) for detailed API endpoints, and [Postman collection](postman.json).
+See [Postman collection](postman.json) for detailed API endpoints.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Layered monolithic REST API with authentication and RBAC, focused on security an
 
 ## 📋 Prerequisites
 
+- [Git](https://git-scm.com/) version control
+- [Docker](https://www.docker.com/) for running PostgreSQL
 - [Bun](https://bun.sh/) runtime (latest version)
-- PostgreSQL database (local or cloud)
 - Email service account ([Resend](https://resend.com/) for production, [Ethereal](https://ethereal.email/) for development)
 
 ## 🛠️ Build and Run
@@ -30,7 +31,7 @@ See [`.env.example`](.env.example) to configure required variables.
 Start the development PostgreSQL container:
 
 ```zsh
-bun run db:up:dev
+bun run db:dev:up
 ```
 
 Run all database setup steps at once (generate → migrate → seed):


### PR DESCRIPTION
1. [Docs]: Add Git, Python, and Docker to prerequisites in README
2. [Fix]: Correct database command names from db:up:dev to db:dev:up format
3. [Improvement]: Remove outdated test database section from bun-testing skill
4. [Fix]: Update API endpoints reference to point to Postman collection