### PR TITLE
Fix team ID enumeration vulnerability

### DIFF
--- a/src/use-cases/user/__tests__/authorization.test.ts
+++ b/src/use-cases/user/__tests__/authorization.test.ts
@@ -1,0 +1,112 @@
+/* eslint-disable ts/await-thenable */
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { testUuids } from '@/__tests__'
+import { AppError, ErrorCode } from '@/errors'
+import { Role } from '@/types'
+
+import { assertTeamAccess } from '../authorization'
+
+const mockTeamRepoFindMember = mock()
+
+void mock.module('@/data', () => ({
+  teamRepo: {
+    findMember: mockTeamRepoFindMember,
+  },
+}))
+
+describe('assertTeamAccess', () => {
+  beforeEach(() => {
+    mockTeamRepoFindMember.mockClear()
+  })
+
+  it('should allow access when membership exists', async () => {
+    mockTeamRepoFindMember.mockImplementation(async () => ({
+      userId: testUuids.USER_1,
+      teamId: testUuids.TEAM_1,
+    }))
+
+    await expect(
+      assertTeamAccess(testUuids.USER_1, testUuids.TEAM_1),
+    ).resolves.toBeUndefined()
+
+    expect(mockTeamRepoFindMember).toHaveBeenCalledWith(
+      testUuids.USER_1,
+      testUuids.TEAM_1,
+    )
+  })
+
+  it('should throw Forbidden when membership does not exist', async () => {
+    mockTeamRepoFindMember.mockImplementation(async () => undefined)
+
+    await expect(
+      assertTeamAccess(testUuids.USER_1, testUuids.TEAM_1),
+    ).rejects.toThrow(AppError)
+
+    await expect(
+      assertTeamAccess(testUuids.USER_1, testUuids.TEAM_1),
+    ).rejects.toMatchObject({
+      code: ErrorCode.Forbidden,
+    })
+
+    expect(mockTeamRepoFindMember).toHaveBeenCalledWith(
+      testUuids.USER_1,
+      testUuids.TEAM_1,
+    )
+  })
+
+  it('should allow admin access even without membership', async () => {
+    mockTeamRepoFindMember.mockImplementation(async () => undefined)
+
+    await expect(
+      assertTeamAccess(testUuids.USER_1, testUuids.TEAM_1, Role.Admin),
+    ).resolves.toBeUndefined()
+
+    // should not call findMember when user is admin
+    expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
+  })
+
+  it('should allow owner access even without membership', async () => {
+    mockTeamRepoFindMember.mockImplementation(async () => undefined)
+
+    await expect(
+      assertTeamAccess(testUuids.USER_1, testUuids.TEAM_1, Role.Owner),
+    ).resolves.toBeUndefined()
+
+    // should not call findMember when user is owner
+    expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
+  })
+
+  it('should use consistent error message for all unauthorized attempts', async () => {
+    mockTeamRepoFindMember.mockImplementation(async () => undefined)
+
+    const expectedError = {
+      code: ErrorCode.Forbidden,
+    }
+
+    await expect(
+      assertTeamAccess(testUuids.USER_1, testUuids.TEAM_1),
+    ).rejects.toMatchObject(expectedError)
+
+    await expect(
+      assertTeamAccess(testUuids.USER_2, testUuids.TEAM_2),
+    ).rejects.toMatchObject(expectedError)
+  })
+
+  it('should check membership for regular users even when userRole is provided', async () => {
+    mockTeamRepoFindMember.mockImplementation(async () => ({
+      userId: testUuids.USER_1,
+      teamId: testUuids.TEAM_1,
+    }))
+
+    await expect(
+      assertTeamAccess(testUuids.USER_1, testUuids.TEAM_1, Role.User),
+    ).resolves.toBeUndefined()
+
+    // should call findMember for regular users
+    expect(mockTeamRepoFindMember).toHaveBeenCalledWith(
+      testUuids.USER_1,
+      testUuids.TEAM_1,
+    )
+  })
+})

--- a/src/use-cases/user/__tests__/teams.test.ts
+++ b/src/use-cases/user/__tests__/teams.test.ts
@@ -119,7 +119,6 @@ describe('getTeam', () => {
     expect(getTeam(TEAM_1, testUuids.USER_2)).rejects.toThrow(AppError)
     expect(getTeam(TEAM_1, testUuids.USER_2)).rejects.toMatchObject({
       code: ErrorCode.Forbidden,
-      message: 'Not authorized to access this team',
     })
   })
 
