### PR TITLE
Add cancel invite for admin and member

### DIFF
--- a/postman.json
+++ b/postman.json
@@ -125,7 +125,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\": \"Books For You\",\n    \"website\": \"https://b4u.com\"\n}",
+              "raw": "{\n    \"name\": \"Caddy\",\n    \"website\": \"https://caddy.com\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -800,6 +800,36 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "teams/:id/members/:id/cancel-invite",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{user_verified_only_api_url}}/teams/{{last_team_id}}/members/{{last_member_id}}/cancel-invite",
+              "host": [
+                "{{user_verified_only_api_url}}"
+              ],
+              "path": [
+                "teams",
+                "{{last_team_id}}",
+                "members",
+                "{{last_member_id}}",
+                "cancel-invite"
+              ]
+            }
+          },
+          "response": []
         }
       ]
     },
@@ -919,6 +949,25 @@
                 "admins",
                 "{{last_admin_id}}",
                 "resend-invite"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "admins/:id/cancel-invite",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{owner_api_url}}/admins/{{last_admin_id}}/cancel-invite",
+              "host": [
+                "{{owner_api_url}}"
+              ],
+              "path": [
+                "admins",
+                "{{last_admin_id}}",
+                "cancel-invite"
               ]
             }
           },

--- a/src/data/repositories/token/index.ts
+++ b/src/data/repositories/token/index.ts
@@ -1,4 +1,4 @@
-import { createToken, issueToken, updateToken } from './mutations'
+import { createToken, deprecateOldTokens, issueToken, updateToken } from './mutations'
 import { findByToken } from './queries'
 
 export * from './types'
@@ -6,6 +6,7 @@ export * from './types'
 export const tokenRepo = {
   create: createToken,
   issue: issueToken,
+  deprecate: deprecateOldTokens,
   findByToken,
   update: updateToken,
 }

