### PR TITLE
Add team info to user responses

### DIFF
--- a/src/data/migrations/0001_keen_thunderball.sql
+++ b/src/data/migrations/0001_keen_thunderball.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "teams" DROP CONSTRAINT "teams_name_unique";

--- a/src/data/migrations/meta/0001_snapshot.json
+++ b/src/data/migrations/meta/0001_snapshot.json
@@ -1,0 +1,945 @@
+{
+  "id": "031af53a-2e55-4a26-be1a-f3c1ed26bcc0",
+  "prevId": "e85f4865-ee10-4309-9d71-b8d961081112",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth": {
+      "name": "auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "auth_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_auth": {
+          "name": "unique_auth",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_id_index": {
+          "name": "auth_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_user_id_users_id_fk": {
+          "name": "auth_user_id_users_id_fk",
+          "tableFrom": "auth",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "resource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_permission": {
+          "name": "unique_permission",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_role_permission": {
+          "name": "unique_role_permission",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_active_index": {
+          "name": "refresh_tokens_user_active_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_cleanup_index": {
+          "name": "refresh_tokens_cleanup_index",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_team_member": {
+          "name": "unique_team_member",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_members_team_index": {
+          "name": "team_members_team_index",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_members_user_index": {
+          "name": "team_members_user_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_invited_by_users_id_fk": {
+          "name": "team_members_invited_by_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_website_unique": {
+          "name": "teams_website_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "website"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "token_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "token_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_type_index": {
+          "name": "user_type_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tokens_status_expires_index": {
+          "name": "tokens_status_expires_index",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_unique": {
+          "name": "tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_invited_by_users_id_fk": {
+          "name": "user_roles_invited_by_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_provider": {
+      "name": "auth_provider",
+      "schema": "public",
+      "values": [
+        "local",
+        "google",
+        "github"
+      ]
+    },
+    "public.action": {
+      "name": "action",
+      "schema": "public",
+      "values": [
+        "view",
+        "create",
+        "edit",
+        "delete"
+      ]
+    },
+    "public.resource": {
+      "name": "resource",
+      "schema": "public",
+      "values": [
+        "users",
+        "admins"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "user"
+      ]
+    },
+    "public.token_status": {
+      "name": "token_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "used",
+        "deprecated",
+        "cancelled"
+      ]
+    },
+    "public.token_type": {
+      "name": "token_type",
+      "schema": "public",
+      "values": [
+        "email_verification",
+        "password_reset",
+        "refresh_token",
+        "user_invite"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "new",
+        "verified",
+        "trial",
+        "active",
+        "suspended",
+        "archived",
+        "pending"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/data/migrations/meta/_journal.json
+++ b/src/data/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1770573144545,
       "tag": "0000_furry_shotgun",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1770843818659,
+      "tag": "0001_keen_thunderball",
+      "breakpoints": true
     }
   ]
 }

--- a/src/data/repositories/team/index.ts
+++ b/src/data/repositories/team/index.ts
@@ -14,7 +14,6 @@ import {
   findTeamMemberById,
   findTeamMembers,
   findUserTeam,
-  findUserTeams,
   searchTeams,
 } from './queries'
 
@@ -33,7 +32,6 @@ export const teamRepo = {
   findMemberById: findTeamMemberById,
   findMembers: findTeamMembers,
   findUserTeam,
-  findUserTeams,
   removeMember: removeTeamMember,
   search: searchTeams,
   update: updateTeam,

--- a/src/data/repositories/team/index.ts
+++ b/src/data/repositories/team/index.ts
@@ -6,7 +6,6 @@ import {
 } from './mutations'
 import {
   findTeamById,
-  findTeamByName,
   findTeamMember,
   findTeamMembers,
   findTeamWithMembers,
@@ -26,7 +25,6 @@ const teamMutations = {
 const teamQueries = {
   find: findTeamWithMembers,
   findById: findTeamById,
-  findByName: findTeamByName,
   findUserTeam,
   search: searchTeams,
 }

--- a/src/data/repositories/team/index.ts
+++ b/src/data/repositories/team/index.ts
@@ -1,8 +1,6 @@
 import {
-  addTeamMember,
   createTeam,
-  deleteTeam,
-  removeTeamMember,
+  createTeamMember,
   updateTeam,
   updateTeamMember,
 } from './mutations'
@@ -20,18 +18,32 @@ export type { TeamSearchParams, TeamSearchResult } from './queries'
 
 export * from './types'
 
-export const teamRepo = {
-  addMember: addTeamMember,
+const teamMutations = {
   create: createTeam,
-  delete: deleteTeam,
+  update: updateTeam,
+}
+
+const teamQueries = {
   find: findTeamWithMembers,
   findById: findTeamById,
   findByName: findTeamByName,
+  findUserTeam,
+  search: searchTeams,
+}
+
+const memberMutations = {
+  createMember: createTeamMember,
+  updateMember: updateTeamMember,
+}
+
+const memberQueries = {
   findMember: findTeamMember,
   findMembers: findTeamMembers,
-  findUserTeam,
-  removeMember: removeTeamMember,
-  search: searchTeams,
-  update: updateTeam,
-  updateMember: updateTeamMember,
+}
+
+export const teamRepo = {
+  ...teamMutations,
+  ...teamQueries,
+  ...memberMutations,
+  ...memberQueries,
 }

--- a/src/data/repositories/team/index.ts
+++ b/src/data/repositories/team/index.ts
@@ -13,6 +13,7 @@ import {
   findTeamMember,
   findTeamMemberById,
   findTeamMembers,
+  findUserTeam,
   findUserTeams,
   searchTeams,
 } from './queries'
@@ -31,6 +32,7 @@ export const teamRepo = {
   findMember: findTeamMember,
   findMemberById: findTeamMemberById,
   findMembers: findTeamMembers,
+  findUserTeam,
   findUserTeams,
   removeMember: removeTeamMember,
   search: searchTeams,

--- a/src/data/repositories/team/index.ts
+++ b/src/data/repositories/team/index.ts
@@ -7,12 +7,11 @@ import {
   updateTeamMember,
 } from './mutations'
 import {
-  findTeam,
   findTeamById,
   findTeamByName,
   findTeamMember,
-  findTeamMemberById,
   findTeamMembers,
+  findTeamWithMembers,
   findUserTeam,
   searchTeams,
 } from './queries'
@@ -25,11 +24,10 @@ export const teamRepo = {
   addMember: addTeamMember,
   create: createTeam,
   delete: deleteTeam,
-  find: findTeam,
+  find: findTeamWithMembers,
   findById: findTeamById,
   findByName: findTeamByName,
   findMember: findTeamMember,
-  findMemberById: findTeamMemberById,
   findMembers: findTeamMembers,
   findUserTeam,
   removeMember: removeTeamMember,

--- a/src/data/repositories/team/mutations.ts
+++ b/src/data/repositories/team/mutations.ts
@@ -52,18 +52,7 @@ export const updateTeam = async (
   return team
 }
 
-export const deleteTeam = async (
-  teamId: string,
-  tx?: Database,
-): Promise<void> => {
-  const executor = tx || db
-
-  await executor
-    .delete(teamsTable)
-    .where(eq(teamsTable.id, teamId))
-}
-
-export const addTeamMember = async (
+export const createTeamMember = async (
   input: CreateTeamMemberInput,
   tx?: Database,
 ): Promise<TeamMember> => {
@@ -79,23 +68,6 @@ export const addTeamMember = async (
   }
 
   return membership
-}
-
-export const removeTeamMember = async (
-  userId: string,
-  teamId: string,
-  tx?: Database,
-): Promise<void> => {
-  const executor = tx || db
-
-  await executor
-    .delete(teamMembersTable)
-    .where(
-      and(
-        eq(teamMembersTable.userId, userId),
-        eq(teamMembersTable.teamId, teamId),
-      ),
-    )
 }
 
 export interface UpdateTeamMemberInput {

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -2,7 +2,7 @@ import { and, count, desc, eq, sql } from 'drizzle-orm'
 
 import type { Database } from '../../clients'
 import type { PaginatedResult, PaginationParams } from '../pagination'
-import type { Team, TeamMemberDetails, TeamMemberWithTeam, TeamWithMembers } from './types'
+import type { Team, TeamMemberDetails, TeamWithMembers } from './types'
 
 import { db } from '../../clients'
 import { teamMembersTable, teamsTable, usersTable } from '../../schema'
@@ -160,37 +160,6 @@ export const findTeamMember = async (
   return member
 }
 
-export const findUserTeams = async (
-  userId: string,
-  tx?: Database,
-): Promise<TeamMemberWithTeam[]> => {
-  const executor = tx || db
-
-  const results = await executor
-    .select({
-      id: teamMembersTable.id,
-      userId: teamMembersTable.userId,
-      teamId: teamMembersTable.teamId,
-      position: teamMembersTable.position,
-      invitedBy: teamMembersTable.invitedBy,
-      joinedAt: teamMembersTable.joinedAt,
-      team: teamsTable,
-    })
-    .from(teamMembersTable)
-    .innerJoin(teamsTable, eq(teamMembersTable.teamId, teamsTable.id))
-    .where(eq(teamMembersTable.userId, userId))
-
-  return results.map(row => ({
-    id: row.id,
-    userId: row.userId,
-    teamId: row.teamId,
-    position: row.position,
-    invitedBy: row.invitedBy,
-    joinedAt: row.joinedAt,
-    team: row.team,
-  }))
-}
-
 export const findUserTeam = async (
   userId: string,
   tx?: Database,
@@ -209,7 +178,6 @@ export const findUserTeam = async (
     .from(teamMembersTable)
     .innerJoin(teamsTable, eq(teamMembersTable.teamId, teamsTable.id))
     .where(eq(teamMembersTable.userId, userId))
-    .limit(1)
 
   return result
 }

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -191,6 +191,29 @@ export const findUserTeams = async (
   }))
 }
 
+export const findUserTeam = async (
+  userId: string,
+  tx?: Database,
+): Promise<Team | undefined> => {
+  const executor = tx || db
+
+  const [result] = await executor
+    .select({
+      id: teamsTable.id,
+      name: teamsTable.name,
+      website: teamsTable.website,
+      description: teamsTable.description,
+      createdAt: teamsTable.createdAt,
+      updatedAt: teamsTable.updatedAt,
+    })
+    .from(teamMembersTable)
+    .innerJoin(teamsTable, eq(teamMembersTable.teamId, teamsTable.id))
+    .where(eq(teamMembersTable.userId, userId))
+    .limit(1)
+
+  return result
+}
+
 export const findTeamMembers = async (
   teamId: string,
   tx?: Database,

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -80,22 +80,27 @@ export const findTeamById = async (
   return team
 }
 
-export const findTeam = async (
-  teamId: string,
+export const findTeamByName = async (
+  name: string,
   tx?: Database,
-): Promise<TeamWithMembers | undefined> => {
+): Promise<Team | undefined> => {
   const executor = tx || db
 
   const [team] = await executor
     .select()
     .from(teamsTable)
-    .where(eq(teamsTable.id, teamId))
+    .where(eq(teamsTable.name, name))
 
-  if (!team) {
-    return undefined
-  }
+  return team
+}
 
-  const memberRows = await executor
+export const findTeamMembers = async (
+  teamId: string,
+  tx?: Database,
+): Promise<TeamMemberDetails[]> => {
+  const executor = tx || db
+
+  return executor
     .select({
       id: teamMembersTable.userId,
       firstName: usersTable.firstName,
@@ -109,25 +114,47 @@ export const findTeam = async (
     .from(teamMembersTable)
     .innerJoin(usersTable, eq(teamMembersTable.userId, usersTable.id))
     .where(eq(teamMembersTable.teamId, teamId))
+}
+
+export const findTeamWithMembers = async (
+  teamId: string,
+  tx?: Database,
+): Promise<TeamWithMembers | undefined> => {
+  const [team, members] = await Promise.all([
+    findTeamById(teamId, tx),
+    findTeamMembers(teamId, tx),
+  ])
+
+  if (!team) {
+    return undefined
+  }
 
   return {
     ...team,
-    members: memberRows,
+    members,
   }
 }
 
-export const findTeamByName = async (
-  name: string,
+export const findUserTeam = async (
+  userId: string,
   tx?: Database,
 ): Promise<Team | undefined> => {
   const executor = tx || db
 
-  const [team] = await executor
-    .select()
-    .from(teamsTable)
-    .where(eq(teamsTable.name, name))
+  const [result] = await executor
+    .select({
+      id: teamsTable.id,
+      name: teamsTable.name,
+      website: teamsTable.website,
+      description: teamsTable.description,
+      createdAt: teamsTable.createdAt,
+      updatedAt: teamsTable.updatedAt,
+    })
+    .from(teamMembersTable)
+    .innerJoin(teamsTable, eq(teamMembersTable.teamId, teamsTable.id))
+    .where(eq(teamMembersTable.userId, userId))
 
-  return team
+  return result
 }
 
 export const findTeamMember = async (
@@ -154,80 +181,6 @@ export const findTeamMember = async (
       and(
         eq(teamMembersTable.userId, userId),
         eq(teamMembersTable.teamId, teamId),
-      ),
-    )
-
-  return member
-}
-
-export const findUserTeam = async (
-  userId: string,
-  tx?: Database,
-): Promise<Team | undefined> => {
-  const executor = tx || db
-
-  const [result] = await executor
-    .select({
-      id: teamsTable.id,
-      name: teamsTable.name,
-      website: teamsTable.website,
-      description: teamsTable.description,
-      createdAt: teamsTable.createdAt,
-      updatedAt: teamsTable.updatedAt,
-    })
-    .from(teamMembersTable)
-    .innerJoin(teamsTable, eq(teamMembersTable.teamId, teamsTable.id))
-    .where(eq(teamMembersTable.userId, userId))
-
-  return result
-}
-
-export const findTeamMembers = async (
-  teamId: string,
-  tx?: Database,
-): Promise<TeamMemberDetails[]> => {
-  const executor = tx || db
-
-  return executor
-    .select({
-      id: teamMembersTable.userId,
-      firstName: usersTable.firstName,
-      lastName: usersTable.lastName,
-      email: usersTable.email,
-      status: usersTable.status,
-      position: teamMembersTable.position,
-      invitedBy: teamMembersTable.invitedBy,
-      joinedAt: teamMembersTable.joinedAt,
-    })
-    .from(teamMembersTable)
-    .innerJoin(usersTable, eq(teamMembersTable.userId, usersTable.id))
-    .where(eq(teamMembersTable.teamId, teamId))
-}
-
-export const findTeamMemberById = async (
-  teamId: string,
-  memberId: string,
-  tx?: Database,
-): Promise<TeamMemberDetails | undefined> => {
-  const executor = tx || db
-
-  const [member] = await executor
-    .select({
-      id: teamMembersTable.userId,
-      firstName: usersTable.firstName,
-      lastName: usersTable.lastName,
-      email: usersTable.email,
-      status: usersTable.status,
-      position: teamMembersTable.position,
-      invitedBy: teamMembersTable.invitedBy,
-      joinedAt: teamMembersTable.joinedAt,
-    })
-    .from(teamMembersTable)
-    .innerJoin(usersTable, eq(teamMembersTable.userId, usersTable.id))
-    .where(
-      and(
-        eq(teamMembersTable.teamId, teamId),
-        eq(teamMembersTable.userId, memberId),
       ),
     )
 

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -116,6 +116,36 @@ export const findTeamMembers = async (
     .where(eq(teamMembersTable.teamId, teamId))
 }
 
+export const findTeamMember = async (
+  userId: string,
+  teamId: string,
+  tx?: Database,
+): Promise<TeamMemberDetails | undefined> => {
+  const executor = tx || db
+
+  const [member] = await executor
+    .select({
+      id: teamMembersTable.userId,
+      firstName: usersTable.firstName,
+      lastName: usersTable.lastName,
+      email: usersTable.email,
+      status: usersTable.status,
+      position: teamMembersTable.position,
+      invitedBy: teamMembersTable.invitedBy,
+      joinedAt: teamMembersTable.joinedAt,
+    })
+    .from(teamMembersTable)
+    .innerJoin(usersTable, eq(teamMembersTable.userId, usersTable.id))
+    .where(
+      and(
+        eq(teamMembersTable.userId, userId),
+        eq(teamMembersTable.teamId, teamId),
+      ),
+    )
+
+  return member
+}
+
 export const findTeamWithMembers = async (
   teamId: string,
   tx?: Database,
@@ -155,34 +185,4 @@ export const findUserTeam = async (
     .where(eq(teamMembersTable.userId, userId))
 
   return result
-}
-
-export const findTeamMember = async (
-  userId: string,
-  teamId: string,
-  tx?: Database,
-): Promise<TeamMemberDetails | undefined> => {
-  const executor = tx || db
-
-  const [member] = await executor
-    .select({
-      id: teamMembersTable.userId,
-      firstName: usersTable.firstName,
-      lastName: usersTable.lastName,
-      email: usersTable.email,
-      status: usersTable.status,
-      position: teamMembersTable.position,
-      invitedBy: teamMembersTable.invitedBy,
-      joinedAt: teamMembersTable.joinedAt,
-    })
-    .from(teamMembersTable)
-    .innerJoin(usersTable, eq(teamMembersTable.userId, usersTable.id))
-    .where(
-      and(
-        eq(teamMembersTable.userId, userId),
-        eq(teamMembersTable.teamId, teamId),
-      ),
-    )
-
-  return member
 }

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -80,20 +80,6 @@ export const findTeamById = async (
   return team
 }
 
-export const findTeamByName = async (
-  name: string,
-  tx?: Database,
-): Promise<Team | undefined> => {
-  const executor = tx || db
-
-  const [team] = await executor
-    .select()
-    .from(teamsTable)
-    .where(eq(teamsTable.name, name))
-
-  return team
-}
-
 export const findTeamMembers = async (
   teamId: string,
   tx?: Database,

--- a/src/data/repositories/team/types.ts
+++ b/src/data/repositories/team/types.ts
@@ -25,7 +25,3 @@ export interface TeamMemberDetails {
 export type TeamWithMembers = Team & {
   members: TeamMemberDetails[]
 }
-
-export type TeamMemberWithTeam = TeamMember & {
-  team: Team
-}

--- a/src/data/schema/teams.ts
+++ b/src/data/schema/teams.ts
@@ -14,7 +14,7 @@ import { usersTable } from './users'
 
 export const teamsTable = pgTable('teams', {
   id: uuid('id').primaryKey().$defaultFn(() => sql`uuidv7()`),
-  name: varchar('name', { length: 255 }).notNull().unique(),
+  name: varchar('name', { length: 255 }).notNull(),
   website: varchar('website', { length: 255 }).unique(),
   description: text('description'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),

--- a/src/use-cases/auth/__tests__/check-invite.test.ts
+++ b/src/use-cases/auth/__tests__/check-invite.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type { Team, TeamMemberWithTeam, TokenRecord, UserRoleRecord } from '@/data'
+import type { Team, TokenRecord, UserRoleRecord } from '@/data'
 
 import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
@@ -23,7 +23,6 @@ describe('Check Invite', () => {
   let mockTokenValidator: any
 
   let mockTeam: Team
-  let mockTeamMemberWithTeam: TeamMemberWithTeam
   let mockAdminRole: UserRoleRecord
 
   beforeEach(async () => {
@@ -49,16 +48,6 @@ describe('Check Invite', () => {
       updatedAt: new Date(),
     }
 
-    mockTeamMemberWithTeam = {
-      id: 1,
-      userId: testUuids.ADMIN_1,
-      teamId: testUuids.TEAM_1,
-      position: 'Developer',
-      invitedBy: testUuids.OWNER_1,
-      joinedAt: new Date(),
-      team: mockTeam,
-    }
-
     mockAdminRole = {
       userId: testUuids.ADMIN_1,
       role: Role.Admin,
@@ -70,7 +59,7 @@ describe('Check Invite', () => {
       findByToken: mock(async () => mockTokenRecord),
     }
     mockTeamRepo = {
-      findUserTeams: mock(async () => [mockTeamMemberWithTeam]),
+      findUserTeam: mock(async () => mockTeam),
     }
     mockUserRoleRepo = {
       findByUserId: mock(async () => mockAdminRole),
@@ -113,8 +102,8 @@ describe('Check Invite', () => {
       )
       expect(mockTokenValidator.validate).toHaveBeenCalledTimes(1)
 
-      expect(mockTeamRepo.findUserTeams).toHaveBeenCalledWith(mockTokenRecord.userId)
-      expect(mockTeamRepo.findUserTeams).toHaveBeenCalledTimes(1)
+      expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(mockTokenRecord.userId)
+      expect(mockTeamRepo.findUserTeam).toHaveBeenCalledTimes(1)
 
       expect(mockUserRoleRepo.findByUserId).not.toHaveBeenCalled()
 
@@ -124,13 +113,13 @@ describe('Check Invite', () => {
 
   describe('when token is valid for admin invite', () => {
     beforeEach(() => {
-      mockTeamRepo.findUserTeams.mockResolvedValue([])
+      mockTeamRepo.findUserTeam.mockResolvedValue(undefined)
     })
 
     it('should return admin type and company name for admin invitation token', async () => {
       const result = await checkInvite(mockTokenString)
 
-      expect(mockTeamRepo.findUserTeams).toHaveBeenCalledWith(mockTokenRecord.userId)
+      expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(mockTokenRecord.userId)
       expect(mockUserRoleRepo.findByUserId).toHaveBeenCalledWith(mockTokenRecord.userId)
       expect(mockUserRoleRepo.findByUserId).toHaveBeenCalledTimes(1)
 
@@ -152,7 +141,7 @@ describe('Check Invite', () => {
         expect((error as AppError).code).toBe(ErrorCode.TokenNotFound)
       }
 
-      expect(mockTeamRepo.findUserTeams).not.toHaveBeenCalled()
+      expect(mockTeamRepo.findUserTeam).not.toHaveBeenCalled()
     })
   })
 
@@ -170,7 +159,7 @@ describe('Check Invite', () => {
         expect((error as AppError).code).toBe(ErrorCode.TokenExpired)
       }
 
-      expect(mockTeamRepo.findUserTeams).not.toHaveBeenCalled()
+      expect(mockTeamRepo.findUserTeam).not.toHaveBeenCalled()
     })
   })
 
@@ -188,7 +177,7 @@ describe('Check Invite', () => {
         expect((error as AppError).code).toBe(ErrorCode.TokenAlreadyUsed)
       }
 
-      expect(mockTeamRepo.findUserTeams).not.toHaveBeenCalled()
+      expect(mockTeamRepo.findUserTeam).not.toHaveBeenCalled()
     })
   })
 
@@ -206,7 +195,7 @@ describe('Check Invite', () => {
         expect((error as AppError).code).toBe(ErrorCode.TokenCancelled)
       }
 
-      expect(mockTeamRepo.findUserTeams).not.toHaveBeenCalled()
+      expect(mockTeamRepo.findUserTeam).not.toHaveBeenCalled()
     })
   })
 
@@ -224,13 +213,13 @@ describe('Check Invite', () => {
         expect((error as AppError).code).toBe(ErrorCode.TokenTypeMismatch)
       }
 
-      expect(mockTeamRepo.findUserTeams).not.toHaveBeenCalled()
+      expect(mockTeamRepo.findUserTeam).not.toHaveBeenCalled()
     })
   })
 
   describe('when user has no team membership and no admin role', () => {
     it('should throw InternalError', async () => {
-      mockTeamRepo.findUserTeams.mockResolvedValue([])
+      mockTeamRepo.findUserTeam.mockResolvedValue(undefined)
       mockUserRoleRepo.findByUserId.mockResolvedValue(undefined)
 
       try {
@@ -242,14 +231,14 @@ describe('Check Invite', () => {
         expect((error as AppError).message).toBe('Invalid invitation state')
       }
 
-      expect(mockTeamRepo.findUserTeams).toHaveBeenCalledWith(mockTokenRecord.userId)
+      expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(mockTokenRecord.userId)
       expect(mockUserRoleRepo.findByUserId).toHaveBeenCalledWith(mockTokenRecord.userId)
     })
   })
 
   describe('when user has non-admin role', () => {
     it('should throw InternalError', async () => {
-      mockTeamRepo.findUserTeams.mockResolvedValue([])
+      mockTeamRepo.findUserTeam.mockResolvedValue(undefined)
       mockUserRoleRepo.findByUserId.mockResolvedValue({
         ...mockAdminRole,
         role: Role.User,
@@ -268,7 +257,7 @@ describe('Check Invite', () => {
 
   describe('when database query fails', () => {
     it('should propagate the error', async () => {
-      mockTeamRepo.findUserTeams.mockRejectedValue(new Error('Database connection failed'))
+      mockTeamRepo.findUserTeam.mockRejectedValue(new Error('Database connection failed'))
 
       try {
         await checkInvite(mockTokenString)

--- a/src/use-cases/auth/__tests__/login.test.ts
+++ b/src/use-cases/auth/__tests__/login.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type { AuthRecord, User } from '@/data'
+import type { AuthRecord, Team, User } from '@/data'
 
 import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
@@ -21,6 +21,8 @@ describe('Login with Email', () => {
   let mockAuthRecord: AuthRecord
   let mockAuthRepo: any
   let mockRefreshTokenRepo: any
+  let mockTeamRepo: any
+  let mockTeam: Team | undefined
 
   let mockComparePasswords: any
 
@@ -67,11 +69,16 @@ describe('Login with Email', () => {
     mockRefreshTokenRepo = {
       create: mock(async () => 1),
     }
+    mockTeam = undefined
+    mockTeamRepo = {
+      findUserTeam: mock(async () => mockTeam),
+    }
 
     await moduleMocker.mock('@/data', () => ({
       userRepo: mockUserRepo,
       authRepo: mockAuthRepo,
       refreshTokenRepo: mockRefreshTokenRepo,
+      teamRepo: mockTeamRepo,
     }))
 
     mockComparePasswords = mock(async () => true)
@@ -104,15 +111,33 @@ describe('Login with Email', () => {
   })
 
   describe('successful login', () => {
-    it('should return user and token for valid credentials', async () => {
+    it('should return user, team, and token for valid credentials', async () => {
       const result = await logInWithEmail(mockLoginParams, mockDeviceInfo)
 
       expect(result).toHaveProperty('data')
       expect(result).toHaveProperty('refreshToken')
       expect(result.data.accessToken).toBe(mockJwtToken)
+      expect(result.data.team).toBeNull()
       expect(result.refreshToken).toBe('refresh_token_123')
       expect(result.data.user).not.toHaveProperty('tokenVersion')
       expect(result.data.user.email).toBe(mockLoginParams.email)
+    })
+
+    it('should return team info when user belongs to a team', async () => {
+      mockTeam = {
+        id: 'team-123',
+        name: 'Acme Corp',
+        website: 'https://acme.com',
+        description: 'A company',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      }
+      mockTeamRepo.findUserTeam.mockImplementation(async () => mockTeam)
+
+      const result = await logInWithEmail(mockLoginParams, mockDeviceInfo)
+
+      expect(result.data.team).toEqual(mockTeam)
+      expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(mockUser.id)
     })
 
     it('should handle different user roles correctly', async () => {

--- a/src/use-cases/auth/__tests__/reset-password.test.ts
+++ b/src/use-cases/auth/__tests__/reset-password.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type { TokenRecord, User } from '@/data'
+import type { Team, TokenRecord, User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
 import { ModuleMocker, testUuids } from '@/__tests__'
@@ -24,6 +24,8 @@ describe('Reset Password', () => {
   let mockAuthRepo: any
   let mockUserRepo: any
   let mockRefreshTokenRepo: any
+  let mockTeamRepo: any
+  let mockTeam: Team | undefined
   let mockTransaction: any
 
   let mockTokenValidator: any
@@ -81,6 +83,10 @@ describe('Reset Password', () => {
     mockRefreshTokenRepo = {
       create: mock(async () => {}),
     }
+    mockTeam = undefined
+    mockTeamRepo = {
+      findUserTeam: mock(async () => mockTeam),
+    }
     mockTransaction = {
       transaction: mock(async (callback: any) => callback({}) as Promise<void>),
     }
@@ -90,6 +96,7 @@ describe('Reset Password', () => {
       authRepo: mockAuthRepo,
       userRepo: mockUserRepo,
       refreshTokenRepo: mockRefreshTokenRepo,
+      teamRepo: mockTeamRepo,
       db: mockTransaction,
     }))
 
@@ -155,9 +162,29 @@ describe('Reset Password', () => {
       expect(mockRefreshTokenRepo.create).toHaveBeenCalledTimes(1)
 
       expect(result).toEqual({
-        data: { user: mockUser, accessToken: mockAccessToken },
+        data: { user: mockUser, team: null, accessToken: mockAccessToken },
         refreshToken: mockRefreshToken,
       })
+    })
+
+    it('should include team info when user belongs to a team', async () => {
+      mockTeam = {
+        id: 'team-456',
+        name: 'Tech Inc',
+        website: null,
+        description: null,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      }
+      mockTeamRepo.findUserTeam.mockImplementation(async () => mockTeam)
+
+      const result = await resetPassword(
+        { token: mockTokenString, password: mockPassword },
+        mockDeviceInfo,
+      )
+
+      expect(result.data.team).toEqual(mockTeam)
+      expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(mockUser.id)
     })
   })
 
@@ -342,7 +369,7 @@ describe('Reset Password', () => {
       )
 
       expect(result).toEqual({
-        data: { user: mockUser, accessToken: mockAccessToken },
+        data: { user: mockUser, team: null, accessToken: mockAccessToken },
         refreshToken: mockRefreshToken,
       })
 

--- a/src/use-cases/auth/check-invite.ts
+++ b/src/use-cases/auth/check-invite.ts
@@ -12,13 +12,13 @@ interface CheckInviteResult {
 }
 
 const checkMemberInvite = async (userId: string): Promise<CheckInviteResult | null> => {
-  const userTeams = await teamRepo.findUserTeams(userId)
+  const userTeam = await teamRepo.findUserTeam(userId)
 
-  if (userTeams.length === 0) {
+  if (!userTeam) {
     return null
   }
 
-  return { type: 'member', teamName: userTeams[0].team.name }
+  return { type: 'member', teamName: userTeam.name }
 }
 
 const checkAdminInvite = async (userId: string): Promise<CheckInviteResult | null> => {

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -1,7 +1,7 @@
 import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { authRepo, refreshTokenRepo, userRepo } from '@/data'
+import { authRepo, refreshTokenRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { signJwt } from '@/security/jwt'
 import { comparePasswordHashes } from '@/security/password'
@@ -59,11 +59,14 @@ const logInWithEmail = async (
     throw new AppError(ErrorCode.InvalidCredentials)
   }
 
-  const accessToken = await createAccessToken(user)
-  const refreshToken = await createRefreshToken(user.id, deviceInfo)
+  const [accessToken, refreshToken, team] = await Promise.all([
+    createAccessToken(user),
+    createRefreshToken(user.id, deviceInfo),
+    teamRepo.findUserTeam(user.id),
+  ])
 
   return {
-    data: { user, accessToken },
+    data: { user, team: team ?? null, accessToken },
     refreshToken,
   }
 }

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -1,7 +1,7 @@
 import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { authRepo, db, refreshTokenRepo, tokenRepo, userRepo } from '@/data'
+import { authRepo, db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { signJwt } from '@/security/jwt'
 import { hashPassword } from '@/security/password'
@@ -70,11 +70,14 @@ const resetPassword = async (
     throw new AppError(ErrorCode.InternalError, 'User not found after password reset')
   }
 
-  const accessToken = await createAccessToken(user)
-  const refreshToken = await createRefreshToken(user.id, deviceInfo)
+  const [accessToken, refreshToken, team] = await Promise.all([
+    createAccessToken(user),
+    createRefreshToken(user.id, deviceInfo),
+    teamRepo.findUserTeam(user.id),
+  ])
 
   return {
-    data: { user, accessToken },
+    data: { user, team: team ?? null, accessToken },
     refreshToken,
   }
 }

--- a/src/use-cases/user/__tests__/invites.test.ts
+++ b/src/use-cases/user/__tests__/invites.test.ts
@@ -21,7 +21,7 @@ describe('inviteMember', () => {
   let mockUserRepoFindById: any
   let mockUserRepoCreate: any
   let mockAuthRepoCreate: any
-  let mockTeamRepoAddMember: any
+  let mockTeamRepoCreateMember: any
   let mockTokenRepoIssue: any
   let mockTransaction: any
   let mockEmailAgent: any
@@ -67,7 +67,7 @@ describe('inviteMember', () => {
       updatedAt: new Date('2024-01-01'),
     }))
     mockAuthRepoCreate = mock(async () => {})
-    mockTeamRepoAddMember = mock(async () => {})
+    mockTeamRepoCreateMember = mock(async () => {})
     mockTokenRepoIssue = mock(async () => {})
     mockTransaction = mock(async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => {
       return callback({})
@@ -79,7 +79,7 @@ describe('inviteMember', () => {
     await moduleMocker.mock('@/data', () => ({
       teamRepo: {
         findById: mockTeamRepoFindById,
-        addMember: mockTeamRepoAddMember,
+        createMember: mockTeamRepoCreateMember,
       },
       userRepo: {
         findByEmail: mockUserRepoFindByEmail,
@@ -152,7 +152,7 @@ describe('inviteMember', () => {
   it('should add user to team with invitedBy', async () => {
     await inviteMember(TEAM_1, inviteParams, USER_2)
 
-    expect(mockTeamRepoAddMember).toHaveBeenCalledWith(
+    expect(mockTeamRepoCreateMember).toHaveBeenCalledWith(
       {
         userId: USER_1,
         teamId: TEAM_1,

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type { UpdateUserInput, User } from '@/data'
+import type { Team, UpdateUserInput, User } from '@/data'
 
 import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
@@ -13,6 +13,8 @@ describe('User Me Use Cases', () => {
 
   let mockUser: User
   let mockUserRepo: any
+  let mockTeamRepo: any
+  let mockTeam: Team | undefined
 
   beforeEach(async () => {
     mockUser = {
@@ -32,9 +34,14 @@ describe('User Me Use Cases', () => {
         ...updates,
       })),
     }
+    mockTeam = undefined
+    mockTeamRepo = {
+      findUserTeam: mock(async () => mockTeam),
+    }
 
     await moduleMocker.mock('@/data', () => ({
       userRepo: mockUserRepo,
+      teamRepo: mockTeamRepo,
     }))
   })
 
@@ -43,12 +50,29 @@ describe('User Me Use Cases', () => {
   })
 
   describe('getUser', () => {
-    it('should return user data when user exists', async () => {
+    it('should return user and team null when user has no team', async () => {
       const result = await getUser(testUuids.USER_1)
 
-      expect(result).toEqual({ user: mockUser })
+      expect(result).toEqual({ user: mockUser, team: null })
       expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
-      expect(mockUserRepo.findById).toHaveBeenCalledTimes(1)
+      expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(testUuids.USER_1)
+    })
+
+    it('should return user and team info when user belongs to a team', async () => {
+      mockTeam = {
+        id: 'team-789',
+        name: 'My Team',
+        website: 'https://myteam.io',
+        description: 'My team description',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
+      }
+      mockTeamRepo.findUserTeam.mockImplementation(async () => mockTeam)
+
+      const result = await getUser(testUuids.USER_1)
+
+      expect(result).toEqual({ user: mockUser, team: mockTeam })
+      expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(testUuids.USER_1)
     })
 
     it('should throw InternalError when user not found', async () => {
@@ -67,6 +91,7 @@ describe('User Me Use Cases', () => {
 
       expect(result.user.firstName).toBe('Jane')
       expect(result.user.lastName).toBe('Smith')
+      expect(result.team).toBeNull()
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: 'Smith',
@@ -78,6 +103,7 @@ describe('User Me Use Cases', () => {
       const result = await updateUser(testUuids.USER_1, { firstName: 'Jane' })
 
       expect(result.user.firstName).toBe('Jane')
+      expect(result.team).toBeNull()
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         updatedAt: expect.any(Date),
@@ -88,16 +114,17 @@ describe('User Me Use Cases', () => {
       const result = await updateUser(testUuids.USER_1, { lastName: 'Smith' })
 
       expect(result.user.lastName).toBe('Smith')
+      expect(result.team).toBeNull()
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         lastName: 'Smith',
         updatedAt: expect.any(Date),
       })
     })
 
-    it('should return current user when no valid updates provided', async () => {
+    it('should return current user and team when no valid updates provided', async () => {
       const result = await updateUser(testUuids.USER_1, {})
 
-      expect(result).toEqual({ user: mockUser })
+      expect(result).toEqual({ user: mockUser, team: null })
       expect(mockUserRepo.update).not.toHaveBeenCalled()
       expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
     })
@@ -108,6 +135,7 @@ describe('User Me Use Cases', () => {
 
       expect(result.user.firstName).toBe('Jane')
       expect(result.user.lastName).toBe('')
+      expect(result.team).toBeNull()
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: '',
@@ -120,6 +148,7 @@ describe('User Me Use Cases', () => {
       const result = await updateUser(testUuids.USER_1, { firstName: undefined, lastName: 'Smith' })
 
       expect(result.user.lastName).toBe('Smith')
+      expect(result.team).toBeNull()
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         lastName: 'Smith',
         updatedAt: expect.any(Date),

--- a/src/use-cases/user/__tests__/teams.test.ts
+++ b/src/use-cases/user/__tests__/teams.test.ts
@@ -13,7 +13,7 @@ import {
   updateTeam,
 } from '../teams'
 
-const { TEAM_1, TEAM_2 } = testUuids
+const { TEAM_1 } = testUuids
 
 describe('getTeams', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
@@ -115,7 +115,6 @@ describe('createTeam', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
   let mockTeam: Team
-  let mockTeamRepoFindByName: any
   let mockTeamRepoCreate: any
 
   beforeEach(async () => {
@@ -128,12 +127,10 @@ describe('createTeam', () => {
       updatedAt: new Date('2024-01-01'),
     }
 
-    mockTeamRepoFindByName = mock(async () => undefined)
     mockTeamRepoCreate = mock(async () => mockTeam)
 
     await moduleMocker.mock('@/data', () => ({
       teamRepo: {
-        findByName: mockTeamRepoFindByName,
         create: mockTeamRepoCreate,
       },
     }))
@@ -143,24 +140,13 @@ describe('createTeam', () => {
     await moduleMocker.clear()
   })
 
-  it('should create team when name is unique', async () => {
+  it('should create team', async () => {
     const params = { name: 'New Team', website: 'https://newteam.com' }
 
     const result = await createTeam(params)
 
-    expect(mockTeamRepoFindByName).toHaveBeenCalledWith('New Team')
     expect(mockTeamRepoCreate).toHaveBeenCalledWith(params)
     expect(result).toEqual({ team: mockTeam })
-  })
-
-  it('should throw Conflict error when team name already exists', async () => {
-    mockTeamRepoFindByName.mockImplementation(async () => mockTeam)
-
-    expect(createTeam({ name: 'New Team' })).rejects.toThrow(AppError)
-    expect(createTeam({ name: 'New Team' })).rejects.toMatchObject({
-      code: ErrorCode.Conflict,
-      message: 'Team with this name already exists',
-    })
   })
 })
 
@@ -170,7 +156,6 @@ describe('updateTeam', () => {
   let mockExistingTeam: Team
   let mockUpdatedTeam: Team
   let mockTeamRepoFindById: any
-  let mockTeamRepoFindByName: any
   let mockTeamRepoUpdate: any
 
   beforeEach(async () => {
@@ -190,13 +175,11 @@ describe('updateTeam', () => {
     }
 
     mockTeamRepoFindById = mock(async () => mockExistingTeam)
-    mockTeamRepoFindByName = mock(async () => undefined)
     mockTeamRepoUpdate = mock(async () => mockUpdatedTeam)
 
     await moduleMocker.mock('@/data', () => ({
       teamRepo: {
         findById: mockTeamRepoFindById,
-        findByName: mockTeamRepoFindByName,
         update: mockTeamRepoUpdate,
       },
     }))
@@ -223,29 +206,6 @@ describe('updateTeam', () => {
     expect(updateTeam(testUuids.NON_EXISTENT, { name: 'Test' })).rejects.toMatchObject({
       code: ErrorCode.NotFound,
       message: 'Team not found',
-    })
-  })
-
-  it('should check name uniqueness when name is being changed', async () => {
-    await updateTeam(TEAM_1, { name: 'Updated Team' })
-
-    expect(mockTeamRepoFindByName).toHaveBeenCalledWith('Updated Team')
-  })
-
-  it('should not check name uniqueness when name is unchanged', async () => {
-    await updateTeam(TEAM_1, { name: 'Old Team' })
-
-    expect(mockTeamRepoFindByName).not.toHaveBeenCalled()
-  })
-
-  it('should throw Conflict error when new name already exists', async () => {
-    const otherTeam: Team = { ...mockExistingTeam, id: TEAM_2, name: 'Taken Name' }
-    mockTeamRepoFindByName.mockImplementation(async () => otherTeam)
-
-    expect(updateTeam(TEAM_1, { name: 'Taken Name' })).rejects.toThrow(AppError)
-    expect(updateTeam(TEAM_1, { name: 'Taken Name' })).rejects.toMatchObject({
-      code: ErrorCode.Conflict,
-      message: 'Team with this name already exists',
     })
   })
 })

--- a/src/use-cases/user/invites.ts
+++ b/src/use-cases/user/invites.ts
@@ -61,7 +61,7 @@ export const inviteMember = async (
       passwordHash,
     }, tx)
 
-    await teamRepo.addMember({
+    await teamRepo.createMember({
       userId: newUser.id,
       teamId,
       position: member.position,

--- a/src/use-cases/user/me.ts
+++ b/src/use-cases/user/me.ts
@@ -1,6 +1,6 @@
 import type { UpdateUserInput } from '@/data'
 
-import { userRepo } from '@/data'
+import { teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 
 const prepareValidUpdates = (updates: UpdateUserInput): UpdateUserInput => {
@@ -10,7 +10,10 @@ const prepareValidUpdates = (updates: UpdateUserInput): UpdateUserInput => {
 }
 
 export const getUser = async (userId: string) => {
-  const user = await userRepo.findById(userId)
+  const [user, team] = await Promise.all([
+    userRepo.findById(userId),
+    teamRepo.findUserTeam(userId),
+  ])
 
   if (!user) {
     // This represents a data inconsistency - user has valid JWT,
@@ -18,7 +21,7 @@ export const getUser = async (userId: string) => {
     throw new AppError(ErrorCode.InternalError)
   }
 
-  return { user }
+  return { user, team: team ?? null }
 }
 
 export const updateUser = async (userId: string, updates: UpdateUserInput) => {
@@ -28,10 +31,13 @@ export const updateUser = async (userId: string, updates: UpdateUserInput) => {
     return getUser(userId)
   }
 
-  const updatedUser = await userRepo.update(userId, {
-    ...validUpdates,
-    updatedAt: new Date(),
-  })
+  const [updatedUser, team] = await Promise.all([
+    userRepo.update(userId, {
+      ...validUpdates,
+      updatedAt: new Date(),
+    }),
+    teamRepo.findUserTeam(userId),
+  ])
 
-  return { user: updatedUser }
+  return { user: updatedUser, team: team ?? null }
 }

--- a/src/use-cases/user/members.ts
+++ b/src/use-cases/user/members.ts
@@ -55,9 +55,7 @@ export const updateTeamMember = async (
     throw new AppError(ErrorCode.NotFound, 'Member not found')
   }
 
-  await teamRepo.updateMember(memberId, teamId, params)
-
-  const member = await teamRepo.findMember(memberId, teamId)
+  const member = await teamRepo.updateMember(memberId, teamId, params)
 
   return { member }
 }

--- a/src/use-cases/user/members.ts
+++ b/src/use-cases/user/members.ts
@@ -24,7 +24,7 @@ export const getTeamMember = async (
     throw new AppError(ErrorCode.Forbidden, 'Not authorized to access this team')
   }
 
-  const member = await teamRepo.findMemberById(teamId, memberId)
+  const member = await teamRepo.findMember(memberId, teamId)
 
   if (!member) {
     throw new AppError(ErrorCode.NotFound, 'Member not found')
@@ -49,7 +49,7 @@ export const updateTeamMember = async (
     throw new AppError(ErrorCode.Forbidden, 'Not authorized to access this team')
   }
 
-  const existing = await teamRepo.findMemberById(teamId, memberId)
+  const existing = await teamRepo.findMember(memberId, teamId)
 
   if (!existing) {
     throw new AppError(ErrorCode.NotFound, 'Member not found')
@@ -57,7 +57,7 @@ export const updateTeamMember = async (
 
   await teamRepo.updateMember(memberId, teamId, params)
 
-  const member = await teamRepo.findMemberById(teamId, memberId)
+  const member = await teamRepo.findMember(memberId, teamId)
 
   return { member }
 }

--- a/src/use-cases/user/teams.ts
+++ b/src/use-cases/user/teams.ts
@@ -36,12 +36,6 @@ export interface CreateTeamParams {
 }
 
 export const createTeam = async (params: CreateTeamParams) => {
-  const existing = await teamRepo.findByName(params.name)
-
-  if (existing) {
-    throw new AppError(ErrorCode.Conflict, 'Team with this name already exists')
-  }
-
   const team = await teamRepo.create(params)
 
   return { team }
@@ -70,14 +64,6 @@ export const updateTeam = async (
 
     if (!membership) {
       throw new AppError(ErrorCode.Forbidden, 'Not authorized to update this team')
-    }
-  }
-
-  if (params.name && params.name !== existing.name) {
-    const nameConflict = await teamRepo.findByName(params.name)
-
-    if (nameConflict) {
-      throw new AppError(ErrorCode.Conflict, 'Team with this name already exists')
     }
   }
 


### PR DESCRIPTION
## Summary

1. [Feature]: Add team info to login, reset-password, and /me responses for consistent user context
2. [Feature]: Add findUserTeam query to fetch user's team membership details
3. [Improvement]: Refactor team repository with grouped exports and CRUD naming conventions
4. [Improvement]: Remove unique constraint from team name field for multiple teams with same name
5. [Improvement]: Remove unused findTeamByName query and duplicate team query functions
6. [Improvement]: Fetch team data in parallel with other async operations for better performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)