### PR TITLE
Optimize team member queries and standardize API

### DIFF
--- a/src/data/repositories/team/index.ts
+++ b/src/data/repositories/team/index.ts
@@ -8,7 +8,7 @@ import {
   findTeamById,
   findTeamMember,
   findTeamMembers,
-  findTeamWithMembers,
+  findTeamWithMemberCount,
   findUserTeam,
   searchTeams,
 } from './queries'
@@ -23,7 +23,7 @@ const teamMutations = {
 }
 
 const teamQueries = {
-  find: findTeamWithMembers,
+  find: findTeamWithMemberCount,
   findById: findTeamById,
   findUserTeam,
   search: searchTeams,

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -3,7 +3,7 @@ import { alias } from 'drizzle-orm/pg-core'
 
 import type { Database } from '../../clients'
 import type { PaginatedResult, PaginationParams } from '../pagination'
-import type { Team, TeamMemberDetails, TeamWithMembers, UserTeamInfo } from './types'
+import type { Team, TeamMemberDetails, TeamWithMemberCount, UserTeamInfo } from './types'
 
 import { db } from '../../clients'
 import { teamMembersTable, teamsTable, usersTable } from '../../schema'
@@ -112,6 +112,20 @@ export const findTeamMembers = async (
   return rows
 }
 
+export const countTeamMembers = async (
+  teamId: string,
+  tx?: Database,
+): Promise<number> => {
+  const executor = tx || db
+
+  const [result] = await executor
+    .select({ value: count() })
+    .from(teamMembersTable)
+    .where(eq(teamMembersTable.teamId, teamId))
+
+  return result?.value ?? 0
+}
+
 export const findTeamMember = async (
   userId: string,
   teamId: string,
@@ -148,13 +162,13 @@ export const findTeamMember = async (
   return row
 }
 
-export const findTeamWithMembers = async (
+export const findTeamWithMemberCount = async (
   teamId: string,
   tx?: Database,
-): Promise<TeamWithMembers | undefined> => {
-  const [team, members] = await Promise.all([
+): Promise<TeamWithMemberCount | undefined> => {
+  const [team, memberCount] = await Promise.all([
     findTeamById(teamId, tx),
-    findTeamMembers(teamId, tx),
+    countTeamMembers(teamId, tx),
   ])
 
   if (!team) {
@@ -163,7 +177,7 @@ export const findTeamWithMembers = async (
 
   return {
     ...team,
-    members,
+    memberCount,
   }
 }
 

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -81,12 +81,21 @@ export const findTeamById = async (
   return team
 }
 
+/**
+ * Gets all team members or a single member if userId is specified
+ */
 export const findTeamMembers = async (
   teamId: string,
+  userId?: string,
   tx?: Database,
 ): Promise<TeamMemberDetails[]> => {
   const executor = tx || db
   const invitersTable = alias(usersTable, 'inviters')
+
+  const whereConditions = [eq(teamMembersTable.teamId, teamId)]
+  if (userId) {
+    whereConditions.push(eq(teamMembersTable.userId, userId))
+  }
 
   const rows = await executor
     .select({
@@ -106,7 +115,7 @@ export const findTeamMembers = async (
     .from(teamMembersTable)
     .innerJoin(usersTable, eq(teamMembersTable.userId, usersTable.id))
     .leftJoin(invitersTable, eq(teamMembersTable.invitedBy, invitersTable.id))
-    .where(eq(teamMembersTable.teamId, teamId))
+    .where(and(...whereConditions))
     .orderBy(desc(teamMembersTable.joinedAt))
 
   return rows
@@ -127,39 +136,13 @@ export const countTeamMembers = async (
 }
 
 export const findTeamMember = async (
-  userId: string,
   teamId: string,
+  userId: string,
   tx?: Database,
 ): Promise<TeamMemberDetails | undefined> => {
-  const executor = tx || db
-  const invitersTable = alias(usersTable, 'inviters')
+  const members = await findTeamMembers(teamId, userId, tx)
 
-  const [row] = await executor
-    .select({
-      id: teamMembersTable.userId,
-      firstName: usersTable.firstName,
-      lastName: usersTable.lastName,
-      email: usersTable.email,
-      status: usersTable.status,
-      position: teamMembersTable.position,
-      joinedAt: teamMembersTable.joinedAt,
-      inviter: {
-        id: invitersTable.id,
-        firstName: invitersTable.firstName,
-        lastName: invitersTable.lastName,
-      },
-    })
-    .from(teamMembersTable)
-    .innerJoin(usersTable, eq(teamMembersTable.userId, usersTable.id))
-    .leftJoin(invitersTable, eq(teamMembersTable.invitedBy, invitersTable.id))
-    .where(
-      and(
-        eq(teamMembersTable.userId, userId),
-        eq(teamMembersTable.teamId, teamId),
-      ),
-    )
-
-  return row
+  return members[0]
 }
 
 export const findTeamWithMemberCount = async (

--- a/src/data/repositories/team/types.ts
+++ b/src/data/repositories/team/types.ts
@@ -28,8 +28,8 @@ export interface TeamMemberDetails {
   joinedAt: Date | null
 }
 
-export type TeamWithMembers = Team & {
-  members: TeamMemberDetails[]
+export type TeamWithMemberCount = Team & {
+  memberCount: number
 }
 
 export interface UserTeamInfo {

--- a/src/middleware/team-access/__tests__/team-access.test.ts
+++ b/src/middleware/team-access/__tests__/team-access.test.ts
@@ -53,7 +53,7 @@ describe('Team Access Middleware', () => {
       const res = await app.request(`/teams/${testUuids.TEAM_1}`)
 
       expect(res.status).toBe(HttpStatus.OK)
-      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(testUuids.USER_1, testUuids.TEAM_1)
+      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(testUuids.TEAM_1, testUuids.USER_1)
 
       const json = await res.json()
       expect(json.message).toBe('success')
@@ -77,7 +77,7 @@ describe('Team Access Middleware', () => {
       const res = await app.request(`/teams/${testUuids.TEAM_1}`)
 
       expect(res.status).toBe(HttpStatus.FORBIDDEN)
-      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(testUuids.USER_1, testUuids.TEAM_1)
+      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(testUuids.TEAM_1, testUuids.USER_1)
 
       const json = await res.json()
       expect(json.code).toBe(ErrorCode.Forbidden)
@@ -101,7 +101,7 @@ describe('Team Access Middleware', () => {
       const res = await app.request(`/teams/${testUuids.TEAM_2}`)
 
       expect(res.status).toBe(HttpStatus.FORBIDDEN)
-      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(testUuids.USER_1, testUuids.TEAM_2)
+      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(testUuids.TEAM_2, testUuids.USER_1)
     })
   })
 
@@ -249,7 +249,7 @@ describe('Team Access Middleware', () => {
       await app.request(`/teams/${testUuids.TEAM_1}`)
 
       expect(mockTeamRepoFindMember).toHaveBeenCalledTimes(1)
-      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(testUuids.USER_1, testUuids.TEAM_1)
+      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(testUuids.TEAM_1, testUuids.USER_1)
     })
   })
 

--- a/src/middleware/team-access/team-access.ts
+++ b/src/middleware/team-access/team-access.ts
@@ -26,7 +26,7 @@ export const teamAccessMiddleware = createMiddleware<AppContext>(async (c, next)
   }
 
   // Regular users must be team members
-  const membership = await teamRepo.findMember(userId, teamId)
+  const membership = await teamRepo.findMember(teamId, userId)
 
   if (!membership) {
     throw new AppError(ErrorCode.Forbidden)

--- a/src/use-cases/user/__tests__/teams.test.ts
+++ b/src/use-cases/user/__tests__/teams.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type { Team, TeamSearchResult, TeamWithMembers } from '@/data'
+import type { Team, TeamSearchResult, TeamWithMemberCount } from '@/data'
 
 import { ModuleMocker, testUuids } from '@/__tests__'
 import AppError from '@/errors/app-error'
@@ -68,7 +68,7 @@ describe('getTeams', () => {
 describe('getTeam', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
-  let mockTeam: TeamWithMembers
+  let mockTeam: TeamWithMemberCount
   let mockTeamRepoFind: any
   let mockTeamRepoFindMember: any
 
@@ -80,7 +80,7 @@ describe('getTeam', () => {
       description: 'A test team',
       createdAt: new Date('2024-01-01'),
       updatedAt: new Date('2024-01-01'),
-      members: [],
+      memberCount: 0,
     }
 
     mockTeamRepoFind = mock(async () => mockTeam)

--- a/src/use-cases/user/invites.ts
+++ b/src/use-cases/user/invites.ts
@@ -104,7 +104,7 @@ export const resendMemberInvite = async (
     userRepo.findById(inviterId),
     teamRepo.findById(teamId),
     userRepo.findById(memberId),
-    teamRepo.findMember(memberId, teamId),
+    teamRepo.findMember(teamId, memberId),
   ])
 
   if (!inviter) {
@@ -148,7 +148,7 @@ export const resendMemberInvite = async (
 export const cancelMemberInvite = async (teamId: string, memberId: string) => {
   const [member, membership] = await Promise.all([
     userRepo.findById(memberId),
-    teamRepo.findMember(memberId, teamId),
+    teamRepo.findMember(teamId, memberId),
   ])
 
   if (!member || !membership) {

--- a/src/use-cases/user/members.ts
+++ b/src/use-cases/user/members.ts
@@ -11,7 +11,7 @@ export const getTeamMember = async (
   teamId: string,
   memberId: string,
 ) => {
-  const member = await teamRepo.findMember(memberId, teamId)
+  const member = await teamRepo.findMember(teamId, memberId)
 
   if (!member) {
     throw new AppError(ErrorCode.NotFound, 'Member not found')
@@ -29,7 +29,7 @@ export const updateTeamMember = async (
   memberId: string,
   params: UpdateTeamMemberParams,
 ) => {
-  const existing = await teamRepo.findMember(memberId, teamId)
+  const existing = await teamRepo.findMember(teamId, memberId)
 
   if (!existing) {
     throw new AppError(ErrorCode.NotFound, 'Member not found')


### PR DESCRIPTION
1. [Performance]: Optimize team queries to use member count instead of full member data
2. [Improvement]: Consolidate findTeamMember and findTeamMembers into single reusable function
3. [Improvement]: Standardize parameter order across team repository methods (teamId first, userId second)
4. [Improvement]: Add JSDoc documentation for enhanced findTeamMembers function
5. [Fix]: Update all usage sites and tests to match new standardized parameter order

This refactoring eliminates code duplication, improves query performance, and provides a more consistent API surface for team member operations.