--- a/src/routes/@shared/index.ts
+++ b/src/routes/@shared/index.ts
@@ -10,6 +10,9 @@ import { userFilterRules } from './user-filter-rules'
 export type { AppCtx, ValidatedJsonCtx, ValidatedParamCtx, ValidatedParamJsonCtx, ValidatedQueryCtx } from './handler'
 
 export {
+  type CancelMemberInviteCtx,
+  type CancelMemberInviteParams,
+  cancelMemberInviteParamsSchema,
   type InviteMemberBody,
   inviteMemberBodySchema,
   type InviteMemberCtx,

--- a/src/routes/@shared/team-invites-schema.ts
+++ b/src/routes/@shared/team-invites-schema.ts
@@ -27,3 +27,11 @@ export const resendMemberInviteParamsSchema = z.object({
 
 export type ResendMemberInviteParams = z.infer<typeof resendMemberInviteParamsSchema>
 export type ResendMemberInviteCtx = ValidatedParamCtx<ResendMemberInviteParams>
+
+export const cancelMemberInviteParamsSchema = z.object({
+  teamId: dataRules.id,
+  memberId: dataRules.id,
+})
+
+export type CancelMemberInviteParams = z.infer<typeof cancelMemberInviteParamsSchema>
+export type CancelMemberInviteCtx = ValidatedParamCtx<CancelMemberInviteParams>

--- a/src/routes/owner/admins/handler.ts
+++ b/src/routes/owner/admins/handler.ts
@@ -1,7 +1,7 @@
 import { HttpStatus } from '@/net/http'
-import { getAdmin, getAdmins, inviteAdmin, resendAdminInvitation } from '@/use-cases/owner'
+import { cancelAdminInvite, getAdmin, getAdmins, inviteAdmin, resendAdminInvite } from '@/use-cases/owner'
 
-import type { CreateAdminCtx, GetAdminCtx, GetAdminsCtx, ResendAdminInviteCtx } from './schema'
+import type { CancelAdminInviteCtx, CreateAdminCtx, GetAdminCtx, GetAdminsCtx, ResendAdminInviteCtx } from './schema'
 
 export const getAdminsHandler = async (c: GetAdminsCtx) => {
   const { search, statuses, page, limit } = c.req.valid('query')
@@ -34,7 +34,15 @@ export const resendAdminInviteHandler = async (c: ResendAdminInviteCtx) => {
   const { adminId } = c.req.valid('param')
   const { id: inviterId } = c.get('user')
 
-  const result = await resendAdminInvitation(adminId, inviterId)
+  const result = await resendAdminInvite(adminId, inviterId)
+
+  return c.json(result, HttpStatus.OK)
+}
+
+export const cancelAdminInviteHandler = async (c: CancelAdminInviteCtx) => {
+  const { adminId } = c.req.valid('param')
+
+  const result = await cancelAdminInvite(adminId)
 
   return c.json(result, HttpStatus.OK)
 }

--- a/src/routes/owner/admins/index.ts
+++ b/src/routes/owner/admins/index.ts
@@ -5,12 +5,14 @@ import type { AppContext } from '@/context'
 import { requestValidator } from '@/middleware'
 
 import {
+  cancelAdminInviteHandler,
   createAdminHandler,
   getAdminHandler,
   getAdminsHandler,
   resendAdminInviteHandler,
 } from './handler'
 import {
+  cancelAdminInviteParamsSchema,
   createAdminBodySchema,
   getAdminParamsSchema,
   getAdminsQuerySchema,
@@ -41,6 +43,12 @@ ownerAdminsRoute.post(
   '/admins/:adminId/resend-invite',
   requestValidator('param', resendAdminInviteParamsSchema),
   resendAdminInviteHandler,
+)
+
+ownerAdminsRoute.post(
+  '/admins/:adminId/cancel-invite',
+  requestValidator('param', cancelAdminInviteParamsSchema),
+  cancelAdminInviteHandler,
 )
 
 export default ownerAdminsRoute

--- a/src/routes/owner/admins/schema.ts
+++ b/src/routes/owner/admins/schema.ts
@@ -41,3 +41,10 @@ export const resendAdminInviteParamsSchema = z.object({
 
 export type ResendAdminInviteParams = z.infer<typeof resendAdminInviteParamsSchema>
 export type ResendAdminInviteCtx = ValidatedParamCtx<ResendAdminInviteParams>
+
+export const cancelAdminInviteParamsSchema = z.object({
+  adminId: rules.data.id,
+})
+
+export type CancelAdminInviteParams = z.infer<typeof cancelAdminInviteParamsSchema>
+export type CancelAdminInviteCtx = ValidatedParamCtx<CancelAdminInviteParams>

--- a/src/routes/user/teams/members/handler.ts
+++ b/src/routes/user/teams/members/handler.ts
@@ -1,5 +1,6 @@
 import { HttpStatus } from '@/net/http'
 import {
+  cancelMemberInvite,
   getTeamMember,
   getTeamMembers,
   inviteMember,
@@ -8,6 +9,7 @@ import {
 } from '@/use-cases/user'
 
 import type {
+  CancelMemberInviteCtx,
   InviteMemberCtx,
   ResendMemberInviteCtx,
   TeamMemberParamsCtx,
@@ -55,6 +57,14 @@ export const resendMemberInviteHandler = async (c: ResendMemberInviteCtx) => {
   const { id: inviterId } = c.get('user')
 
   const result = await resendMemberInvite(teamId, memberId, inviterId)
+
+  return c.json(result, HttpStatus.OK)
+}
+
+export const cancelMemberInviteHandler = async (c: CancelMemberInviteCtx) => {
+  const { teamId, memberId } = c.req.valid('param')
+
+  const result = await cancelMemberInvite(teamId, memberId)
 
   return c.json(result, HttpStatus.OK)
 }

--- a/src/routes/user/teams/members/index.ts
+++ b/src/routes/user/teams/members/index.ts
@@ -5,6 +5,7 @@ import type { AppContext } from '@/context'
 import { requestValidator, teamAccessMiddleware } from '@/middleware'
 
 import {
+  cancelMemberInviteHandler,
   createMemberHandler,
   getTeamMemberHandler,
   getTeamMembersHandler,
@@ -12,6 +13,7 @@ import {
   updateTeamMemberHandler,
 } from './handler'
 import {
+  cancelMemberInviteParamsSchema,
   createMemberParamsSchema,
   inviteMemberBodySchema,
   resendMemberInviteParamsSchema,
@@ -57,6 +59,13 @@ teamsMembersRoute.post(
   requestValidator('param', resendMemberInviteParamsSchema),
   teamAccessMiddleware,
   resendMemberInviteHandler,
+)
+
+teamsMembersRoute.post(
+  '/:memberId/cancel-invite',
+  requestValidator('param', cancelMemberInviteParamsSchema),
+  teamAccessMiddleware,
+  cancelMemberInviteHandler,
 )
 
 export default teamsMembersRoute

--- a/src/routes/user/teams/members/schema.ts
+++ b/src/routes/user/teams/members/schema.ts
@@ -33,6 +33,8 @@ export type UpdateTeamMemberBody = z.infer<typeof updateTeamMemberBodySchema>
 export type UpdateTeamMemberCtx = ValidatedParamJsonCtx<TeamMemberParams, UpdateTeamMemberBody>
 
 export {
+  type CancelMemberInviteCtx,
+  cancelMemberInviteParamsSchema,
   type ResendMemberInviteCtx,
   resendMemberInviteParamsSchema,
 } from '../../../@shared'

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -7,7 +7,7 @@ import AppError from '@/errors/app-error'
 import ErrorCode from '@/errors/codes'
 import { Role, Status } from '@/types'
 
-import { getAdmin, getAdmins, inviteAdmin, resendAdminInvite } from '../admins'
+import { cancelAdminInvite, getAdmin, getAdmins, inviteAdmin, resendAdminInvite } from '../admins'
 
 describe('getAdmins', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
@@ -508,6 +508,92 @@ describe('resendAdminInvite', () => {
       'new-invitation-token',
       'Owner',
       'Test Company',
+    )
+    expect(result).toEqual({ success: true })
+  })
+})
+
+describe('cancelAdminInvite', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockAdmin: User
+  let mockFindById: any
+  let mockTokenDeprecate: any
+  let mockUserUpdate: any
+  let mockTransaction: any
+
+  beforeEach(async () => {
+    mockAdmin = {
+      id: testUuids.ADMIN_1,
+      firstName: 'Admin',
+      lastName: 'User',
+      email: 'admin@example.com',
+      role: Role.Admin,
+      status: Status.Pending,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+    }
+
+    mockFindById = mock(async () => mockAdmin)
+    mockTokenDeprecate = mock(async () => {})
+    mockUserUpdate = mock(async () => ({ ...mockAdmin, status: Status.Archived }))
+
+    // eslint-disable-next-line ts/no-unsafe-return
+    mockTransaction = mock(async (callback: any) => callback({}))
+
+    await moduleMocker.mock('@/data', () => ({
+      userRepo: { findById: mockFindById, update: mockUserUpdate },
+      tokenRepo: { deprecate: mockTokenDeprecate },
+      db: { transaction: mockTransaction },
+    }))
+
+    await moduleMocker.mock('@/security/token', () => ({
+      TokenType: { UserInvite: 'user_invite' },
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should throw NotFound when admin does not exist', async () => {
+    mockFindById.mockImplementation(async () => undefined)
+
+    expect(cancelAdminInvite(testUuids.NON_EXISTENT)).rejects.toThrow(AppError)
+    expect(cancelAdminInvite(testUuids.NON_EXISTENT)).rejects.toMatchObject({
+      code: ErrorCode.NotFound,
+      message: 'Admin not found',
+    })
+  })
+
+  it('should throw NotFound when user is not Admin role', async () => {
+    mockFindById.mockImplementation(async () => ({ ...mockAdmin, role: Role.User }))
+
+    expect(cancelAdminInvite(testUuids.ADMIN_1)).rejects.toThrow(AppError)
+    expect(cancelAdminInvite(testUuids.ADMIN_1)).rejects.toMatchObject({
+      code: ErrorCode.NotFound,
+      message: 'Admin not found',
+    })
+  })
+
+  it('should throw BadRequest when admin has already accepted invitation', async () => {
+    mockFindById.mockImplementation(async () => ({ ...mockAdmin, status: Status.Active }))
+
+    expect(cancelAdminInvite(testUuids.ADMIN_1)).rejects.toThrow(AppError)
+    expect(cancelAdminInvite(testUuids.ADMIN_1)).rejects.toMatchObject({
+      code: ErrorCode.BadRequest,
+      message: 'Admin has already accepted invitation',
+    })
+  })
+
+  it('should deprecate token and archive user in a transaction', async () => {
+    const result = await cancelAdminInvite(testUuids.ADMIN_1)
+
+    expect(mockTokenDeprecate).toHaveBeenCalledWith(testUuids.ADMIN_1, 'user_invite', expect.anything())
+    expect(mockUserUpdate).toHaveBeenCalledWith(
+      testUuids.ADMIN_1,
+      { status: Status.Archived },
+      expect.anything(),
     )
     expect(result).toEqual({ success: true })
   })

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -7,7 +7,7 @@ import AppError from '@/errors/app-error'
 import ErrorCode from '@/errors/codes'
 import { Role, Status } from '@/types'
 
-import { getAdmin, getAdmins, inviteAdmin, resendAdminInvitation } from '../admins'
+import { getAdmin, getAdmins, inviteAdmin, resendAdminInvite } from '../admins'
 
 describe('getAdmins', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
@@ -328,7 +328,7 @@ describe('inviteAdmin', () => {
   })
 })
 
-describe('resendAdminInvitation', () => {
+describe('resendAdminInvite', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
   let mockAdmin: User
@@ -416,11 +416,11 @@ describe('resendAdminInvitation', () => {
       return undefined
     })
 
-    expect(resendAdminInvitation(
+    expect(resendAdminInvite(
       testUuids.NON_EXISTENT,
       testUuids.OWNER_1,
     )).rejects.toThrow(AppError)
-    expect(resendAdminInvitation(
+    expect(resendAdminInvite(
       testUuids.NON_EXISTENT,
       testUuids.OWNER_1,
     )).rejects.toMatchObject({
@@ -441,8 +441,8 @@ describe('resendAdminInvitation', () => {
       return undefined
     })
 
-    expect(resendAdminInvitation(testUuids.ADMIN_1, testUuids.OWNER_1)).rejects.toThrow(AppError)
-    expect(resendAdminInvitation(testUuids.ADMIN_1, testUuids.OWNER_1)).rejects.toMatchObject({
+    expect(resendAdminInvite(testUuids.ADMIN_1, testUuids.OWNER_1)).rejects.toThrow(AppError)
+    expect(resendAdminInvite(testUuids.ADMIN_1, testUuids.OWNER_1)).rejects.toMatchObject({
       code: ErrorCode.NotFound,
       message: 'Admin not found',
     })
@@ -460,8 +460,8 @@ describe('resendAdminInvitation', () => {
       return undefined
     })
 
-    expect(resendAdminInvitation(testUuids.ADMIN_1, testUuids.OWNER_1)).rejects.toThrow(AppError)
-    expect(resendAdminInvitation(testUuids.ADMIN_1, testUuids.OWNER_1)).rejects.toMatchObject({
+    expect(resendAdminInvite(testUuids.ADMIN_1, testUuids.OWNER_1)).rejects.toThrow(AppError)
+    expect(resendAdminInvite(testUuids.ADMIN_1, testUuids.OWNER_1)).rejects.toMatchObject({
       code: ErrorCode.BadRequest,
       message: 'Admin has already accepted invitation',
     })
@@ -476,11 +476,11 @@ describe('resendAdminInvitation', () => {
       return undefined
     })
 
-    expect(resendAdminInvitation(
+    expect(resendAdminInvite(
       testUuids.ADMIN_1,
       testUuids.NON_EXISTENT,
     )).rejects.toThrow(AppError)
-    expect(resendAdminInvitation(
+    expect(resendAdminInvite(
       testUuids.ADMIN_1,
       testUuids.NON_EXISTENT,
     )).rejects.toMatchObject({
@@ -490,7 +490,7 @@ describe('resendAdminInvitation', () => {
   })
 
   it('should issue new token and send invitation email with current inviter name', async () => {
-    const result = await resendAdminInvitation(testUuids.ADMIN_1, testUuids.OWNER_1)
+    const result = await resendAdminInvite(testUuids.ADMIN_1, testUuids.OWNER_1)
 
     expect(mockTokenIssue).toHaveBeenCalledWith(
       testUuids.ADMIN_1,

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -120,7 +120,7 @@ export const inviteAdmin = async (params: AdminInvitationParams, inviterId: stri
   return { admin }
 }
 
-export const resendAdminInvitation = async (adminId: string, inviterId: string) => {
+export const resendAdminInvite = async (adminId: string, inviterId: string) => {
   const [admin, inviter] = await Promise.all([
     userRepo.findById(adminId),
     userRepo.findById(inviterId),
@@ -152,6 +152,25 @@ export const resendAdminInvitation = async (adminId: string, inviterId: string) 
     inviter.firstName,
     env.COMPANY_NAME,
   )
+
+  return { success: true }
+}
+
+export const cancelAdminInvite = async (adminId: string) => {
+  const admin = await userRepo.findById(adminId)
+
+  if (!admin || admin.role !== Role.Admin) {
+    throw new AppError(ErrorCode.NotFound, 'Admin not found')
+  }
+
+  if (admin.status !== Status.Pending) {
+    throw new AppError(ErrorCode.BadRequest, 'Admin has already accepted invitation')
+  }
+
+  await db.transaction(async (tx) => {
+    await tokenRepo.deprecate(adminId, TokenType.UserInvite, tx)
+    await userRepo.update(adminId, { status: Status.Archived }, tx)
+  })
 
   return { success: true }
 }

--- a/src/use-cases/owner/index.ts
+++ b/src/use-cases/owner/index.ts
@@ -1,1 +1,1 @@
-export { getAdmin, getAdmins, inviteAdmin, resendAdminInvitation } from './admins'
+export { cancelAdminInvite, getAdmin, getAdmins, inviteAdmin, resendAdminInvite } from './admins'

--- a/src/use-cases/user/__tests__/invites.test.ts
+++ b/src/use-cases/user/__tests__/invites.test.ts
@@ -7,7 +7,7 @@ import AppError from '@/errors/app-error'
 import ErrorCode from '@/errors/codes'
 import { Role, Status } from '@/types'
 
-import { inviteMember, resendMemberInvite } from '../invites'
+import { cancelMemberInvite, inviteMember, resendMemberInvite } from '../invites'
 
 const { TEAM_1, USER_1, USER_2 } = testUuids
 
@@ -395,6 +395,106 @@ describe('resendMemberInvite', () => {
   it('should return success true', async () => {
     const result = await resendMemberInvite(TEAM_1, USER_1, USER_2)
 
+    expect(result).toEqual({ success: true })
+  })
+})
+
+describe('cancelMemberInvite', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockMember: User
+  let mockMembership: TeamMember
+  let mockUserRepoFindById: any
+  let mockTeamRepoFindMember: any
+  let mockTokenDeprecate: any
+  let mockUserUpdate: any
+  let mockTransaction: any
+
+  beforeEach(async () => {
+    mockMember = {
+      id: USER_1,
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john@example.com',
+      status: Status.Pending,
+      role: Role.User,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+    }
+
+    mockMembership = {
+      id: 1,
+      userId: USER_1,
+      teamId: TEAM_1,
+      position: 'Developer',
+      invitedBy: USER_2,
+      joinedAt: new Date('2024-01-01'),
+    }
+
+    mockUserRepoFindById = mock(async () => mockMember)
+    mockTeamRepoFindMember = mock(async () => mockMembership)
+    mockTokenDeprecate = mock(async () => {})
+    mockUserUpdate = mock(async () => ({ ...mockMember, status: Status.Archived }))
+
+    mockTransaction = mock(async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => {
+      return callback({})
+    })
+
+    await moduleMocker.mock('@/data', () => ({
+      userRepo: { findById: mockUserRepoFindById, update: mockUserUpdate },
+      teamRepo: { findMember: mockTeamRepoFindMember },
+      tokenRepo: { deprecate: mockTokenDeprecate },
+      db: { transaction: mockTransaction },
+    }))
+
+    await moduleMocker.mock('@/security/token', () => ({
+      TokenType: { UserInvite: 'user_invite' },
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should throw NotFound when member does not exist', async () => {
+    mockUserRepoFindById.mockImplementation(async () => undefined)
+
+    expect(cancelMemberInvite(TEAM_1, USER_1)).rejects.toThrow(AppError)
+    expect(cancelMemberInvite(TEAM_1, USER_1)).rejects.toMatchObject({
+      code: ErrorCode.NotFound,
+      message: 'Member not found',
+    })
+  })
+
+  it('should throw NotFound when member is not in team', async () => {
+    mockTeamRepoFindMember.mockImplementation(async () => undefined)
+
+    expect(cancelMemberInvite(TEAM_1, USER_1)).rejects.toThrow(AppError)
+    expect(cancelMemberInvite(TEAM_1, USER_1)).rejects.toMatchObject({
+      code: ErrorCode.NotFound,
+      message: 'Member not found',
+    })
+  })
+
+  it('should throw BadRequest when member has already accepted invitation', async () => {
+    mockUserRepoFindById.mockImplementation(async () => ({ ...mockMember, status: Status.Active }))
+
+    expect(cancelMemberInvite(TEAM_1, USER_1)).rejects.toThrow(AppError)
+    expect(cancelMemberInvite(TEAM_1, USER_1)).rejects.toMatchObject({
+      code: ErrorCode.BadRequest,
+      message: 'Member has already accepted invitation',
+    })
+  })
+
+  it('should deprecate token and archive user in a transaction', async () => {
+    const result = await cancelMemberInvite(TEAM_1, USER_1)
+
+    expect(mockTokenDeprecate).toHaveBeenCalledWith(USER_1, 'user_invite', expect.anything())
+    expect(mockUserUpdate).toHaveBeenCalledWith(
+      USER_1,
+      { status: Status.Archived },
+      expect.anything(),
+    )
     expect(result).toEqual({ success: true })
   })
 })

--- a/src/use-cases/user/index.ts
+++ b/src/use-cases/user/index.ts
@@ -1,4 +1,4 @@
-export { inviteMember, resendMemberInvite } from './invites'
+export { cancelMemberInvite, inviteMember, resendMemberInvite } from './invites'
 
 export { getUser, updateUser } from './me'
 

--- a/src/use-cases/user/invites.ts
+++ b/src/use-cases/user/invites.ts
@@ -144,3 +144,25 @@ export const resendMemberInvite = async (
 
   return { success: true }
 }
+
+export const cancelMemberInvite = async (teamId: string, memberId: string) => {
+  const [member, membership] = await Promise.all([
+    userRepo.findById(memberId),
+    teamRepo.findMember(memberId, teamId),
+  ])
+
+  if (!member || !membership) {
+    throw new AppError(ErrorCode.NotFound, 'Member not found')
+  }
+
+  if (member.status !== Status.Pending) {
+    throw new AppError(ErrorCode.BadRequest, 'Member has already accepted invitation')
+  }
+
+  await db.transaction(async (tx) => {
+    await tokenRepo.deprecate(memberId, TokenType.UserInvite, tx)
+    await userRepo.update(memberId, { status: Status.Archived }, tx)
+  })
+
+  return { success: true }
+}


### PR DESCRIPTION
1. [Feature]: Add `POST /owner/admins/:adminId/cancel-invite` endpoint to cancel pending admin invitations
2. [Feature]: Add `POST /user/teams/:teamId/members/:memberId/cancel-invite` endpoint to cancel pending member invitations
3. [Improvement]: Rename `resendAdminInvitation` to `resendAdminInvite` for naming consistency
4. [Improvement]: Expose `tokenRepo.deprecate` to allow direct token deprecation without re-issuing
5. [Feature]: Cancelling an invite deprecates the token and archives the user in a single transaction
6. [Feature]: Add unit tests for `cancelAdminInvite` and `cancelMemberInvite` covering all error and success cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)