### PR TITLE
Standardize auth route handlers, naming, and request body structure

### DIFF
--- a/postman.json
+++ b/postman.json
@@ -266,7 +266,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"data\": {\n        \"firstName\": \"Slava\",\n        \"email\": \"{{user_email}}\",\n        \"password\": \"{{initial_password}}\"\n    },\n    \"captcha\": {\n        \"token\": \"03AAYGu2S8_HuuT4N0xE8N8zQJ9nQJ8nQJ8nQJ8nQJ8nQJ8nQJ8n---\"\n    }\n}\n",
+              "raw": "{\n    \"firstName\": \"Slava\",\n    \"email\": \"{{user_email}}\",\n    \"password\": \"{{initial_password}}\",\n    \"captcha\": {\n        \"token\": \"03AAYGu2S8_HuuT4N0xE8N8zQJ9nQJ8nQJ8nQJ8nQJ8nQJ8nQJ8n---\"\n    }\n}\n",
               "options": {
                 "raw": {
                   "language": "json"
@@ -292,7 +292,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"data\": {\n        \"email\": \"{{user_email}}\"\n    },\n    \"captcha\": {\n        \"token\": \"03AAYGu2S8_HuuT4N0xE8N8zQJ9nQJ8nQJ8nQJ8nQJ8nQJ8nQJ8n---\"\n    }\n}\n",
+              "raw": "{\n    \"email\": \"{{user_email}}\",\n    \"captcha\": {\n        \"token\": \"03AAYGu2S8_HuuT4N0xE8N8zQJ9nQJ8nQJ8nQJ8nQJ8nQJ8nQJ8n---\"\n    }\n}\n",
               "options": {
                 "raw": {
                   "language": "json"
@@ -363,7 +363,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"data\": {\n        \"token\": \"2f2f69f037200103e01e1c8553c60e8e0f188b8aba8c855572fb700d631e87a9\"\n    }\n}",
+              "raw": "{\n    \"token\": \"6c9ec022ca779a2396c5882b50ddc4c7d99b0c2d6503b12ce9764dac182f475c\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -407,7 +407,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"data\": {\n        \"email\": \"{{owner_email}}\",\n        \"password\": \"{{owner_password}}\"\n    },\n    \"captcha\": {\n        \"token\": \"03AAYGu2S8_HuuT4N0xE8N8zQJ9nQJ8nQJ8nQJ8nQJ8nQJ8nQJ8n---\"\n    }\n}\n",
+              "raw": "{\n    \"email\": \"{{user_email}}\",\n    \"password\": \"{{initial_password}}\",\n    \"captcha\": {\n        \"token\": \"03AAYGu2S8_HuuT4N0xE8N8zQJ9nQJ8nQJ8nQJ8nQJ8nQJ8nQJ8n---\"\n    }\n}\n",
               "options": {
                 "raw": {
                   "language": "json"
@@ -433,7 +433,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"data\": {\n        \"email\": \"{{user_email}}\"\n    },\n    \"captcha\": {\n        \"token\": \"03AAYGu2S8_HuuT4N0xE8N8zQJ9nQJ8nQJ8nQJ8nQJ8nQJ8nQJ8n---\"\n    }\n}\n",
+              "raw": "{\n    \"email\": \"{{user_email}}\",\n    \"captcha\": {\n        \"token\": \"03AAYGu2S8_HuuT4N0xE8N8zQJ9nQJ8nQJ8nQJ8nQJ8nQJ8nQJ8n---\"\n    }\n}\n",
               "options": {
                 "raw": {
                   "language": "json"
@@ -459,7 +459,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"data\": {\n        \"token\": \"2bae77a059a4f2fbb1f5029ff6aaccd53cd32f594bf59bb112f0d9972cc0ffa3\",\n        \"password\": \"{{new_password}}\"\n    }\n}\n",
+              "raw": "{\n    \"token\": \"a3e3fad5ea11db103203099e3724384eaaccac932fca77539973f978f08582cb\",\n    \"password\": \"{{new_password}}\"\n}\n",
               "options": {
                 "raw": {
                   "language": "json"
@@ -568,7 +568,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"data\": {\n        \"token\": \"081930a069e4b76564cc4be5ca563266fe68227a7f8486eaaa59cce78b19257f\",\n        \"password\": \"{{initial_password}}\"\n    }\n}\n",
+              "raw": "{\n    \"token\": \"081930a069e4b76564cc4be5ca563266fe68227a7f8486eaaa59cce78b19257f\",\n    \"password\": \"{{initial_password}}\"\n}\n",
               "options": {
                 "raw": {
                   "language": "json"
@@ -622,7 +622,7 @@
         {
           "name": "me",
           "request": {
-            "method": "POST",
+            "method": "PATCH",
             "header": [],
             "body": {
               "mode": "raw",
@@ -869,7 +869,7 @@
           "response": []
         },
         {
-          "name": "admins/invitations",
+          "name": "admins/invites",
           "request": {
             "method": "POST",
             "header": [],
@@ -883,20 +883,20 @@
               }
             },
             "url": {
-              "raw": "{{owner_api_url}}/admins/invitations",
+              "raw": "{{owner_api_url}}/admins/invites",
               "host": [
                 "{{owner_api_url}}"
               ],
               "path": [
                 "admins",
-                "invitations"
+                "invites"
               ]
             }
           },
           "response": []
         },
         {
-          "name": "admins/invitations/:adminId/resend",
+          "name": "admins/invites/:adminId/resend",
           "request": {
             "method": "POST",
             "header": [],

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,4 +1,4 @@
 export { createTestApp } from './app'
 export { ModuleMocker } from './module-mocker'
-export { doRequest, get, post } from './request'
+export { doRequest, get, patch, post } from './request'
 export { createTestUuid, resetTestUuidCounter, testUuids } from './uuid'

--- a/src/__tests__/request.ts
+++ b/src/__tests__/request.ts
@@ -27,3 +27,11 @@ export const get = async (
   headers?: Record<string, string>,
 ) =>
   doRequest(app, url, 'GET', undefined, headers)
+
+export const patch = async (
+  app: Hono,
+  url: string,
+  body?: any,
+  headers: Record<string, string> = { 'Content-Type': 'application/json' },
+) =>
+  doRequest(app, url, 'PATCH', body, headers)

--- a/src/routes/auth/accept-invite/__tests__/endpoint.test.ts
+++ b/src/routes/auth/accept-invite/__tests__/endpoint.test.ts
@@ -34,10 +34,8 @@ describe('Accept Invite Endpoint', () => {
   })
 
   const validPayload = {
-    data: {
-      token: '1'.repeat(TOKEN_LENGTH),
-      password: 'NewSecure@123',
-    },
+    token: '1'.repeat(TOKEN_LENGTH),
+    password: 'NewSecure@123',
   }
 
   describe('POST /auth/accept-invite', () => {
@@ -49,11 +47,10 @@ describe('Accept Invite Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({ user: { id: testUuids.USER_1 }, accessToken: 'test-token' })
 
-      expect(mockAcceptInvite).toHaveBeenCalledWith({
-        token: validPayload.data.token,
-        password: validPayload.data.password,
-        deviceInfo: { ipAddress: null, userAgent: null },
-      })
+      expect(mockAcceptInvite).toHaveBeenCalledWith(
+        { token: validPayload.token, password: validPayload.password },
+        { ipAddress: null, userAgent: null },
+      )
       expect(mockAcceptInvite).toHaveBeenCalledTimes(1)
 
       // Verify refresh token cookie is set
@@ -80,11 +77,11 @@ describe('Accept Invite Endpoint', () => {
       ]
 
       for (const testCase of invalidTokens) {
-        const payload: any = { data: { ...validPayload.data } }
+        const payload: any = { ...validPayload }
         if (testCase.token !== null) {
-          payload.data.token = testCase.token
+          payload.token = testCase.token
         } else {
-          delete payload.data.token
+          delete payload.token
         }
 
         const res = await post(app, ACCEPT_INVITE_URL, payload)
@@ -104,11 +101,11 @@ describe('Accept Invite Endpoint', () => {
       ]
 
       for (const testCase of invalidPasswords) {
-        const payload: any = { data: { ...validPayload.data } }
+        const payload: any = { ...validPayload }
         if (testCase.password !== null) {
-          payload.data.password = testCase.password
+          payload.password = testCase.password
         } else {
-          delete payload.data.password
+          delete payload.password
         }
 
         const res = await post(app, ACCEPT_INVITE_URL, payload)

--- a/src/routes/auth/accept-invite/handler.ts
+++ b/src/routes/auth/accept-invite/handler.ts
@@ -4,10 +4,10 @@ import acceptInvite from '@/use-cases/auth/accept-invite'
 import type { AcceptInviteCtx } from './schema'
 
 export const acceptInviteHandler = async (c: AcceptInviteCtx) => {
-  const payload = c.req.valid('json')
+  const { token, password } = c.req.valid('json')
   const deviceInfo = getDeviceInfo(c)
 
-  const result = await acceptInvite({ ...payload.data, deviceInfo })
+  const result = await acceptInvite({ token, password }, deviceInfo)
 
   setRefreshCookie(c, result.refreshToken)
 

--- a/src/routes/auth/accept-invite/handler.ts
+++ b/src/routes/auth/accept-invite/handler.ts
@@ -3,7 +3,7 @@ import acceptInvite from '@/use-cases/auth/accept-invite'
 
 import type { AcceptInviteCtx } from './schema'
 
-const acceptInviteHandler = async (c: AcceptInviteCtx) => {
+export const acceptInviteHandler = async (c: AcceptInviteCtx) => {
   const payload = c.req.valid('json')
   const deviceInfo = getDeviceInfo(c)
 
@@ -13,5 +13,3 @@ const acceptInviteHandler = async (c: AcceptInviteCtx) => {
 
   return c.json(result.data, HttpStatus.OK)
 }
-
-export default acceptInviteHandler

--- a/src/routes/auth/accept-invite/index.ts
+++ b/src/routes/auth/accept-invite/index.ts
@@ -4,7 +4,7 @@ import type { AppContext } from '@/context'
 
 import { requestValidator } from '@/middleware'
 
-import acceptInviteHandler from './handler'
+import { acceptInviteHandler } from './handler'
 import schema from './schema'
 
 const acceptInviteRoute = new Hono<AppContext>()

--- a/src/routes/auth/accept-invite/schema.ts
+++ b/src/routes/auth/accept-invite/schema.ts
@@ -5,10 +5,8 @@ import type { ValidatedJsonCtx } from '../../@shared'
 import { requestValidationRules as rules } from '../../@shared'
 
 const acceptInviteSchema = z.object({
-  data: z.object({
-    token: rules.data.securityToken,
-    password: rules.data.password,
-  }).strict(),
+  token: rules.data.securityToken,
+  password: rules.data.password,
 }).strict()
 
 export type AcceptInviteBody = z.infer<typeof acceptInviteSchema>

--- a/src/routes/auth/check-invite/handler.ts
+++ b/src/routes/auth/check-invite/handler.ts
@@ -3,12 +3,10 @@ import checkInvite from '@/use-cases/auth/check-invite'
 
 import type { CheckInviteCtx } from './schema'
 
-const checkInviteHandler = async (c: CheckInviteCtx) => {
+export const checkInviteHandler = async (c: CheckInviteCtx) => {
   const { token } = c.req.valid('query')
 
   const result = await checkInvite(token)
 
   return c.json({ data: result }, HttpStatus.OK)
 }
-
-export default checkInviteHandler

--- a/src/routes/auth/check-invite/index.ts
+++ b/src/routes/auth/check-invite/index.ts
@@ -4,7 +4,7 @@ import type { AppContext } from '@/context'
 
 import { requestValidator } from '@/middleware'
 
-import checkInviteHandler from './handler'
+import { checkInviteHandler } from './handler'
 import schema from './schema'
 
 const checkInviteRoute = new Hono<AppContext>()

--- a/src/routes/auth/login/__tests__/endpoint.test.ts
+++ b/src/routes/auth/login/__tests__/endpoint.test.ts
@@ -70,10 +70,8 @@ describe('Login Endpoint', () => {
   describe('POST /auth/login', () => {
     it('should set cookie and return user/token on successful login', async () => {
       const res = await post(app, LOGIN_URL, {
-        data: {
-          email: 'test@example.com',
-          password: 'ValidPass123!',
-        },
+        email: 'test@example.com',
+        password: 'ValidPass123!',
         captcha: { token: VALID_CAPTCHA_TOKEN },
       })
 
@@ -124,10 +122,8 @@ describe('Login Endpoint', () => {
       })
 
       const res = await post(app, '/api/v1/auth/login', {
-        data: {
-          email: 'test@example.com',
-          password: 'WrongPass123!',
-        },
+        email: 'test@example.com',
+        password: 'WrongPass123!',
         captcha: { token: VALID_CAPTCHA_TOKEN },
       })
 
@@ -143,22 +139,21 @@ describe('Login Endpoint', () => {
     it('should validate required fields', async () => {
       const invalidRequests = [
         // Email validation
-        { name: 'empty email', body: { data: { email: '', password: 'ValidPass123!' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'invalid email format', body: { data: { email: 'invalid', password: 'ValidPass123!' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'incomplete email', body: { data: { email: 'test@', password: 'ValidPass123!' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'email missing local part', body: { data: { email: '@example.com', password: 'ValidPass123!' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'empty email', body: { email: '', password: 'ValidPass123!', captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'invalid email format', body: { email: 'invalid', password: 'ValidPass123!', captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'incomplete email', body: { email: 'test@', password: 'ValidPass123!', captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'email missing local part', body: { email: '@example.com', password: 'ValidPass123!', captcha: { token: VALID_CAPTCHA_TOKEN } } },
 
         // Password validation
-        { name: 'empty password', body: { data: { email: 'test@example.com', password: '' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'short password', body: { data: { email: 'test@example.com', password: '123' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'password without numbers', body: { data: { email: 'test@example.com', password: 'NoNumbers!' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'password without special chars', body: { data: { email: 'test@example.com', password: 'NoSpecial123' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'empty password', body: { email: 'test@example.com', password: '', captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'short password', body: { email: 'test@example.com', password: '123', captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'password without numbers', body: { email: 'test@example.com', password: 'NoNumbers!', captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'password without special chars', body: { email: 'test@example.com', password: 'NoSpecial123', captcha: { token: VALID_CAPTCHA_TOKEN } } },
 
         // Missing fields
-        { name: 'missing password', body: { data: { email: 'test@example.com' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'missing email', body: { data: { password: 'ValidPass123!' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'missing both email and password', body: { data: {}, captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'missing data object', body: { captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'missing password', body: { email: 'test@example.com', captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'missing email', body: { password: 'ValidPass123!', captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'missing both email and password', body: { captcha: { token: VALID_CAPTCHA_TOKEN } } },
         { name: 'missing all fields', body: {} },
       ]
 
@@ -175,7 +170,7 @@ describe('Login Endpoint', () => {
 
     it('should handle malformed requests', async () => {
       const scenarios: Array<{ name: string, headers?: Record<string, string>, body?: any }> = [
-        { name: 'missing Content-Type', headers: {}, body: { data: { email: 'test@example.com', password: 'ValidPass123!' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'missing Content-Type', headers: {}, body: { email: 'test@example.com', password: 'ValidPass123!', captcha: { token: VALID_CAPTCHA_TOKEN } } },
         { name: 'malformed JSON', headers: { 'Content-Type': 'application/json' }, body: '{ invalid json' },
         { name: 'missing request body', headers: { 'Content-Type': 'application/json' }, body: undefined },
       ]
@@ -195,10 +190,8 @@ describe('Login Endpoint', () => {
       })
 
       const res = await post(app, '/api/v1/auth/login', {
-        data: {
-          email: 'inactive@example.com',
-          password: 'ValidPass123!',
-        },
+        email: 'inactive@example.com',
+        password: 'ValidPass123!',
         captcha: { token: VALID_CAPTCHA_TOKEN },
       })
 
@@ -227,10 +220,8 @@ describe('Login Endpoint', () => {
       })
 
       const res = await post(app, LOGIN_URL, {
-        data: {
-          email: 'test@example.com',
-          password: 'ValidPass123!',
-        },
+        email: 'test@example.com',
+        password: 'ValidPass123!',
         captcha: { token: VALID_CAPTCHA_TOKEN },
       })
 

--- a/src/routes/auth/login/handler.ts
+++ b/src/routes/auth/login/handler.ts
@@ -3,7 +3,7 @@ import logInWithEmail from '@/use-cases/auth/login'
 
 import type { LoginCtx } from './schema'
 
-const loginHandler = async (c: LoginCtx) => {
+export const loginHandler = async (c: LoginCtx) => {
   const payload = c.req.valid('json')
   const deviceInfo = getDeviceInfo(c)
 
@@ -13,5 +13,3 @@ const loginHandler = async (c: LoginCtx) => {
 
   return c.json(result.data, HttpStatus.OK)
 }
-
-export default loginHandler

--- a/src/routes/auth/login/handler.ts
+++ b/src/routes/auth/login/handler.ts
@@ -4,10 +4,10 @@ import logInWithEmail from '@/use-cases/auth/login'
 import type { LoginCtx } from './schema'
 
 export const loginHandler = async (c: LoginCtx) => {
-  const payload = c.req.valid('json')
+  const { email, password } = c.req.valid('json')
   const deviceInfo = getDeviceInfo(c)
 
-  const result = await logInWithEmail(payload.data, deviceInfo)
+  const result = await logInWithEmail({ email, password }, deviceInfo)
 
   setRefreshCookie(c, result.refreshToken)
 

--- a/src/routes/auth/login/index.ts
+++ b/src/routes/auth/login/index.ts
@@ -4,7 +4,7 @@ import type { AppContext } from '@/context'
 
 import { captchaMiddleware, requestValidator } from '@/middleware'
 
-import handler from './handler'
+import { loginHandler } from './handler'
 import schema from './schema'
 
 const loginRoute = new Hono<AppContext>()
@@ -13,7 +13,7 @@ loginRoute.post(
   '/login',
   requestValidator('json', schema),
   captchaMiddleware(),
-  handler,
+  loginHandler,
 )
 
 export default loginRoute

--- a/src/routes/auth/login/schema.ts
+++ b/src/routes/auth/login/schema.ts
@@ -5,10 +5,8 @@ import type { ValidatedJsonCtx } from '../../@shared'
 import { nestedSchemas as nested, requestValidationRules as rules } from '../../@shared'
 
 const loginSchema = z.object({
-  data: z.object({
-    email: rules.data.email,
-    password: rules.data.password,
-  }).strict(),
+  email: rules.data.email,
+  password: rules.data.password,
   captcha: nested.captcha.strict(),
 }).strict()
 

--- a/src/routes/auth/logout/__tests__/handler.test.ts
+++ b/src/routes/auth/logout/__tests__/handler.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { ModuleMocker } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 
-import logoutHandler from '../handler'
+import { logoutHandler } from '../handler'
 
 describe('Logout Handler', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)

--- a/src/routes/auth/logout/handler.ts
+++ b/src/routes/auth/logout/handler.ts
@@ -3,7 +3,7 @@ import { logout } from '@/use-cases/auth/logout'
 
 import type { AppCtx } from '../../@shared'
 
-const logoutHandler = async (c: AppCtx) => {
+export const logoutHandler = async (c: AppCtx) => {
   const refreshToken = getRefreshCookie(c)
 
   await logout(refreshToken)
@@ -12,5 +12,3 @@ const logoutHandler = async (c: AppCtx) => {
 
   return c.body(null, HttpStatus.NO_CONTENT)
 }
-
-export default logoutHandler

--- a/src/routes/auth/logout/index.ts
+++ b/src/routes/auth/logout/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import logoutHandler from './handler'
+import { logoutHandler } from './handler'
 
 const logout = new Hono<AppContext>()
 

--- a/src/routes/auth/refresh-token/__tests__/handler.test.ts
+++ b/src/routes/auth/refresh-token/__tests__/handler.test.ts
@@ -6,7 +6,7 @@ import { ModuleMocker, testUuids } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { Role, Status } from '@/types'
 
-import refreshTokenHandler from '../handler'
+import { refreshTokenHandler } from '../handler'
 
 describe('Refresh Token Handler', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)

--- a/src/routes/auth/refresh-token/handler.ts
+++ b/src/routes/auth/refresh-token/handler.ts
@@ -3,7 +3,7 @@ import { refreshAuthTokens } from '@/use-cases/auth'
 
 import type { AppCtx } from '../../@shared'
 
-const refreshTokenHandler = async (c: AppCtx) => {
+export const refreshTokenHandler = async (c: AppCtx) => {
   const refreshToken = getRefreshCookie(c)
   const deviceInfo = getDeviceInfo(c)
 
@@ -13,5 +13,3 @@ const refreshTokenHandler = async (c: AppCtx) => {
 
   return c.json(result.data, HttpStatus.OK)
 }
-
-export default refreshTokenHandler

--- a/src/routes/auth/refresh-token/index.ts
+++ b/src/routes/auth/refresh-token/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
 
-import refreshTokenHandler from './handler'
+import { refreshTokenHandler } from './handler'
 
 const refreshToken = new Hono<AppContext>()
 

--- a/src/routes/auth/request-password-reset/__tests__/endpoint.test.ts
+++ b/src/routes/auth/request-password-reset/__tests__/endpoint.test.ts
@@ -35,7 +35,7 @@ describe('Request Password Reset Endpoint', () => {
   describe('POST /auth/request-password-reset', () => {
     it('should return success response on valid request', async () => {
       const res = await post(app, REQUEST_PASSWORD_RESET_URL, {
-        data: { email: 'test@example.com' },
+        email: 'test@example.com',
         captcha: { token: VALID_CAPTCHA_TOKEN },
       })
 
@@ -53,7 +53,7 @@ describe('Request Password Reset Endpoint', () => {
 
     it('should pass preferences to use-case when provided', async () => {
       const res = await post(app, REQUEST_PASSWORD_RESET_URL, {
-        data: { email: 'test@example.com' },
+        email: 'test@example.com',
         captcha: { token: VALID_CAPTCHA_TOKEN },
         preferences: { locale: 'uk', theme: 'dark' },
       })
@@ -69,18 +69,17 @@ describe('Request Password Reset Endpoint', () => {
     it('should validate required fields', async () => {
       const invalidRequests = [
         // Invalid email formats
-        { data: { email: '' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // empty email
-        { data: { email: 'invalid' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // invalid format
-        { data: { email: 'test@' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // incomplete
-        { data: { email: '@example.com' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing local part
-        { data: {}, captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing email field
-        { captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing data object
+        { email: '', captcha: { token: VALID_CAPTCHA_TOKEN } }, // empty email
+        { email: 'invalid', captcha: { token: VALID_CAPTCHA_TOKEN } }, // invalid format
+        { email: 'test@', captcha: { token: VALID_CAPTCHA_TOKEN } }, // incomplete
+        { email: '@example.com', captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing local part
+        { captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing email field
 
         // Invalid captcha
-        { data: { email: 'test@example.com' } }, // missing captcha
-        { data: { email: 'test@example.com' }, captcha: {} }, // empty captcha object
-        { data: { email: 'test@example.com' }, captcha: { token: '' } }, // empty captcha token
-        { data: { email: 'test@example.com' }, captcha: { token: 'invalid-token' } }, // invalid captcha token
+        { email: 'test@example.com' }, // missing captcha
+        { email: 'test@example.com', captcha: {} }, // empty captcha object
+        { email: 'test@example.com', captcha: { token: '' } }, // empty captcha token
+        { email: 'test@example.com', captcha: { token: 'invalid-token' } }, // invalid captcha token
       ]
 
       for (const body of invalidRequests) {
@@ -94,7 +93,7 @@ describe('Request Password Reset Endpoint', () => {
 
     it('should handle malformed requests', async () => {
       const scenarios: Array<{ name: string, headers?: Record<string, string>, body?: any }> = [
-        { name: 'missing Content-Type header', headers: {}, body: { data: { email: 'test@example.com' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'missing Content-Type header', headers: {}, body: { email: 'test@example.com', captcha: { token: VALID_CAPTCHA_TOKEN } } },
         { name: 'undefined body', headers: { 'Content-Type': 'application/json' }, body: undefined },
         { name: 'empty body', headers: { 'Content-Type': 'application/json' }, body: {} },
         { name: 'malformed JSON body', headers: { 'Content-Type': 'application/json' }, body: '{ invalid json' },

--- a/src/routes/auth/request-password-reset/handler.ts
+++ b/src/routes/auth/request-password-reset/handler.ts
@@ -3,12 +3,10 @@ import requestPasswordReset from '@/use-cases/auth/request-password-reset'
 
 import type { RequestPasswordResetCtx } from './schema'
 
-const requestPasswordResetHandler = async (c: RequestPasswordResetCtx) => {
+export const requestPasswordResetHandler = async (c: RequestPasswordResetCtx) => {
   const payload = c.req.valid('json')
 
   const result = await requestPasswordReset(payload.data, payload.preferences)
 
   return c.json(result, HttpStatus.ACCEPTED)
 }
-
-export default requestPasswordResetHandler

--- a/src/routes/auth/request-password-reset/handler.ts
+++ b/src/routes/auth/request-password-reset/handler.ts
@@ -4,9 +4,9 @@ import requestPasswordReset from '@/use-cases/auth/request-password-reset'
 import type { RequestPasswordResetCtx } from './schema'
 
 export const requestPasswordResetHandler = async (c: RequestPasswordResetCtx) => {
-  const payload = c.req.valid('json')
+  const { email, preferences } = c.req.valid('json')
 
-  const result = await requestPasswordReset(payload.data, payload.preferences)
+  const result = await requestPasswordReset({ email }, preferences)
 
   return c.json(result, HttpStatus.ACCEPTED)
 }

--- a/src/routes/auth/request-password-reset/index.ts
+++ b/src/routes/auth/request-password-reset/index.ts
@@ -4,7 +4,7 @@ import type { AppContext } from '@/context'
 
 import { captchaMiddleware, requestValidator } from '@/middleware'
 
-import handler from './handler'
+import { requestPasswordResetHandler } from './handler'
 import schema from './schema'
 
 const requestPasswordResetRoute = new Hono<AppContext>()
@@ -13,7 +13,7 @@ requestPasswordResetRoute.post(
   '/request-password-reset',
   requestValidator('json', schema),
   captchaMiddleware(),
-  handler,
+  requestPasswordResetHandler,
 )
 
 export default requestPasswordResetRoute

--- a/src/routes/auth/request-password-reset/schema.ts
+++ b/src/routes/auth/request-password-reset/schema.ts
@@ -5,9 +5,7 @@ import type { ValidatedJsonCtx } from '../../@shared'
 import { nestedSchemas as nested, requestValidationRules as rules } from '../../@shared'
 
 const requestPasswordResetSchema = z.object({
-  data: z.object({
-    email: rules.data.email,
-  }).strict(),
+  email: rules.data.email,
   captcha: nested.captcha.strict(),
   preferences: nested.preferences.optional(),
 }).strict()

--- a/src/routes/auth/resend-verification-email/__tests__/endpoint.test.ts
+++ b/src/routes/auth/resend-verification-email/__tests__/endpoint.test.ts
@@ -35,7 +35,7 @@ describe('Resend Verification Email Endpoint', () => {
   describe('POST /auth/resend-verification-email', () => {
     it('should return success when verification email is resent', async () => {
       const res = await post(app, RESEND_VERIFICATION_EMAIL_URL, {
-        data: { email: 'test@example.com' },
+        email: 'test@example.com',
         captcha: { token: VALID_CAPTCHA_TOKEN },
       })
 
@@ -53,7 +53,7 @@ describe('Resend Verification Email Endpoint', () => {
 
     it('should pass preferences to use-case when provided', async () => {
       const res = await post(app, RESEND_VERIFICATION_EMAIL_URL, {
-        data: { email: 'test@example.com' },
+        email: 'test@example.com',
         captcha: { token: VALID_CAPTCHA_TOKEN },
         preferences: { locale: 'uk', theme: 'dark' },
       })
@@ -72,7 +72,7 @@ describe('Resend Verification Email Endpoint', () => {
       })
 
       const res = await post(app, RESEND_VERIFICATION_EMAIL_URL, {
-        data: { email: 'test@example.com' },
+        email: 'test@example.com',
         captcha: { token: VALID_CAPTCHA_TOKEN },
       })
 
@@ -82,11 +82,10 @@ describe('Resend Verification Email Endpoint', () => {
 
     it('should validate request format and required fields', async () => {
       const invalidRequests = [
-        { name: 'empty email', body: { data: { email: '' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'invalid email format', body: { data: { email: 'invalid' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'missing email field', body: { data: {}, captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'missing data object', body: { captcha: { token: VALID_CAPTCHA_TOKEN } } },
-        { name: 'missing captcha', body: { data: { email: 'test@example.com' } } },
+        { name: 'empty email', body: { email: '', captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'invalid email format', body: { email: 'invalid', captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'missing email field', body: { captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'missing captcha', body: { email: 'test@example.com' } },
         { name: 'missing all fields', body: {} },
       ]
 
@@ -101,7 +100,7 @@ describe('Resend Verification Email Endpoint', () => {
 
     it('should handle malformed requests', async () => {
       const scenarios: Array<{ name: string, headers?: Record<string, string>, body?: any }> = [
-        { name: 'missing Content-Type', headers: {}, body: { data: { email: 'test@example.com' }, captcha: { token: VALID_CAPTCHA_TOKEN } } },
+        { name: 'missing Content-Type', headers: {}, body: { email: 'test@example.com', captcha: { token: VALID_CAPTCHA_TOKEN } } },
         { name: 'malformed JSON', headers: { 'Content-Type': 'application/json' }, body: '{ invalid json' },
         { name: 'missing request body', headers: { 'Content-Type': 'application/json' }, body: '' },
       ]

--- a/src/routes/auth/resend-verification-email/handler.ts
+++ b/src/routes/auth/resend-verification-email/handler.ts
@@ -3,12 +3,10 @@ import resendVerificationEmail from '@/use-cases/auth/resend-verification-email'
 
 import type { ResendVerificationEmailCtx } from './schema'
 
-const resendVerificationEmailHandler = async (c: ResendVerificationEmailCtx) => {
+export const resendVerificationEmailHandler = async (c: ResendVerificationEmailCtx) => {
   const payload = c.req.valid('json')
 
   const result = await resendVerificationEmail(payload.data, payload.preferences)
 
   return c.json(result, HttpStatus.ACCEPTED)
 }
-
-export default resendVerificationEmailHandler

--- a/src/routes/auth/resend-verification-email/handler.ts
+++ b/src/routes/auth/resend-verification-email/handler.ts
@@ -4,9 +4,9 @@ import resendVerificationEmail from '@/use-cases/auth/resend-verification-email'
 import type { ResendVerificationEmailCtx } from './schema'
 
 export const resendVerificationEmailHandler = async (c: ResendVerificationEmailCtx) => {
-  const payload = c.req.valid('json')
+  const { email, preferences } = c.req.valid('json')
 
-  const result = await resendVerificationEmail(payload.data, payload.preferences)
+  const result = await resendVerificationEmail({ email }, preferences)
 
   return c.json(result, HttpStatus.ACCEPTED)
 }

--- a/src/routes/auth/resend-verification-email/index.ts
+++ b/src/routes/auth/resend-verification-email/index.ts
@@ -4,7 +4,7 @@ import type { AppContext } from '@/context'
 
 import { captchaMiddleware, requestValidator } from '@/middleware'
 
-import handler from './handler'
+import { resendVerificationEmailHandler } from './handler'
 import schema from './schema'
 
 const resendVerificationEmailRoute = new Hono<AppContext>()
@@ -13,7 +13,7 @@ resendVerificationEmailRoute.post(
   '/resend-verification-email',
   requestValidator('json', schema),
   captchaMiddleware(),
-  handler,
+  resendVerificationEmailHandler,
 )
 
 export default resendVerificationEmailRoute

--- a/src/routes/auth/resend-verification-email/schema.ts
+++ b/src/routes/auth/resend-verification-email/schema.ts
@@ -5,9 +5,7 @@ import type { ValidatedJsonCtx } from '../../@shared'
 import { nestedSchemas as nested, requestValidationRules as rules } from '../../@shared'
 
 const resendVerificationEmailSchema = z.object({
-  data: z.object({
-    email: rules.data.email,
-  }).strict(),
+  email: rules.data.email,
   captcha: nested.captcha.strict(),
   preferences: nested.preferences.optional(),
 }).strict()

--- a/src/routes/auth/reset-password/__tests__/endpoint.test.ts
+++ b/src/routes/auth/reset-password/__tests__/endpoint.test.ts
@@ -34,10 +34,8 @@ describe('Reset Password Endpoint', () => {
   })
 
   const validPayload = {
-    data: {
-      token: '1'.repeat(TOKEN_LENGTH),
-      password: 'NewSecure@123',
-    },
+    token: '1'.repeat(TOKEN_LENGTH),
+    password: 'NewSecure@123',
   }
 
   describe('POST /auth/reset-password', () => {
@@ -49,11 +47,10 @@ describe('Reset Password Endpoint', () => {
       const data = await res.json()
       expect(data).toEqual({ user: { id: testUuids.USER_1 }, accessToken: 'test-token' })
 
-      expect(mockResetPassword).toHaveBeenCalledWith({
-        token: validPayload.data.token,
-        password: validPayload.data.password,
-        deviceInfo: { ipAddress: null, userAgent: null },
-      })
+      expect(mockResetPassword).toHaveBeenCalledWith(
+        { token: validPayload.token, password: validPayload.password },
+        { ipAddress: null, userAgent: null },
+      )
       expect(mockResetPassword).toHaveBeenCalledTimes(1)
 
       // Verify refresh token cookie is set
@@ -80,11 +77,11 @@ describe('Reset Password Endpoint', () => {
       ]
 
       for (const testCase of invalidTokens) {
-        const payload: any = { data: { ...validPayload.data } }
+        const payload: any = { ...validPayload }
         if (testCase.token !== null) {
-          payload.data.token = testCase.token
+          payload.token = testCase.token
         } else {
-          delete payload.data.token
+          delete payload.token
         }
 
         const res = await post(app, RESET_PASSWORD_URL, payload)
@@ -104,11 +101,11 @@ describe('Reset Password Endpoint', () => {
       ]
 
       for (const testCase of invalidPasswords) {
-        const payload: any = { data: { ...validPayload.data } }
+        const payload: any = { ...validPayload }
         if (testCase.password !== null) {
-          payload.data.password = testCase.password
+          payload.password = testCase.password
         } else {
-          delete payload.data.password
+          delete payload.password
         }
 
         const res = await post(app, RESET_PASSWORD_URL, payload)

--- a/src/routes/auth/reset-password/handler.ts
+++ b/src/routes/auth/reset-password/handler.ts
@@ -3,7 +3,7 @@ import resetPassword from '@/use-cases/auth/reset-password'
 
 import type { ResetPasswordCtx } from './schema'
 
-const resetPasswordHandler = async (c: ResetPasswordCtx) => {
+export const resetPasswordHandler = async (c: ResetPasswordCtx) => {
   const payload = c.req.valid('json')
   const deviceInfo = getDeviceInfo(c)
 
@@ -13,5 +13,3 @@ const resetPasswordHandler = async (c: ResetPasswordCtx) => {
 
   return c.json(result.data, HttpStatus.OK)
 }
-
-export default resetPasswordHandler

--- a/src/routes/auth/reset-password/handler.ts
+++ b/src/routes/auth/reset-password/handler.ts
@@ -4,10 +4,10 @@ import resetPassword from '@/use-cases/auth/reset-password'
 import type { ResetPasswordCtx } from './schema'
 
 export const resetPasswordHandler = async (c: ResetPasswordCtx) => {
-  const payload = c.req.valid('json')
+  const { token, password } = c.req.valid('json')
   const deviceInfo = getDeviceInfo(c)
 
-  const result = await resetPassword({ ...payload.data, deviceInfo })
+  const result = await resetPassword({ token, password }, deviceInfo)
 
   setRefreshCookie(c, result.refreshToken)
 

--- a/src/routes/auth/reset-password/index.ts
+++ b/src/routes/auth/reset-password/index.ts
@@ -4,7 +4,7 @@ import type { AppContext } from '@/context'
 
 import { requestValidator } from '@/middleware'
 
-import handler from './handler'
+import { resetPasswordHandler } from './handler'
 import schema from './schema'
 
 const resetPasswordRoute = new Hono<AppContext>()
@@ -12,7 +12,7 @@ const resetPasswordRoute = new Hono<AppContext>()
 resetPasswordRoute.post(
   '/reset-password',
   requestValidator('json', schema),
-  handler,
+  resetPasswordHandler,
 )
 
 export default resetPasswordRoute

--- a/src/routes/auth/reset-password/schema.ts
+++ b/src/routes/auth/reset-password/schema.ts
@@ -5,10 +5,8 @@ import type { ValidatedJsonCtx } from '../../@shared'
 import { requestValidationRules as rules } from '../../@shared'
 
 const resetPasswordSchema = z.object({
-  data: z.object({
-    token: rules.data.securityToken,
-    password: rules.data.password,
-  }).strict(),
+  token: rules.data.securityToken,
+  password: rules.data.password,
 }).strict()
 
 export type ResetPasswordBody = z.infer<typeof resetPasswordSchema>

--- a/src/routes/auth/signup/__tests__/endpoint.test.ts
+++ b/src/routes/auth/signup/__tests__/endpoint.test.ts
@@ -71,12 +71,10 @@ describe('Signup Endpoint', () => {
   describe('POST /auth/signup', () => {
     it('should set cookie with JWT token on successful signup', async () => {
       const validPayload = {
-        data: {
-          firstName: 'John',
-          lastName: 'Doe',
-          email: 'test@example.com',
-          password: 'ValidPass123!',
-        },
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'test@example.com',
+        password: 'ValidPass123!',
         captcha: { token: VALID_CAPTCHA_TOKEN },
       }
 
@@ -112,12 +110,10 @@ describe('Signup Endpoint', () => {
 
     it('should pass preferences to use-case when provided', async () => {
       const validPayload = {
-        data: {
-          firstName: 'John',
-          lastName: 'Doe',
-          email: 'test@example.com',
-          password: 'ValidPass123!',
-        },
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'test@example.com',
+        password: 'ValidPass123!',
         captcha: { token: VALID_CAPTCHA_TOKEN },
         preferences: { locale: 'uk', theme: 'dark' },
       }
@@ -135,12 +131,12 @@ describe('Signup Endpoint', () => {
 
     it('should validate required field formats', async () => {
       const invalidData = [
-        { data: { firstName: '', lastName: 'Doe', email: 'test@example.com', password: 'ValidPass123!' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // empty firstName
-        { data: { firstName: 'John', lastName: 'X', email: 'test@example.com', password: 'ValidPass123!' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // lastName too short (1 char)
-        { data: { firstName: 'John', lastName: 'Doe', email: 'invalid', password: 'ValidPass123!' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // invalid email format
-        { data: { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'short' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // password too short
-        { data: { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'NoNumbers!' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // password missing numbers
-        { data: { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'NoSpecial123' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // password missing special chars
+        { firstName: '', lastName: 'Doe', email: 'test@example.com', password: 'ValidPass123!', captcha: { token: VALID_CAPTCHA_TOKEN } }, // empty firstName
+        { firstName: 'John', lastName: 'X', email: 'test@example.com', password: 'ValidPass123!', captcha: { token: VALID_CAPTCHA_TOKEN } }, // lastName too short (1 char)
+        { firstName: 'John', lastName: 'Doe', email: 'invalid', password: 'ValidPass123!', captcha: { token: VALID_CAPTCHA_TOKEN } }, // invalid email format
+        { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'short', captcha: { token: VALID_CAPTCHA_TOKEN } }, // password too short
+        { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'NoNumbers!', captcha: { token: VALID_CAPTCHA_TOKEN } }, // password missing numbers
+        { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'NoSpecial123', captcha: { token: VALID_CAPTCHA_TOKEN } }, // password missing special chars
       ]
 
       for (const body of invalidData) {
@@ -154,10 +150,10 @@ describe('Signup Endpoint', () => {
 
     it('should require all required fields', async () => {
       const incompleteRequests = [
-        { data: { lastName: 'Doe', email: 'test@example.com', password: 'ValidPass123!' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing firstName
-        { data: { firstName: 'John', password: 'ValidPass123!' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing lastName and email
-        { data: { firstName: 'John', lastName: 'Doe', email: 'test@example.com' }, captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing password
-        { captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing data object
+        { lastName: 'Doe', email: 'test@example.com', password: 'ValidPass123!', captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing firstName
+        { firstName: 'John', password: 'ValidPass123!', captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing lastName and email
+        { firstName: 'John', lastName: 'Doe', email: 'test@example.com', captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing password
+        { captcha: { token: VALID_CAPTCHA_TOKEN } }, // missing all fields
         {}, // completely empty
       ]
 
@@ -172,12 +168,10 @@ describe('Signup Endpoint', () => {
 
     it('should handle malformed requests', async () => {
       const validPayload = {
-        data: {
-          firstName: 'John',
-          lastName: 'Doe',
-          email: 'test@example.com',
-          password: 'ValidPass123!',
-        },
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'test@example.com',
+        password: 'ValidPass123!',
         captcha: { token: VALID_CAPTCHA_TOKEN },
       }
 
@@ -200,12 +194,10 @@ describe('Signup Endpoint', () => {
       })
 
       const res = await post(app, SIGNUP_URL, {
-        data: {
-          firstName: 'John',
-          lastName: 'Doe',
-          email: 'test@example.com',
-          password: 'ValidPass123!',
-        },
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'test@example.com',
+        password: 'ValidPass123!',
         captcha: { token: VALID_CAPTCHA_TOKEN },
       })
 

--- a/src/routes/auth/signup/handler.ts
+++ b/src/routes/auth/signup/handler.ts
@@ -4,13 +4,13 @@ import signUpWithEmail from '@/use-cases/auth/signup'
 import type { SignupCtx } from './schema'
 
 export const signupHandler = async (c: SignupCtx) => {
-  const payload = c.req.valid('json')
+  const { firstName, lastName, email, password, preferences } = c.req.valid('json')
   const deviceInfo = getDeviceInfo(c)
 
   const result = await signUpWithEmail(
-    payload.data,
+    { firstName, lastName, email, password },
     deviceInfo,
-    payload.preferences,
+    preferences,
   )
 
   setRefreshCookie(c, result.refreshToken)

--- a/src/routes/auth/signup/handler.ts
+++ b/src/routes/auth/signup/handler.ts
@@ -3,7 +3,7 @@ import signUpWithEmail from '@/use-cases/auth/signup'
 
 import type { SignupCtx } from './schema'
 
-const signupHandler = async (c: SignupCtx) => {
+export const signupHandler = async (c: SignupCtx) => {
   const payload = c.req.valid('json')
   const deviceInfo = getDeviceInfo(c)
 
@@ -17,5 +17,3 @@ const signupHandler = async (c: SignupCtx) => {
 
   return c.json(result.data, HttpStatus.CREATED)
 }
-
-export default signupHandler

--- a/src/routes/auth/signup/index.ts
+++ b/src/routes/auth/signup/index.ts
@@ -4,7 +4,7 @@ import type { AppContext } from '@/context'
 
 import { captchaMiddleware, requestValidator } from '@/middleware'
 
-import handler from './handler'
+import { signupHandler } from './handler'
 import schema from './schema'
 
 const signupRoute = new Hono<AppContext>()
@@ -13,7 +13,7 @@ signupRoute.post(
   '/signup',
   requestValidator('json', schema),
   captchaMiddleware(),
-  handler,
+  signupHandler,
 )
 
 export default signupRoute

--- a/src/routes/auth/signup/schema.ts
+++ b/src/routes/auth/signup/schema.ts
@@ -5,12 +5,10 @@ import type { ValidatedJsonCtx } from '../../@shared'
 import { nestedSchemas as nested, requestValidationRules as rules } from '../../@shared'
 
 const signupSchema = z.object({
-  data: z.object({
-    firstName: rules.data.firstName,
-    lastName: rules.data.lastName.optional(),
-    email: rules.data.email,
-    password: rules.data.password,
-  }).strict(),
+  firstName: rules.data.firstName,
+  lastName: rules.data.lastName.optional(),
+  email: rules.data.email,
+  password: rules.data.password,
   captcha: nested.captcha.strict(),
   preferences: nested.preferences.optional(),
 }).strict()

--- a/src/routes/auth/verify-email/__tests__/endpoint.test.ts
+++ b/src/routes/auth/verify-email/__tests__/endpoint.test.ts
@@ -49,7 +49,7 @@ describe('Verify Email Endpoint', () => {
     it('should return user and token on successful email verification', async () => {
       const validToken = 'a'.repeat(64)
 
-      const res = await post(app, VERIFY_EMAIL_URL, { data: { token: validToken } })
+      const res = await post(app, VERIFY_EMAIL_URL, { token: validToken })
 
       expect(res.status).toBe(HttpStatus.OK)
 
@@ -76,7 +76,7 @@ describe('Verify Email Endpoint', () => {
     })
 
     it('should require token parameter', async () => {
-      const res = await post(app, VERIFY_EMAIL_URL, { data: {} })
+      const res = await post(app, VERIFY_EMAIL_URL, {})
 
       expect(res.status).toBe(HttpStatus.BAD_REQUEST)
       const json = await res.json()
@@ -93,7 +93,7 @@ describe('Verify Email Endpoint', () => {
       ]
 
       for (const token of invalidTokens) {
-        const res = await post(app, VERIFY_EMAIL_URL, { data: { token } })
+        const res = await post(app, VERIFY_EMAIL_URL, { token })
 
         expect(res.status).toBe(HttpStatus.BAD_REQUEST)
         const json = await res.json()
@@ -105,7 +105,7 @@ describe('Verify Email Endpoint', () => {
       const validToken = 'a'.repeat(64)
 
       const scenarios: Array<{ name: string, headers?: Record<string, string>, body?: any }> = [
-        { name: 'missing Content-Type', headers: {}, body: { data: { token: validToken } } },
+        { name: 'missing Content-Type', headers: {}, body: { token: validToken } },
         { name: 'malformed JSON', headers: { 'Content-Type': 'application/json' }, body: '{ invalid json' },
         { name: 'missing request body', headers: { 'Content-Type': 'application/json' }, body: '' },
       ]
@@ -124,7 +124,7 @@ describe('Verify Email Endpoint', () => {
 
       const validToken = 'c'.repeat(64)
 
-      const res = await post(app, VERIFY_EMAIL_URL, { data: { token: validToken } })
+      const res = await post(app, VERIFY_EMAIL_URL, { token: validToken })
 
       expect(res.status).toBe(HttpStatus.INTERNAL_SERVER_ERROR)
       expect(mockVerifyEmail).toHaveBeenCalledTimes(1)

--- a/src/routes/auth/verify-email/handler.ts
+++ b/src/routes/auth/verify-email/handler.ts
@@ -4,10 +4,10 @@ import verifyEmail from '@/use-cases/auth/verify-email'
 import type { VerifyEmailCtx } from './schema'
 
 export const verifyEmailHandler = async (c: VerifyEmailCtx) => {
-  const payload = c.req.valid('json')
+  const { token } = c.req.valid('json')
   const deviceInfo = getDeviceInfo(c)
 
-  const result = await verifyEmail(payload.data, deviceInfo)
+  const result = await verifyEmail({ token }, deviceInfo)
 
   setRefreshCookie(c, result.refreshToken)
 

--- a/src/routes/auth/verify-email/handler.ts
+++ b/src/routes/auth/verify-email/handler.ts
@@ -3,7 +3,7 @@ import verifyEmail from '@/use-cases/auth/verify-email'
 
 import type { VerifyEmailCtx } from './schema'
 
-const verifyEmailHandler = async (c: VerifyEmailCtx) => {
+export const verifyEmailHandler = async (c: VerifyEmailCtx) => {
   const payload = c.req.valid('json')
   const deviceInfo = getDeviceInfo(c)
 
@@ -13,5 +13,3 @@ const verifyEmailHandler = async (c: VerifyEmailCtx) => {
 
   return c.json(result.data, HttpStatus.OK)
 }
-
-export default verifyEmailHandler

--- a/src/routes/auth/verify-email/index.ts
+++ b/src/routes/auth/verify-email/index.ts
@@ -4,7 +4,7 @@ import type { AppContext } from '@/context'
 
 import { requestValidator } from '@/middleware'
 
-import handler from './handler'
+import { verifyEmailHandler } from './handler'
 import schema from './schema'
 
 const verifyEmailRoute = new Hono<AppContext>()
@@ -12,7 +12,7 @@ const verifyEmailRoute = new Hono<AppContext>()
 verifyEmailRoute.post(
   '/verify-email',
   requestValidator('json', schema),
-  handler,
+  verifyEmailHandler,
 )
 
 export default verifyEmailRoute

--- a/src/routes/auth/verify-email/schema.ts
+++ b/src/routes/auth/verify-email/schema.ts
@@ -5,9 +5,7 @@ import type { ValidatedJsonCtx } from '../../@shared'
 import { requestValidationRules as rules } from '../../@shared'
 
 const verifyEmailSchema = z.object({
-  data: z.object({
-    token: rules.data.securityToken,
-  }).strict(),
+  token: rules.data.securityToken,
 }).strict()
 
 export type VerifyEmailBody = z.infer<typeof verifyEmailSchema>

--- a/src/routes/owner/admins/invites/__tests__/handler.test.ts
+++ b/src/routes/owner/admins/invites/__tests__/handler.test.ts
@@ -6,9 +6,9 @@ import { ModuleMocker, testUuids } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { Role, Status } from '@/types'
 
-import { createInvitationHandler, resendInvitationHandler } from '../handler'
+import { createInviteHandler, resendInviteHandler } from '../handler'
 
-describe('createInvitationHandler', () => {
+describe('createInviteHandler', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
   let mockContext: any
@@ -63,13 +63,13 @@ describe('createInvitationHandler', () => {
   })
 
   it('should call inviteAdmin with correct body parameters', async () => {
-    await createInvitationHandler(mockContext)
+    await createInviteHandler(mockContext)
 
     expect(mockInviteAdmin).toHaveBeenCalledWith(inviteAdminBody, testUuids.OWNER_1)
   })
 
   it('should return created admin with CREATED status', async () => {
-    const result = await createInvitationHandler(mockContext)
+    const result = await createInviteHandler(mockContext)
 
     expect(mockJson).toHaveBeenCalledWith({ admin: mockAdmin }, HttpStatus.CREATED)
     expect(result.status).toBe(HttpStatus.CREATED)
@@ -80,11 +80,11 @@ describe('createInvitationHandler', () => {
       throw new Error('Email already in use')
     })
 
-    expect(createInvitationHandler(mockContext)).rejects.toThrow('Email already in use')
+    expect(createInviteHandler(mockContext)).rejects.toThrow('Email already in use')
   })
 })
 
-describe('resendInvitationHandler', () => {
+describe('resendInviteHandler', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
   let mockContext: any
@@ -114,13 +114,13 @@ describe('resendInvitationHandler', () => {
   })
 
   it('should call resendAdminInvitation with admin id and inviter id', async () => {
-    await resendInvitationHandler(mockContext)
+    await resendInviteHandler(mockContext)
 
     expect(mockResendAdminInvitation).toHaveBeenCalledWith(testUuids.ADMIN_1, testUuids.OWNER_1)
   })
 
   it('should return success with OK status', async () => {
-    const result = await resendInvitationHandler(mockContext)
+    const result = await resendInviteHandler(mockContext)
 
     expect(mockJson).toHaveBeenCalledWith({ success: true }, HttpStatus.OK)
     expect(result.status).toBe(HttpStatus.OK)
@@ -131,6 +131,6 @@ describe('resendInvitationHandler', () => {
       throw new Error('Admin not found')
     })
 
-    expect(resendInvitationHandler(mockContext)).rejects.toThrow('Admin not found')
+    expect(resendInviteHandler(mockContext)).rejects.toThrow('Admin not found')
   })
 })

--- a/src/routes/owner/admins/invites/handler.ts
+++ b/src/routes/owner/admins/invites/handler.ts
@@ -3,7 +3,7 @@ import { inviteAdmin, resendAdminInvitation } from '@/use-cases/owner'
 
 import type { InviteAdminCtx, ResendAdminInviteCtx } from './schema'
 
-export const createInvitationHandler = async (c: InviteAdminCtx) => {
+export const createInviteHandler = async (c: InviteAdminCtx) => {
   const body = c.req.valid('json')
   const { id: inviterId } = c.get('user')
 
@@ -12,7 +12,7 @@ export const createInvitationHandler = async (c: InviteAdminCtx) => {
   return c.json(result, HttpStatus.CREATED)
 }
 
-export const resendInvitationHandler = async (c: ResendAdminInviteCtx) => {
+export const resendInviteHandler = async (c: ResendAdminInviteCtx) => {
   const { adminId } = c.req.valid('param')
   const { id: inviterId } = c.get('user')
 

--- a/src/routes/owner/admins/invites/index.ts
+++ b/src/routes/owner/admins/invites/index.ts
@@ -4,7 +4,7 @@ import type { AppContext } from '@/context'
 
 import { requestValidator } from '@/middleware'
 
-import { createInvitationHandler, resendInvitationHandler } from './handler'
+import { createInviteHandler, resendInviteHandler } from './handler'
 import { inviteAdminBodySchema, resendAdminInviteParamsSchema } from './schema'
 
 const adminsInvitesRoute = new Hono<AppContext>()
@@ -12,13 +12,13 @@ const adminsInvitesRoute = new Hono<AppContext>()
 adminsInvitesRoute.post(
   '/admins/invites',
   requestValidator('json', inviteAdminBodySchema),
-  createInvitationHandler,
+  createInviteHandler,
 )
 
 adminsInvitesRoute.post(
   '/admins/invites/:adminId/resend',
   requestValidator('param', resendAdminInviteParamsSchema),
-  resendInvitationHandler,
+  resendInviteHandler,
 )
 
 export default adminsInvitesRoute

--- a/src/routes/user/me/__tests__/endpoint.test.ts
+++ b/src/routes/user/me/__tests__/endpoint.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { User } from '@/data'
 import type { UserClaims } from '@/security/jwt'
 
-import { createTestApp, ModuleMocker, post, testUuids } from '@/__tests__'
+import { createTestApp, ModuleMocker, patch, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { HttpStatus } from '@/net/http'
 import { Role, Status } from '@/types'
@@ -174,9 +174,9 @@ describe('Me Endpoint', () => {
     })
   })
 
-  describe('POST /me', () => {
+  describe('PATCH /me', () => {
     it('should update user profile successfully', async () => {
-      const res = await post(app, ME_URL, { data: { firstName: 'Jane', lastName: 'Smith' } }, {
+      const res = await patch(app, ME_URL, { data: { firstName: 'Jane', lastName: 'Smith' } }, {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer mock-token',
       })
@@ -214,7 +214,7 @@ describe('Me Endpoint', () => {
         throw new AppError(ErrorCode.InternalError, 'Failed to update user.')
       })
 
-      const res = await post(app, ME_URL, { data: { firstName: 'Jane', lastName: 'Smith' } }, {
+      const res = await patch(app, ME_URL, { data: { firstName: 'Jane', lastName: 'Smith' } }, {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer mock-token',
       })
@@ -226,7 +226,7 @@ describe('Me Endpoint', () => {
     })
 
     it('should validate input data - empty strings', async () => {
-      const res = await post(app, ME_URL, { data: { firstName: '', lastName: '' } }, { // empty strings should fail validation
+      const res = await patch(app, ME_URL, { data: { firstName: '', lastName: '' } }, { // empty strings should fail validation
         'Content-Type': 'application/json',
         'Authorization': 'Bearer mock-token',
       })
@@ -239,7 +239,7 @@ describe('Me Endpoint', () => {
     })
 
     it('should allow partial updates with only firstName', async () => {
-      const res = await post(app, ME_URL, { data: { firstName: 'Jane' } }, { // only firstName
+      const res = await patch(app, ME_URL, { data: { firstName: 'Jane' } }, { // only firstName
         'Content-Type': 'application/json',
         'Authorization': 'Bearer mock-token',
       })
@@ -259,7 +259,7 @@ describe('Me Endpoint', () => {
     it('should handle valid names with minimum length', async () => {
       mockUpdateUser.mockImplementation(async () => ({ user: mockUpdatedUserMinimal }))
 
-      const res = await post(app, ME_URL, {
+      const res = await patch(app, ME_URL, {
         data: {
           firstName: mockUpdatedUserMinimal.firstName,
           lastName: mockUpdatedUserMinimal.lastName,
@@ -294,7 +294,7 @@ describe('Me Endpoint', () => {
         return { user: mockUpdatedUser }
       })
 
-      const res = await post(app, ME_URL, { data: {} }, {
+      const res = await patch(app, ME_URL, { data: {} }, {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer mock-token',
       })
@@ -312,7 +312,7 @@ describe('Me Endpoint', () => {
     })
 
     it('should normalize null lastName to empty string', async () => {
-      const res = await post(app, ME_URL, { data: { firstName: 'Jane', lastName: null } }, {
+      const res = await patch(app, ME_URL, { data: { firstName: 'Jane', lastName: null } }, {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer mock-token',
       })
@@ -328,7 +328,7 @@ describe('Me Endpoint', () => {
     })
 
     it('should allow updating only lastName', async () => {
-      const res = await post(app, ME_URL, { data: { lastName: 'Smith' } }, { // only lastName
+      const res = await patch(app, ME_URL, { data: { lastName: 'Smith' } }, { // only lastName
         'Content-Type': 'application/json',
         'Authorization': 'Bearer mock-token',
       })
@@ -346,7 +346,7 @@ describe('Me Endpoint', () => {
     })
 
     it('should reject empty strings at validation level', async () => {
-      const res = await post(app, ME_URL, { data: { firstName: '', lastName: 'Smith' } }, { // empty string for firstName
+      const res = await patch(app, ME_URL, { data: { firstName: '', lastName: 'Smith' } }, { // empty string for firstName
         'Content-Type': 'application/json',
         'Authorization': 'Bearer mock-token',
       })
@@ -358,7 +358,7 @@ describe('Me Endpoint', () => {
     })
 
     it('should reject whitespace-only strings at validation level', async () => {
-      const res = await post(app, ME_URL, { data: { firstName: '   ', lastName: 'Smith' } }, {
+      const res = await patch(app, ME_URL, { data: { firstName: '   ', lastName: 'Smith' } }, {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer mock-token',
       })
@@ -368,7 +368,7 @@ describe('Me Endpoint', () => {
     })
 
     it('should trim valid strings at validation layer', async () => {
-      const res = await post(app, ME_URL, { data: { firstName: '  Jane  ', lastName: '  Smith  ' } }, {
+      const res = await patch(app, ME_URL, { data: { firstName: '  Jane  ', lastName: '  Smith  ' } }, {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer mock-token',
       })

--- a/src/routes/user/me/handler.ts
+++ b/src/routes/user/me/handler.ts
@@ -3,7 +3,7 @@ import { getUser, updateUser } from '@/use-cases/user/me'
 import type { AppCtx } from '../../@shared'
 import type { UpdateProfileCtx } from './schema'
 
-const getHandler = async (c: AppCtx) => {
+export const getMeHandler = async (c: AppCtx) => {
   const user = c.get('user')
 
   const result = await getUser(user.id)
@@ -11,7 +11,7 @@ const getHandler = async (c: AppCtx) => {
   return c.json(result)
 }
 
-const postHandler = async (c: UpdateProfileCtx) => {
+export const updateMeHandler = async (c: UpdateProfileCtx) => {
   const user = c.get('user')
   const payload = c.req.valid('json')
 
@@ -19,5 +19,3 @@ const postHandler = async (c: UpdateProfileCtx) => {
 
   return c.json(result)
 }
-
-export { getHandler, postHandler }

--- a/src/routes/user/me/index.ts
+++ b/src/routes/user/me/index.ts
@@ -4,12 +4,12 @@ import type { AppContext } from '@/context'
 
 import { requestValidator } from '@/middleware'
 
-import { getHandler, postHandler } from './handler'
+import { getMeHandler, updateMeHandler } from './handler'
 import updateProfileSchema from './schema'
 
 const meRoute = new Hono<AppContext>()
 
-meRoute.get('/me', getHandler)
-meRoute.post('/me', requestValidator('json', updateProfileSchema), postHandler)
+meRoute.get('/me', getMeHandler)
+meRoute.patch('/me', requestValidator('json', updateProfileSchema), updateMeHandler)
 
 export default meRoute

--- a/src/use-cases/auth/__tests__/accept-invite.test.ts
+++ b/src/use-cases/auth/__tests__/accept-invite.test.ts
@@ -133,11 +133,10 @@ describe('Accept Invite', () => {
 
   describe('when token is valid and active', () => {
     it('should validate token, hash password, mark token as used, update password, activate user, and return user with tokens', async () => {
-      const result = await acceptInvite({
-        token: mockTokenString,
-        password: mockPassword,
-        deviceInfo: mockDeviceInfo,
-      })
+      const result = await acceptInvite(
+        { token: mockTokenString, password: mockPassword },
+        mockDeviceInfo,
+      )
 
       expect(mockTokenRepo.findByToken).toHaveBeenCalledWith(mockTokenString)
       expect(mockTokenRepo.findByToken).toHaveBeenCalledTimes(1)
@@ -182,7 +181,8 @@ describe('Accept Invite', () => {
 
       try {
         await acceptInvite(
-          { token: 'invalid-token', password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: 'invalid-token', password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false)
       } catch (error) {
@@ -205,7 +205,8 @@ describe('Accept Invite', () => {
 
       try {
         await acceptInvite(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false)
       } catch (error) {
@@ -228,7 +229,8 @@ describe('Accept Invite', () => {
 
       try {
         await acceptInvite(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false)
       } catch (error) {
@@ -251,7 +253,8 @@ describe('Accept Invite', () => {
 
       try {
         await acceptInvite(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false)
       } catch (error) {
@@ -274,7 +277,8 @@ describe('Accept Invite', () => {
 
       try {
         await acceptInvite(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false)
       } catch (error) {
@@ -297,7 +301,8 @@ describe('Accept Invite', () => {
 
       try {
         await acceptInvite(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false)
       } catch (error) {
@@ -320,7 +325,8 @@ describe('Accept Invite', () => {
 
       try {
         await acceptInvite(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false)
       } catch (error) {
@@ -343,7 +349,8 @@ describe('Accept Invite', () => {
 
       try {
         await acceptInvite(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false)
       } catch (error) {
@@ -361,7 +368,7 @@ describe('Accept Invite', () => {
   describe('edge cases', () => {
     it('should handle empty password', async () => {
       try {
-        await acceptInvite({ token: mockTokenString, password: '', deviceInfo: mockDeviceInfo })
+        await acceptInvite({ token: mockTokenString, password: '' }, mockDeviceInfo)
         expect(true).toBe(false)
       } catch (error) {
         expect(error).toBeDefined()
@@ -371,11 +378,10 @@ describe('Accept Invite', () => {
     it('should handle very long passwords', async () => {
       const longPassword = `A1@${'a'.repeat(1000)}`
 
-      const result = await acceptInvite({
-        token: mockTokenString,
-        password: longPassword,
-        deviceInfo: mockDeviceInfo,
-      })
+      const result = await acceptInvite(
+        { token: mockTokenString, password: longPassword },
+        mockDeviceInfo,
+      )
 
       expect(result).toEqual({
         data: { user: mockActivatedUser, accessToken: mockAccessToken },

--- a/src/use-cases/auth/__tests__/reset-password.test.ts
+++ b/src/use-cases/auth/__tests__/reset-password.test.ts
@@ -126,11 +126,10 @@ describe('Reset Password', () => {
 
   describe('when token is valid and active', () => {
     it('should validate token, hash password, mark token as used, update password, and return user with tokens', async () => {
-      const result = await resetPassword({
-        token: mockTokenString,
-        password: mockPassword,
-        deviceInfo: mockDeviceInfo,
-      })
+      const result = await resetPassword(
+        { token: mockTokenString, password: mockPassword },
+        mockDeviceInfo,
+      )
 
       expect(mockTokenRepo.findByToken).toHaveBeenCalledWith(mockTokenString)
       expect(mockTokenRepo.findByToken).toHaveBeenCalledTimes(1)
@@ -170,7 +169,8 @@ describe('Reset Password', () => {
 
       try {
         await resetPassword(
-          { token: 'invalid-token', password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: 'invalid-token', password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false) // should not reach here
       } catch (error) {
@@ -192,7 +192,8 @@ describe('Reset Password', () => {
 
       try {
         await resetPassword(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false) // should not reach here
       } catch (error) {
@@ -214,7 +215,8 @@ describe('Reset Password', () => {
 
       try {
         await resetPassword(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false) // should not reach here
       } catch (error) {
@@ -236,7 +238,8 @@ describe('Reset Password', () => {
 
       try {
         await resetPassword(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false) // should not reach here
       } catch (error) {
@@ -258,7 +261,8 @@ describe('Reset Password', () => {
 
       try {
         await resetPassword(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false) // should not reach here
       } catch (error) {
@@ -280,7 +284,8 @@ describe('Reset Password', () => {
 
       try {
         await resetPassword(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false) // should not reach here
       } catch (error) {
@@ -302,7 +307,8 @@ describe('Reset Password', () => {
 
       try {
         await resetPassword(
-          { token: mockTokenString, password: mockPassword, deviceInfo: mockDeviceInfo },
+          { token: mockTokenString, password: mockPassword },
+          mockDeviceInfo,
         )
         expect(true).toBe(false) // should not reach here
       } catch (error) {
@@ -319,7 +325,7 @@ describe('Reset Password', () => {
   describe('edge cases', () => {
     it('should handle empty password', async () => {
       try {
-        await resetPassword({ token: mockTokenString, password: '', deviceInfo: mockDeviceInfo })
+        await resetPassword({ token: mockTokenString, password: '' }, mockDeviceInfo)
         expect(true).toBe(false) // should not reach here due to validation
       } catch (error) {
         // This would be caught by the validation layer before reaching this function
@@ -330,11 +336,10 @@ describe('Reset Password', () => {
     it('should handle very long passwords', async () => {
       const longPassword = `A1@${'a'.repeat(1000)}` // very long password
 
-      const result = await resetPassword({
-        token: mockTokenString,
-        password: longPassword,
-        deviceInfo: mockDeviceInfo,
-      })
+      const result = await resetPassword(
+        { token: mockTokenString, password: longPassword },
+        mockDeviceInfo,
+      )
 
       expect(result).toEqual({
         data: { user: mockUser, accessToken: mockAccessToken },

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -13,10 +13,9 @@ import {
 } from '@/security/token'
 import Status from '@/types/status'
 
-interface AcceptInviteParams {
+export interface AcceptInviteParams {
   token: string
   password: string
-  deviceInfo: DeviceInfo
 }
 
 const validateToken = async (token: string) => {
@@ -49,7 +48,8 @@ const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
 }
 
 const acceptInvite = async (
-  { token, password, deviceInfo }: AcceptInviteParams,
+  { token, password }: AcceptInviteParams,
+  deviceInfo: DeviceInfo,
 ) => {
   const validatedToken = await validateToken(token)
 

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -12,10 +12,9 @@ import {
   TokenValidator,
 } from '@/security/token'
 
-interface ResetPasswordParams {
+export interface ResetPasswordParams {
   token: string
   password: string
-  deviceInfo: DeviceInfo
 }
 
 const validateToken = async (token: string) => {
@@ -48,7 +47,8 @@ const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
 }
 
 const resetPassword = async (
-  { token, password, deviceInfo }: ResetPasswordParams,
+  { token, password }: ResetPasswordParams,
+  deviceInfo: DeviceInfo,
 ) => {
   const validatedToken = await validateToken(token)
 


### PR DESCRIPTION
## Summary
- Flatten auth request bodies (remove `data` wrapper, keep `captcha` as top-level object)
- Replace default exports with named exports in all auth handlers
- Standardize route handler naming convention (e.g., `loginHandler`, `signupHandler`)
- Use PATCH method for update operations
- Pass `deviceInfo` as separate argument to use-cases (not inside params object)

## Test plan
- [x] All 238 auth tests pass
- [x] Lint passes
- [x] No breaking changes to response structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)