### PR TITLE
Enrich team member and admin inviter details

### DIFF
--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -1,4 +1,5 @@
 import { and, count, desc, eq, sql } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
 
 import type { Database } from '../../clients'
 import type { PaginatedResult, PaginationParams } from '../pagination'
@@ -85,8 +86,9 @@ export const findTeamMembers = async (
   tx?: Database,
 ): Promise<TeamMemberDetails[]> => {
   const executor = tx || db
+  const invitersTable = alias(usersTable, 'inviters')
 
-  return executor
+  const rows = await executor
     .select({
       id: teamMembersTable.userId,
       firstName: usersTable.firstName,
@@ -94,13 +96,20 @@ export const findTeamMembers = async (
       email: usersTable.email,
       status: usersTable.status,
       position: teamMembersTable.position,
-      invitedBy: teamMembersTable.invitedBy,
       joinedAt: teamMembersTable.joinedAt,
+      inviter: {
+        id: invitersTable.id,
+        firstName: invitersTable.firstName,
+        lastName: invitersTable.lastName,
+      },
     })
     .from(teamMembersTable)
     .innerJoin(usersTable, eq(teamMembersTable.userId, usersTable.id))
+    .leftJoin(invitersTable, eq(teamMembersTable.invitedBy, invitersTable.id))
     .where(eq(teamMembersTable.teamId, teamId))
     .orderBy(desc(teamMembersTable.joinedAt))
+
+  return rows
 }
 
 export const findTeamMember = async (
@@ -109,8 +118,9 @@ export const findTeamMember = async (
   tx?: Database,
 ): Promise<TeamMemberDetails | undefined> => {
   const executor = tx || db
+  const invitersTable = alias(usersTable, 'inviters')
 
-  const [member] = await executor
+  const [row] = await executor
     .select({
       id: teamMembersTable.userId,
       firstName: usersTable.firstName,
@@ -118,11 +128,16 @@ export const findTeamMember = async (
       email: usersTable.email,
       status: usersTable.status,
       position: teamMembersTable.position,
-      invitedBy: teamMembersTable.invitedBy,
       joinedAt: teamMembersTable.joinedAt,
+      inviter: {
+        id: invitersTable.id,
+        firstName: invitersTable.firstName,
+        lastName: invitersTable.lastName,
+      },
     })
     .from(teamMembersTable)
     .innerJoin(usersTable, eq(teamMembersTable.userId, usersTable.id))
+    .leftJoin(invitersTable, eq(teamMembersTable.invitedBy, invitersTable.id))
     .where(
       and(
         eq(teamMembersTable.userId, userId),
@@ -130,7 +145,7 @@ export const findTeamMember = async (
       ),
     )
 
-  return member
+  return row
 }
 
 export const findTeamWithMembers = async (

--- a/src/data/repositories/team/types.ts
+++ b/src/data/repositories/team/types.ts
@@ -11,6 +11,12 @@ export type CreateTeamMemberInput = typeof teamMembersTable.$inferInsert
 export type Team = TeamRecord
 export type TeamMember = TeamMemberRecord
 
+export interface TeamMemberInviter {
+  id: string | null
+  firstName: string | null
+  lastName: string | null
+}
+
 export interface TeamMemberDetails {
   id: string
   firstName: string
@@ -18,7 +24,7 @@ export interface TeamMemberDetails {
   email: string
   status: string
   position: string | null
-  invitedBy: string | null
+  inviter: TeamMemberInviter | null
   joinedAt: Date | null
 }
 

--- a/src/data/repositories/user-role/index.ts
+++ b/src/data/repositories/user-role/index.ts
@@ -1,11 +1,11 @@
 import { assign, remove } from './mutations'
-import { findByUserId, findInvites } from './queries'
+import { findByUserId, findInviters } from './queries'
 
 export * from './types'
 
 export const userRoleRepo = {
   assign,
   findByUserId,
-  findInvites,
+  findInviters,
   remove,
 }

--- a/src/data/repositories/user-role/queries.ts
+++ b/src/data/repositories/user-role/queries.ts
@@ -1,7 +1,7 @@
 import { eq, inArray } from 'drizzle-orm'
 
 import type { Database } from '../../clients'
-import type { InviteInfo, UserRoleRecord } from './types'
+import type { Inviter, UserRoleRecord } from './types'
 
 import { db } from '../../clients'
 import { userRolesTable, usersTable } from '../../schema'
@@ -23,7 +23,7 @@ export const findByUserId = async (
 export const findInviters = async (
   userIds: string[],
   tx?: Database,
-): Promise<Map<string, InviteInfo>> => {
+): Promise<Map<string, Inviter>> => {
   if (userIds.length === 0) {
     return new Map()
   }
@@ -41,6 +41,8 @@ export const findInviters = async (
     .where(inArray(userRolesTable.userId, userIds))
 
   return new Map(rows.map(r => [r.userId, {
-    inviter: { id: r.inviterId, firstName: r.firstName, lastName: r.lastName },
+    id: r.inviterId,
+    firstName: r.firstName,
+    lastName: r.lastName,
   }]))
 }

--- a/src/data/repositories/user-role/queries.ts
+++ b/src/data/repositories/user-role/queries.ts
@@ -20,7 +20,7 @@ export const findByUserId = async (
   return found
 }
 
-export const findInvites = async (
+export const findInviters = async (
   userIds: string[],
   tx?: Database,
 ): Promise<Map<string, InviteInfo>> => {
@@ -35,15 +35,12 @@ export const findInvites = async (
       inviterId: usersTable.id,
       firstName: usersTable.firstName,
       lastName: usersTable.lastName,
-      invitedAt: userRolesTable.assignedAt,
     })
     .from(userRolesTable)
     .innerJoin(usersTable, eq(userRolesTable.invitedBy, usersTable.id))
     .where(inArray(userRolesTable.userId, userIds))
 
   return new Map(rows.map(r => [r.userId, {
-    inviterId: r.inviterId,
-    inviterName: r.lastName ? `${r.firstName} ${r.lastName}` : r.firstName,
-    invitedAt: r.invitedAt,
+    inviter: { id: r.inviterId, firstName: r.firstName, lastName: r.lastName },
   }]))
 }

--- a/src/data/repositories/user-role/types.ts
+++ b/src/data/repositories/user-role/types.ts
@@ -10,8 +10,12 @@ export interface CreateUserRoleInput {
   invitedBy?: string
 }
 
+export interface InviteInviter {
+  id: string
+  firstName: string
+  lastName: string | null
+}
+
 export interface InviteInfo {
-  inviterId: string
-  inviterName: string
-  invitedAt: Date
+  inviter: InviteInviter
 }

--- a/src/data/repositories/user-role/types.ts
+++ b/src/data/repositories/user-role/types.ts
@@ -10,12 +10,8 @@ export interface CreateUserRoleInput {
   invitedBy?: string
 }
 
-export interface InviteInviter {
+export interface Inviter {
   id: string
   firstName: string
   lastName: string | null
-}
-
-export interface InviteInfo {
-  inviter: InviteInviter
 }

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -82,7 +82,9 @@ describe('getAdmins', () => {
 
   it('should include invite info when available', async () => {
     const inviteInfo = {
-      inviter: { id: testUuids.OWNER_1, firstName: 'Owner', lastName: 'User' },
+      id: testUuids.OWNER_1,
+      firstName: 'Owner',
+      lastName: 'User',
     }
     mockFindInvites.mockImplementation(
       async () => new Map([[testUuids.ADMIN_1, inviteInfo]]),
@@ -136,7 +138,9 @@ describe('getAdmin', () => {
 
   it('should include invite info when available', async () => {
     const inviteInfo = {
-      inviter: { id: testUuids.OWNER_1, firstName: 'Owner', lastName: 'User' },
+      id: testUuids.OWNER_1,
+      firstName: 'Owner',
+      lastName: 'User',
     }
     mockFindInvites.mockImplementation(
       async () => new Map([[testUuids.ADMIN_1, inviteInfo]]),

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -40,7 +40,7 @@ describe('getAdmins', () => {
 
     await moduleMocker.mock('@/data', () => ({
       userRepo: { search: mockUserRepoSearch },
-      userRoleRepo: { findInvites: mockFindInvites },
+      userRoleRepo: { findInviters: mockFindInvites },
     }))
   })
 
@@ -62,7 +62,7 @@ describe('getAdmins', () => {
 
     expect(result).toEqual({
       data: {
-        admins: mockSearchResult.users.map(u => ({ ...u, invite: undefined })),
+        admins: mockSearchResult.users.map(u => ({ ...u, inviter: undefined })),
       },
       pagination: mockSearchResult.pagination,
     })
@@ -82,9 +82,7 @@ describe('getAdmins', () => {
 
   it('should include invite info when available', async () => {
     const inviteInfo = {
-      inviterId: testUuids.OWNER_1,
-      inviterName: 'Owner User',
-      invitedAt: new Date('2024-01-01'),
+      inviter: { id: testUuids.OWNER_1, firstName: 'Owner', lastName: 'User' },
     }
     mockFindInvites.mockImplementation(
       async () => new Map([[testUuids.ADMIN_1, inviteInfo]]),
@@ -93,7 +91,7 @@ describe('getAdmins', () => {
     const result = await getAdmins({ roles: [] }, DEFAULT_PAGINATION)
 
     expect(mockFindInvites).toHaveBeenCalledWith([testUuids.ADMIN_1])
-    expect(result.data.admins[0].invite).toEqual(inviteInfo)
+    expect(result.data.admins[0].inviter).toEqual(inviteInfo)
   })
 })
 
@@ -121,7 +119,7 @@ describe('getAdmin', () => {
 
     await moduleMocker.mock('@/data', () => ({
       userRepo: { findById: mockFindById },
-      userRoleRepo: { findInvites: mockFindInvites },
+      userRoleRepo: { findInviters: mockFindInvites },
     }))
   })
 
@@ -133,14 +131,12 @@ describe('getAdmin', () => {
     const result = await getAdmin(testUuids.ADMIN_1)
 
     expect(mockFindById).toHaveBeenCalledWith(testUuids.ADMIN_1)
-    expect(result).toEqual({ admin: { ...mockAdmin, invite: undefined } })
+    expect(result).toEqual({ admin: { ...mockAdmin, inviter: undefined } })
   })
 
   it('should include invite info when available', async () => {
     const inviteInfo = {
-      inviterId: testUuids.OWNER_1,
-      inviterName: 'Owner User',
-      invitedAt: new Date('2024-01-01'),
+      inviter: { id: testUuids.OWNER_1, firstName: 'Owner', lastName: 'User' },
     }
     mockFindInvites.mockImplementation(
       async () => new Map([[testUuids.ADMIN_1, inviteInfo]]),
@@ -149,7 +145,7 @@ describe('getAdmin', () => {
     const result = await getAdmin(testUuids.ADMIN_1)
 
     expect(mockFindInvites).toHaveBeenCalledWith([testUuids.ADMIN_1])
-    expect(result.admin.invite).toEqual(inviteInfo)
+    expect(result.admin.inviter).toEqual(inviteInfo)
   })
 
   it('should throw NotFound error when admin does not exist', async () => {

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -17,11 +17,11 @@ export const getAdmins = async (params: SearchParams, pagination: PaginationPara
   const result = await userRepo.search(normalizeRoles(params), pagination)
 
   const adminIds = result.users.map(u => u.id)
-  const invites = await userRoleRepo.findInvites(adminIds)
+  const inviters = await userRoleRepo.findInviters(adminIds)
 
   const admins = result.users.map(admin => ({
     ...admin,
-    invite: invites.get(admin.id),
+    inviter: inviters.get(admin.id),
   }))
 
   return {
@@ -37,12 +37,12 @@ export const getAdmin = async (adminId: string) => {
     throw new AppError(ErrorCode.NotFound, 'Admin not found')
   }
 
-  const invites = await userRoleRepo.findInvites([adminId])
+  const inviters = await userRoleRepo.findInviters([adminId])
 
   return {
     admin: {
       ...admin,
-      invite: invites.get(adminId),
+      inviter: inviters.get(adminId),
     },
   }
 }


### PR DESCRIPTION
1. [Feature]: Join inviter user record into team member queries via left join
2. [Improvement]: Replace flat `invitedBy` string with nested `inviter` object on `TeamMemberDetails`
3. [Improvement]: Flatten `InviteInfo` wrapper — map values are now `Inviter` directly
4. [Improvement]: Rename `findInvites` → `findInviters` and `invite` field → `inviter` on admin responses
5. [Improvement]: Rename `InviteInviter` → `Inviter` for cleaner type naming