@@ -129,7 +128,6 @@ describe('getTeam', () => {
     expect(getTeam(testUuids.NON_EXISTENT, testUuids.USER_1)).rejects.toThrow(AppError)
     expect(getTeam(testUuids.NON_EXISTENT, testUuids.USER_1)).rejects.toMatchObject({
       code: ErrorCode.Forbidden,
-      message: 'Not authorized to access this team',
     })
   })
 
@@ -252,7 +250,6 @@ describe('updateTeam', () => {
     expect(updateTeam(TEAM_1, { name: 'Test' }, testUuids.USER_2)).rejects.toThrow(AppError)
     expect(updateTeam(TEAM_1, { name: 'Test' }, testUuids.USER_2)).rejects.toMatchObject({
       code: ErrorCode.Forbidden,
-      message: 'Not authorized to update this team',
     })
   })
 

--- a/src/use-cases/user/__tests__/teams.test.ts
+++ b/src/use-cases/user/__tests__/teams.test.ts
@@ -70,6 +70,7 @@ describe('getTeam', () => {
 
   let mockTeam: TeamWithMembers
   let mockTeamRepoFind: any
+  let mockTeamRepoFindMember: any
 
   beforeEach(async () => {
     mockTeam = {
@@ -83,9 +84,13 @@ describe('getTeam', () => {
     }
 
     mockTeamRepoFind = mock(async () => mockTeam)
+    mockTeamRepoFindMember = mock(async () => ({ userId: testUuids.USER_1, teamId: TEAM_1 }))
 
     await moduleMocker.mock('@/data', () => ({
-      teamRepo: { find: mockTeamRepoFind },
+      teamRepo: {
+        find: mockTeamRepoFind,
+        findMember: mockTeamRepoFindMember,
+      },
     }))
   })
 
@@ -93,14 +98,42 @@ describe('getTeam', () => {
     await moduleMocker.clear()
   })
 
-  it('should return team when found', async () => {
+  it('should return team when found (admin access, no userId)', async () => {
     const result = await getTeam(TEAM_1)
 
     expect(mockTeamRepoFind).toHaveBeenCalledWith(TEAM_1)
     expect(result).toEqual({ team: mockTeam })
   })
 
-  it('should throw NotFound error when team does not exist', async () => {
+  it('should return team for authorized user', async () => {
+    const result = await getTeam(TEAM_1, testUuids.USER_1)
+
+    expect(mockTeamRepoFindMember).toHaveBeenCalledWith(testUuids.USER_1, TEAM_1)
+    expect(mockTeamRepoFind).toHaveBeenCalledWith(TEAM_1)
+    expect(result).toEqual({ team: mockTeam })
+  })
+
+  it('should throw Forbidden error for unauthorized user (prevents enumeration)', async () => {
+    mockTeamRepoFindMember.mockImplementation(async () => undefined)
+
+    expect(getTeam(TEAM_1, testUuids.USER_2)).rejects.toThrow(AppError)
+    expect(getTeam(TEAM_1, testUuids.USER_2)).rejects.toMatchObject({
+      code: ErrorCode.Forbidden,
+      message: 'Not authorized to access this team',
+    })
+  })
+
+  it('should throw Forbidden error for non-existent team (prevents enumeration)', async () => {
+    mockTeamRepoFindMember.mockImplementation(async () => undefined)
+
+    expect(getTeam(testUuids.NON_EXISTENT, testUuids.USER_1)).rejects.toThrow(AppError)
+    expect(getTeam(testUuids.NON_EXISTENT, testUuids.USER_1)).rejects.toMatchObject({
+      code: ErrorCode.Forbidden,
+      message: 'Not authorized to access this team',
+    })
+  })
+
+  it('should throw NotFound error when team does not exist (admin access)', async () => {
     mockTeamRepoFind.mockImplementation(async () => undefined)
 
     expect(getTeam(testUuids.NON_EXISTENT)).rejects.toThrow(AppError)
@@ -157,6 +190,7 @@ describe('updateTeam', () => {
   let mockUpdatedTeam: Team
   let mockTeamRepoFindById: any
   let mockTeamRepoUpdate: any
+  let mockTeamRepoFindMember: any
 
   beforeEach(async () => {
     mockExistingTeam = {
@@ -176,11 +210,13 @@ describe('updateTeam', () => {
 
     mockTeamRepoFindById = mock(async () => mockExistingTeam)
     mockTeamRepoUpdate = mock(async () => mockUpdatedTeam)
+    mockTeamRepoFindMember = mock(async () => ({ userId: testUuids.USER_1, teamId: TEAM_1 }))
 
     await moduleMocker.mock('@/data', () => ({
       teamRepo: {
         findById: mockTeamRepoFindById,
         update: mockTeamRepoUpdate,
+        findMember: mockTeamRepoFindMember,
       },
     }))
   })
@@ -189,7 +225,7 @@ describe('updateTeam', () => {
     await moduleMocker.clear()
   })
 
-  it('should update team when it exists', async () => {
+  it('should update team when it exists (admin access, no userId)', async () => {
     const params = { name: 'Updated Team' }
 
     const result = await updateTeam(TEAM_1, params)
@@ -199,7 +235,28 @@ describe('updateTeam', () => {
     expect(result).toEqual({ team: mockUpdatedTeam })
   })
 
-  it('should throw NotFound error when team does not exist', async () => {
+  it('should update team for authorized user', async () => {
+    const params = { name: 'Updated Team' }
+
+    const result = await updateTeam(TEAM_1, params, testUuids.USER_1)
+
+    expect(mockTeamRepoFindMember).toHaveBeenCalledWith(testUuids.USER_1, TEAM_1)
+    expect(mockTeamRepoFindById).toHaveBeenCalledWith(TEAM_1)
+    expect(mockTeamRepoUpdate).toHaveBeenCalledWith(TEAM_1, params)
+    expect(result).toEqual({ team: mockUpdatedTeam })
+  })
+
+  it('should throw Forbidden error for unauthorized user (prevents enumeration)', async () => {
+    mockTeamRepoFindMember.mockImplementation(async () => undefined)
+
+    expect(updateTeam(TEAM_1, { name: 'Test' }, testUuids.USER_2)).rejects.toThrow(AppError)
+    expect(updateTeam(TEAM_1, { name: 'Test' }, testUuids.USER_2)).rejects.toMatchObject({
+      code: ErrorCode.Forbidden,
+      message: 'Not authorized to update this team',
+    })
+  })
+
+  it('should throw NotFound error when team does not exist (admin access)', async () => {
     mockTeamRepoFindById.mockImplementation(async () => undefined)
 
     expect(updateTeam(testUuids.NON_EXISTENT, { name: 'Test' })).rejects.toThrow(AppError)

--- a/src/use-cases/user/authorization.ts
+++ b/src/use-cases/user/authorization.ts
@@ -1,0 +1,21 @@
+import type { Role } from '@/types'
+
+import { teamRepo } from '@/data'
+import { AppError, ErrorCode } from '@/errors'
+import { isAdmin } from '@/types'
+
+export const assertTeamAccess = async (
+  userId: string,
+  teamId: string,
+  userRole?: Role,
+): Promise<void> => {
+  if (userRole && isAdmin(userRole)) {
+    return
+  }
+
+  const membership = await teamRepo.findMember(userId, teamId)
+
+  if (!membership) {
+    throw new AppError(ErrorCode.Forbidden)
+  }
+}

--- a/src/use-cases/user/index.ts
+++ b/src/use-cases/user/index.ts
@@ -1,3 +1,5 @@
+export { assertTeamAccess } from './authorization'
+
 export { inviteMember, resendMemberInvite } from './invites'
 
 export { getUser, updateUser } from './me'

--- a/src/use-cases/user/invites.ts
+++ b/src/use-cases/user/invites.ts
@@ -3,7 +3,9 @@ import { AppError, ErrorCode } from '@/errors'
 import { generatePasswordHash } from '@/security/password'
 import { generateToken, TokenType } from '@/security/token'
 import { emailAgent } from '@/services/email'
-import { AuthProvider, isAdmin, Role, Status } from '@/types'
+import { AuthProvider, Role, Status } from '@/types'
+
+import { assertTeamAccess } from './authorization'
 
 export interface InviteMemberParams {
   firstName: string
@@ -27,13 +29,8 @@ export const inviteMember = async (
     throw new AppError(ErrorCode.NotFound, 'Inviter not found')
   }
 
-  // Check authorization: admins can invite to any team, regular users only to their own
-  if (!isAdmin(inviter.role)) {
-    const membership = await teamRepo.findMember(inviterId, teamId)
-    if (!membership) {
-      throw new AppError(ErrorCode.Forbidden, 'Not authorized to invite to this team')
-    }
-  }
+  // Check authorization with admin bypass
+  await assertTeamAccess(inviterId, teamId, inviter.role)
 
   if (!team) {
     throw new AppError(ErrorCode.NotFound, 'Team not found')
@@ -117,13 +114,8 @@ export const resendMemberInvite = async (
     throw new AppError(ErrorCode.NotFound, 'Inviter not found')
   }
 
-  // Check authorization: admins can resend to any team, regular users only to their own
-  if (!isAdmin(inviter.role)) {
-    const inviterMembership = await teamRepo.findMember(inviterId, teamId)
-    if (!inviterMembership) {
-      throw new AppError(ErrorCode.Forbidden, 'Not authorized to invite to this team')
-    }
-  }
+  // Check authorization with admin bypass
+  await assertTeamAccess(inviterId, teamId, inviter.role)
 
   if (!team) {
     throw new AppError(ErrorCode.NotFound, 'Team not found')

--- a/src/use-cases/user/invites.ts
+++ b/src/use-cases/user/invites.ts
@@ -17,15 +17,11 @@ export const inviteMember = async (
   member: InviteMemberParams,
   inviterId: string,
 ) => {
-  const [team, inviter, existingUser] = await Promise.all([
-    teamRepo.findById(teamId),
+  const [inviter, team, existingUser] = await Promise.all([
     userRepo.findById(inviterId),
+    teamRepo.findById(teamId),
     userRepo.findByEmail(member.email),
   ])
-
-  if (!team) {
-    throw new AppError(ErrorCode.NotFound, 'Team not found')
-  }
 
   if (!inviter) {
     throw new AppError(ErrorCode.NotFound, 'Inviter not found')
@@ -37,6 +33,10 @@ export const inviteMember = async (
     if (!membership) {
       throw new AppError(ErrorCode.Forbidden, 'Not authorized to invite to this team')
     }
+  }
+
+  if (!team) {
+    throw new AppError(ErrorCode.NotFound, 'Team not found')
   }
 
   if (existingUser) {
@@ -106,12 +106,24 @@ export const resendMemberInvite = async (
   memberId: string,
   inviterId: string,
 ) => {
-  const [team, member, membership, inviter] = await Promise.all([
+  const [inviter, team, member, membership] = await Promise.all([
+    userRepo.findById(inviterId),
     teamRepo.findById(teamId),
     userRepo.findById(memberId),
     teamRepo.findMember(memberId, teamId),
-    userRepo.findById(inviterId),
   ])
+
+  if (!inviter) {
+    throw new AppError(ErrorCode.NotFound, 'Inviter not found')
+  }
+
+  // Check authorization: admins can resend to any team, regular users only to their own
+  if (!isAdmin(inviter.role)) {
+    const inviterMembership = await teamRepo.findMember(inviterId, teamId)
+    if (!inviterMembership) {
+      throw new AppError(ErrorCode.Forbidden, 'Not authorized to invite to this team')
+    }
+  }
 
   if (!team) {
     throw new AppError(ErrorCode.NotFound, 'Team not found')
@@ -127,18 +139,6 @@ export const resendMemberInvite = async (
 
   if (member.status !== Status.Pending) {
     throw new AppError(ErrorCode.BadRequest, 'Member has already accepted invitation')
-  }
-
-  if (!inviter) {
-    throw new AppError(ErrorCode.NotFound, 'Inviter not found')
-  }
-
-  // Check authorization: admins can resend to any team, regular users only to their own
-  if (!isAdmin(inviter.role)) {
-    const inviterMembership = await teamRepo.findMember(inviterId, teamId)
-    if (!inviterMembership) {
-      throw new AppError(ErrorCode.Forbidden, 'Not authorized to invite to this team')
-    }
   }
 
   const token = await db.transaction(async (tx) => {

--- a/src/use-cases/user/members.ts
+++ b/src/use-cases/user/members.ts
@@ -1,12 +1,10 @@
 import { teamRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 
-export const getTeamMembers = async (teamId: string, userId: string) => {
-  const membership = await teamRepo.findMember(userId, teamId)
+import { assertTeamAccess } from './authorization'
 
-  if (!membership) {
-    throw new AppError(ErrorCode.Forbidden, 'Not authorized to access this team')
-  }
+export const getTeamMembers = async (teamId: string, userId: string) => {
+  await assertTeamAccess(userId, teamId)
 
   const members = await teamRepo.findMembers(teamId)
 
@@ -18,11 +16,7 @@ export const getTeamMember = async (
   memberId: string,
   userId: string,
 ) => {
-  const membership = await teamRepo.findMember(userId, teamId)
-
-  if (!membership) {
-    throw new AppError(ErrorCode.Forbidden, 'Not authorized to access this team')
-  }
+  await assertTeamAccess(userId, teamId)
 
   const member = await teamRepo.findMember(memberId, teamId)
 
@@ -43,11 +37,7 @@ export const updateTeamMember = async (
   params: UpdateTeamMemberParams,
   userId: string,
 ) => {
-  const membership = await teamRepo.findMember(userId, teamId)
-
-  if (!membership) {
-    throw new AppError(ErrorCode.Forbidden, 'Not authorized to access this team')
-  }
+  await assertTeamAccess(userId, teamId)
 
   const existing = await teamRepo.findMember(memberId, teamId)
 

--- a/src/use-cases/user/teams.ts
+++ b/src/use-cases/user/teams.ts
@@ -3,6 +3,8 @@ import type { PaginationParams, TeamSearchParams } from '@/data'
 import { teamRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 
+import { assertTeamAccess } from './authorization'
+
 export const getTeams = async (
   params: TeamSearchParams,
   pagination: PaginationParams,
@@ -12,11 +14,7 @@ export const getTeams = async (
 
 export const getTeam = async (teamId: string, userId?: string) => {
   if (userId) {
-    const membership = await teamRepo.findMember(userId, teamId)
-
-    if (!membership) {
-      throw new AppError(ErrorCode.Forbidden, 'Not authorized to access this team')
-    }
+    await assertTeamAccess(userId, teamId)
   }
 
   const team = await teamRepo.find(teamId)
@@ -52,11 +50,7 @@ export const updateTeam = async (
   userId?: string,
 ) => {
   if (userId) {
-    const membership = await teamRepo.findMember(userId, teamId)
-
-    if (!membership) {
-      throw new AppError(ErrorCode.Forbidden, 'Not authorized to update this team')
-    }
+    await assertTeamAccess(userId, teamId)
   }
 
   const existing = await teamRepo.findById(teamId)

--- a/src/use-cases/user/teams.ts
+++ b/src/use-cases/user/teams.ts
@@ -11,19 +11,18 @@ export const getTeams = async (
 }
 
 export const getTeam = async (teamId: string, userId?: string) => {
-  const team = await teamRepo.find(teamId)
-
-  if (!team) {
-    throw new AppError(ErrorCode.NotFound, 'Team not found')
-  }
-
-  // If userId provided, verify membership (user-level access)
   if (userId) {
     const membership = await teamRepo.findMember(userId, teamId)
 
     if (!membership) {
       throw new AppError(ErrorCode.Forbidden, 'Not authorized to access this team')
     }
+  }
+
+  const team = await teamRepo.find(teamId)
+
+  if (!team) {
+    throw new AppError(ErrorCode.NotFound, 'Team not found')
   }
 
   return { team }
@@ -52,19 +51,18 @@ export const updateTeam = async (
   params: UpdateTeamParams,
   userId?: string,
 ) => {
-  const existing = await teamRepo.findById(teamId)
-
-  if (!existing) {
-    throw new AppError(ErrorCode.NotFound, 'Team not found')
-  }
-
-  // If userId provided, verify membership (user-level access)
   if (userId) {
     const membership = await teamRepo.findMember(userId, teamId)
 
     if (!membership) {
       throw new AppError(ErrorCode.Forbidden, 'Not authorized to update this team')
     }
+  }
+
+  const existing = await teamRepo.findById(teamId)
+
+  if (!existing) {
+    throw new AppError(ErrorCode.NotFound, 'Team not found')
   }
 
   const team = await teamRepo.update(teamId, params)


### PR DESCRIPTION
1. [Security]: Prevent team ID enumeration by checking authorization before resource existence
2. [Fix]: Reverse validation order in getTeam and updateTeam to check membership first
3. [Fix]: Reverse validation order in inviteMember and resendMemberInvite to check authorization first
4. [Security]: Ensure consistent error responses for unauthorized access regardless of team existence
5. [Improvement]: Add comprehensive security tests verifying enumeration prevention