### PR TITLE
Add per-user permission overrides

### DIFF
--- a/src/data/migrations/0001_panoramic_norman_osborn.sql
+++ b/src/data/migrations/0001_panoramic_norman_osborn.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "user_permissions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" uuid NOT NULL,
+	"permission_id" integer NOT NULL,
+	"granted" boolean NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user_permissions" ADD CONSTRAINT "user_permissions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_permissions" ADD CONSTRAINT "user_permissions_permission_id_permissions_id_fk" FOREIGN KEY ("permission_id") REFERENCES "public"."permissions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "unique_user_permission" ON "user_permissions" USING btree ("user_id","permission_id");

--- a/src/data/migrations/meta/0001_snapshot.json
+++ b/src/data/migrations/meta/0001_snapshot.json
@@ -1,0 +1,1037 @@
+{
+  "id": "1008220f-a313-4ebc-855f-c324faf8c0af",
+  "prevId": "02cb0f63-25ad-4042-ae39-9b736663451c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth": {
+      "name": "auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "auth_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_auth": {
+          "name": "unique_auth",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_user_id_index": {
+          "name": "auth_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_user_id_users_id_fk": {
+          "name": "auth_user_id_users_id_fk",
+          "tableFrom": "auth",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "resource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_permission": {
+          "name": "unique_permission",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_role_permission": {
+          "name": "unique_role_permission",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_permissions": {
+      "name": "user_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted": {
+          "name": "granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_user_permission": {
+          "name": "unique_user_permission",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_permissions_user_id_users_id_fk": {
+          "name": "user_permissions_user_id_users_id_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_permissions_permission_id_permissions_id_fk": {
+          "name": "user_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": [
+            "permission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_active_index": {
+          "name": "refresh_tokens_user_active_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_cleanup_index": {
+          "name": "refresh_tokens_cleanup_index",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_team_member": {
+          "name": "unique_team_member",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_members_team_index": {
+          "name": "team_members_team_index",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_members_user_index": {
+          "name": "team_members_user_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_invited_by_users_id_fk": {
+          "name": "team_members_invited_by_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_website_unique": {
+          "name": "teams_website_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "website"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tokens": {
+      "name": "tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "token_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "token_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_type_index": {
+          "name": "user_type_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tokens_status_expires_index": {
+          "name": "tokens_status_expires_index",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tokens_user_id_users_id_fk": {
+          "name": "tokens_user_id_users_id_fk",
+          "tableFrom": "tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tokens_token_unique": {
+          "name": "tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_invited_by_users_id_fk": {
+          "name": "user_roles_invited_by_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_provider": {
+      "name": "auth_provider",
+      "schema": "public",
+      "values": [
+        "local",
+        "google",
+        "github"
+      ]
+    },
+    "public.action": {
+      "name": "action",
+      "schema": "public",
+      "values": [
+        "view",
+        "manage"
+      ]
+    },
+    "public.resource": {
+      "name": "resource",
+      "schema": "public",
+      "values": [
+        "users",
+        "admins",
+        "teams"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "user"
+      ]
+    },
+    "public.token_status": {
+      "name": "token_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "used",
+        "deprecated",
+        "cancelled"
+      ]
+    },
+    "public.token_type": {
+      "name": "token_type",
+      "schema": "public",
+      "values": [
+        "email_verification",
+        "password_reset",
+        "refresh_token",
+        "user_invite"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "new",
+        "verified",
+        "trial",
+        "active",
+        "suspended",
+        "archived",
+        "pending"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/data/migrations/meta/_journal.json
+++ b/src/data/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1771529403238,
       "tag": "0000_stiff_piledriver",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1771578750059,
+      "tag": "0001_panoramic_norman_osborn",
+      "breakpoints": true
     }
   ]
 }

--- a/src/data/repositories/index.ts
+++ b/src/data/repositories/index.ts
@@ -1,5 +1,6 @@
 export * from './auth'
 export * from './pagination'
+export * from './rbac'
 export * from './refresh-token'
 export * from './team'
 export * from './token'

--- a/src/data/repositories/rbac/index.ts
+++ b/src/data/repositories/rbac/index.ts
@@ -1,4 +1,4 @@
-import { remove, setUserPermissions } from './mutations'
+import { setUserPermissions } from './mutations'
 import { findRolePermissions, findUserPermissions } from './queries'
 
 export * from './queries'
@@ -8,5 +8,4 @@ export const rbacRepo = {
   findRolePermissions,
   findUserPermissions,
   setUserPermissions,
-  remove,
 }

--- a/src/data/repositories/rbac/index.ts
+++ b/src/data/repositories/rbac/index.ts
@@ -1,0 +1,12 @@
+import { remove, setUserPermissions } from './mutations'
+import { findRolePermissions, findUserPermissions } from './queries'
+
+export * from './queries'
+export * from './types'
+
+export const rbacRepo = {
+  findRolePermissions,
+  findUserPermissions,
+  setUserPermissions,
+  remove,
+}

--- a/src/data/repositories/rbac/mutations.ts
+++ b/src/data/repositories/rbac/mutations.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from 'drizzle-orm'
+import { sql } from 'drizzle-orm'
 
 import type { Permissions } from '@/routes/@shared/permissions-schema'
 import type { Role } from '@/types'
@@ -33,10 +33,4 @@ export const setUserPermissions = async (
       target: [userPermissionsTable.userId, userPermissionsTable.permissionId],
       set: { granted: sql`excluded.granted` },
     })
-}
-
-export const remove = async (userId: string, tx?: Database): Promise<void> => {
-  await (tx || db)
-    .delete(userPermissionsTable)
-    .where(eq(userPermissionsTable.userId, userId))
 }

--- a/src/data/repositories/rbac/mutations.ts
+++ b/src/data/repositories/rbac/mutations.ts
@@ -1,0 +1,42 @@
+import { eq, sql } from 'drizzle-orm'
+
+import type { Permissions } from '@/routes/@shared/permissions-schema'
+import type { Role } from '@/types'
+
+import type { Database } from '../../clients'
+
+import { db } from '../../clients'
+import { userPermissionsTable } from '../../schema'
+import { findRolePermissions } from './queries'
+
+export const setUserPermissions = async (
+  userId: string,
+  role: Role,
+  permissions: Permissions,
+  tx?: Database,
+): Promise<void> => {
+  const executor = tx || db
+
+  const rolePerms = await findRolePermissions(role, tx)
+  const revocations = rolePerms
+    .filter(p => permissions[p.resource]?.[p.action] === false)
+    .map(p => ({ userId, permissionId: p.permissionId, granted: false }))
+
+  if (revocations.length === 0) {
+    return
+  }
+
+  await executor
+    .insert(userPermissionsTable)
+    .values(revocations)
+    .onConflictDoUpdate({
+      target: [userPermissionsTable.userId, userPermissionsTable.permissionId],
+      set: { granted: sql`excluded.granted` },
+    })
+}
+
+export const remove = async (userId: string, tx?: Database): Promise<void> => {
+  await (tx || db)
+    .delete(userPermissionsTable)
+    .where(eq(userPermissionsTable.userId, userId))
+}

--- a/src/data/repositories/rbac/queries.ts
+++ b/src/data/repositories/rbac/queries.ts
@@ -1,0 +1,61 @@
+import { and, eq, sql } from 'drizzle-orm'
+
+import type { Action, Resource, Role } from '@/types'
+
+import type { Database } from '../../clients'
+
+import { db } from '../../clients'
+import { permissionsTable, rolePermissionsTable, userPermissionsTable } from '../../schema'
+
+export interface PermissionRow {
+  action: Action
+  resource: Resource
+  default: boolean
+  override: boolean | null // null = no user override, use role default
+}
+
+export interface RolePermissionRow {
+  permissionId: number
+  action: Action
+  resource: Resource
+}
+
+export const findRolePermissions = async (
+  role: Role,
+  tx?: Database,
+): Promise<RolePermissionRow[]> => {
+  return (tx || db)
+    .select({
+      permissionId: rolePermissionsTable.permissionId,
+      action: permissionsTable.action,
+      resource: permissionsTable.resource,
+    })
+    .from(rolePermissionsTable)
+    .innerJoin(permissionsTable, eq(permissionsTable.id, rolePermissionsTable.permissionId))
+    .where(eq(rolePermissionsTable.role, role))
+}
+
+export const findUserPermissions = async (
+  userId: string,
+  role: Role,
+  tx?: Database,
+): Promise<PermissionRow[]> => {
+  const executor = tx || db
+
+  return executor
+    .select({
+      action: permissionsTable.action,
+      resource: permissionsTable.resource,
+      default: sql<boolean>`${rolePermissionsTable.id} IS NOT NULL`,
+      override: userPermissionsTable.granted,
+    })
+    .from(permissionsTable)
+    .leftJoin(rolePermissionsTable, and(
+      eq(rolePermissionsTable.permissionId, permissionsTable.id),
+      eq(rolePermissionsTable.role, role),
+    ))
+    .leftJoin(userPermissionsTable, and(
+      eq(userPermissionsTable.permissionId, permissionsTable.id),
+      eq(userPermissionsTable.userId, userId),
+    ))
+}

--- a/src/data/repositories/rbac/types.ts
+++ b/src/data/repositories/rbac/types.ts
@@ -1,0 +1,3 @@
+import type { userPermissionsTable } from '../../schema'
+
+export type UserPermissionRecord = typeof userPermissionsTable.$inferSelect

--- a/src/data/schema/rbac.ts
+++ b/src/data/schema/rbac.ts
@@ -1,14 +1,17 @@
 import {
+  boolean,
   integer,
   pgTable,
   serial,
   timestamp,
   uniqueIndex,
+  uuid,
 } from 'drizzle-orm/pg-core'
 
 import { Action, Resource, Role } from '@/types'
 
 import { createPgEnum } from '../utils'
+import { usersTable } from './users'
 
 export const roleEnum = createPgEnum('role', Role)
 export const actionEnum = createPgEnum('action', Action)
@@ -16,8 +19,8 @@ export const resourceEnum = createPgEnum('resource', Resource)
 
 export const permissionsTable = pgTable('permissions', {
   id: serial('id').primaryKey(),
-  action: actionEnum('action').notNull(),
-  resource: resourceEnum('resource').notNull(),
+  action: actionEnum('action').notNull().$type<Action>(),
+  resource: resourceEnum('resource').notNull().$type<Resource>(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 }, table => [
   uniqueIndex('unique_permission').on(table.action, table.resource),
@@ -25,11 +28,25 @@ export const permissionsTable = pgTable('permissions', {
 
 export const rolePermissionsTable = pgTable('role_permissions', {
   id: serial('id').primaryKey(),
-  role: roleEnum('role').notNull(),
+  role: roleEnum('role').notNull().$type<Role>(),
   permissionId: integer('permission_id')
     .notNull()
     .references(() => permissionsTable.id, { onDelete: 'cascade' }),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 }, table => [
   uniqueIndex('unique_role_permission').on(table.role, table.permissionId),
+])
+
+export const userPermissionsTable = pgTable('user_permissions', {
+  id: serial('id').primaryKey(),
+  userId: uuid('user_id')
+    .notNull()
+    .references(() => usersTable.id, { onDelete: 'cascade' }),
+  permissionId: integer('permission_id')
+    .notNull()
+    .references(() => permissionsTable.id, { onDelete: 'cascade' }),
+  granted: boolean('granted').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+}, table => [
+  uniqueIndex('unique_user_permission').on(table.userId, table.permissionId),
 ])

--- a/src/routes/@shared/permissions-schema.ts
+++ b/src/routes/@shared/permissions-schema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import Resource from '@/types/resource'
 
-const resourcePermissions = z.object({ view: z.boolean(), manage: z.boolean() })
+const resourcePermissions = z.object({ view: z.boolean(), manage: z.boolean() }).optional()
 
 export const permissionsSchema = z.object(
   Object.fromEntries(

--- a/src/use-cases/owner/__tests__/admins.test.ts
+++ b/src/use-cases/owner/__tests__/admins.test.ts
@@ -199,6 +199,7 @@ describe('inviteAdmin', () => {
   let mockUserRoleAssign: any
   let mockAuthCreate: any
   let mockTokenIssue: any
+  let mockRbacSet: any
   let mockTransaction: any
   let mockSendUserInvitationEmail: any
 
@@ -231,6 +232,7 @@ describe('inviteAdmin', () => {
     mockUserRoleAssign = mock(async () => ({}))
     mockAuthCreate = mock(async () => ({}))
     mockTokenIssue = mock(async () => ({}))
+    mockRbacSet = mock(async () => {})
     mockSendUserInvitationEmail = mock(async () => {})
 
     // eslint-disable-next-line ts/no-unsafe-return
@@ -245,6 +247,7 @@ describe('inviteAdmin', () => {
       userRoleRepo: { assign: mockUserRoleAssign },
       authRepo: { create: mockAuthCreate },
       tokenRepo: { issue: mockTokenIssue },
+      rbacRepo: { setUserPermissions: mockRbacSet },
       db: { transaction: mockTransaction },
     }))
 

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -1,7 +1,7 @@
 import type { PaginationParams, SearchParams } from '@/data'
 import type { Permissions } from '@/routes/@shared/permissions-schema'
 
-import { authRepo, db, tokenRepo, userRepo, userRoleRepo } from '@/data'
+import { authRepo, db, rbacRepo, tokenRepo, userRepo, userRoleRepo } from '@/data'
 import env from '@/env'
 import { AppError, ErrorCode } from '@/errors'
 import { generatePasswordHash } from '@/security/password'
@@ -92,6 +92,8 @@ export const inviteAdmin = async (params: AdminInvitationParams, inviterId: stri
       role: Role.Admin,
       invitedBy: inviterId,
     }, tx)
+
+    await rbacRepo.setUserPermissions(newAdmin.id, Role.Admin, params.permissions, tx)
 
     const { type, token, expiresAt } = generateToken(TokenType.UserInvite)
 

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -69,6 +69,8 @@ export const inviteAdmin = async (params: AdminInvitationParams, inviterId: stri
     throw new AppError(ErrorCode.NotFound, 'Inviter not found')
   }
 
+  const role = Role.Admin
+
   const { admin, token } = await db.transaction(async (tx) => {
     const newAdmin = await userRepo.create({
       firstName: params.firstName,
@@ -89,11 +91,11 @@ export const inviteAdmin = async (params: AdminInvitationParams, inviterId: stri
 
     await userRoleRepo.assign({
       userId: newAdmin.id,
-      role: Role.Admin,
+      role,
       invitedBy: inviterId,
     }, tx)
 
-    await rbacRepo.setUserPermissions(newAdmin.id, Role.Admin, params.permissions, tx)
+    await rbacRepo.setUserPermissions(newAdmin.id, role, params.permissions, tx)
 
     const { type, token, expiresAt } = generateToken(TokenType.UserInvite)
 
@@ -104,7 +106,7 @@ export const inviteAdmin = async (params: AdminInvitationParams, inviterId: stri
       expiresAt,
     }, tx)
 
-    return { admin: { ...newAdmin, role: Role.Admin }, token }
+    return { admin: { ...newAdmin, role }, token }
   })
 
   await emailAgent.sendUserInvitationEmail(

--- a/src/use-cases/user/__tests__/invites.test.ts
+++ b/src/use-cases/user/__tests__/invites.test.ts
@@ -23,6 +23,7 @@ describe('inviteMember', () => {
   let mockAuthRepoCreate: any
   let mockTeamRepoCreateMember: any
   let mockTokenRepoIssue: any
+  let mockRbacSet: any
   let mockTransaction: any
   let mockEmailAgent: any
 
@@ -31,6 +32,11 @@ describe('inviteMember', () => {
     lastName: 'Doe',
     email: 'john@example.com',
     position: 'Developer',
+    permissions: {
+      users: { view: true, manage: false },
+      admins: { view: false, manage: false },
+      teams: { view: true, manage: true },
+    },
   }
 
   beforeEach(async () => {
@@ -69,6 +75,7 @@ describe('inviteMember', () => {
     mockAuthRepoCreate = mock(async () => {})
     mockTeamRepoCreateMember = mock(async () => {})
     mockTokenRepoIssue = mock(async () => {})
+    mockRbacSet = mock(async () => {})
     mockTransaction = mock(async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => {
       return callback({})
     })
@@ -88,6 +95,7 @@ describe('inviteMember', () => {
       },
       authRepo: { create: mockAuthRepoCreate },
       tokenRepo: { issue: mockTokenRepoIssue },
+      rbacRepo: { setUserPermissions: mockRbacSet },
       db: { transaction: mockTransaction },
     }))
 

--- a/src/use-cases/user/invites.ts
+++ b/src/use-cases/user/invites.ts
@@ -1,15 +1,18 @@
-import { authRepo, db, teamRepo, tokenRepo, userRepo } from '@/data'
+import type { Permissions } from '@/routes/@shared/permissions-schema'
+
+import { authRepo, db, rbacRepo, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { generatePasswordHash } from '@/security/password'
 import { generateToken, TokenType } from '@/security/token'
 import { emailAgent } from '@/services/email'
-import { AuthProvider, Status } from '@/types'
+import { AuthProvider, Role, Status } from '@/types'
 
 export interface InviteMemberParams {
   firstName: string
   lastName?: string
   email: string
   position?: string
+  permissions: Permissions
 }
 
 export const inviteMember = async (
@@ -59,6 +62,8 @@ export const inviteMember = async (
       position: member.position,
       invitedBy: inviterId,
     }, tx)
+
+    await rbacRepo.setUserPermissions(newUser.id, Role.User, member.permissions, tx)
 
     const { type, token, expiresAt } = generateToken(TokenType.UserInvite)
 


### PR DESCRIPTION
1. [Feature]: Add \`user_permissions\` table for sparse per-user permission overrides
2. [Feature]: Implement \`rbacRepo\` with \`findRolePermissions\`, \`findUserPermissions\`, and \`setUserPermissions\`
3. [Improvement]: Override model stores only revocations from role defaults, preventing privilege escalation
4. [Feature]: Wire permission overrides into admin and team member invitation flows
5. [Fix]: Make permission resource keys optional so partial payloads are accepted