### PR TITLE
Return user permissions in login and reset-password responses

### DIFF
--- a/src/data/repositories/rbac/queries.ts
+++ b/src/data/repositories/rbac/queries.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, isNotNull, isNull, or } from 'drizzle-orm'
 
 import type { Action, Resource, Role } from '@/types'
 
@@ -7,11 +7,9 @@ import type { Database } from '../../clients'
 import { db } from '../../clients'
 import { permissionsTable, rolePermissionsTable, userPermissionsTable } from '../../schema'
 
-export interface PermissionRow {
+export interface ActivePermissionRow {
   action: Action
   resource: Resource
-  default: boolean
-  override: boolean | null // null = no user override, use role default
 }
 
 export interface RolePermissionRow {
@@ -35,19 +33,24 @@ export const findRolePermissions = async (
     .where(eq(rolePermissionsTable.role, role))
 }
 
+/**
+ * Returns all permissions effectively granted to a user given their role.
+ *
+ * A permission is included when:
+ * - The user has an explicit override (`granted = true`), or
+ * - No user override exists and the role has the permission by default
+ *
+ * Explicit revocations (`granted = false`) are excluded.
+ */
 export const findUserPermissions = async (
   userId: string,
   role: Role,
   tx?: Database,
-): Promise<PermissionRow[]> => {
-  const executor = tx || db
-
-  return executor
+): Promise<ActivePermissionRow[]> => {
+  return (tx || db)
     .select({
       action: permissionsTable.action,
       resource: permissionsTable.resource,
-      default: sql<boolean>`${rolePermissionsTable.id} IS NOT NULL`,
-      override: userPermissionsTable.granted,
     })
     .from(permissionsTable)
     .leftJoin(rolePermissionsTable, and(
@@ -58,4 +61,13 @@ export const findUserPermissions = async (
       eq(userPermissionsTable.permissionId, permissionsTable.id),
       eq(userPermissionsTable.userId, userId),
     ))
+    .where(
+      or(
+        eq(userPermissionsTable.granted, true),
+        and(
+          isNull(userPermissionsTable.granted),
+          isNotNull(rolePermissionsTable.id),
+        ),
+      ),
+    )
 }

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -167,7 +167,7 @@ export const findTeamWithMemberCount = async (
 export const findUserTeam = async (
   userId: string,
   tx?: Database,
-): Promise<UserTeamInfo | null> => {
+): Promise<UserTeamInfo | undefined> => {
   const executor = tx || db
 
   const [result] = await executor
@@ -180,5 +180,5 @@ export const findUserTeam = async (
     .innerJoin(teamsTable, eq(teamMembersTable.teamId, teamsTable.id))
     .where(eq(teamMembersTable.userId, userId))
 
-  return result ?? null
+  return result
 }

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -167,7 +167,7 @@ export const findTeamWithMemberCount = async (
 export const findUserTeam = async (
   userId: string,
   tx?: Database,
-): Promise<UserTeamInfo | undefined> => {
+): Promise<UserTeamInfo | null> => {
   const executor = tx || db
 
   const [result] = await executor
@@ -180,5 +180,5 @@ export const findUserTeam = async (
     .innerJoin(teamsTable, eq(teamMembersTable.teamId, teamsTable.id))
     .where(eq(teamMembersTable.userId, userId))
 
-  return result
+  return result ?? null
 }

--- a/src/data/scripts/seed.ts
+++ b/src/data/scripts/seed.ts
@@ -111,6 +111,13 @@ const seedDefaultAdminPermissions = async () => {
   })
 }
 
+const seedDefaultUserPermissions = async () => {
+  await assignPermissionsToRole({
+    role: Role.User,
+    resources: [Resource.Teams],
+  })
+}
+
 const seedTeams = async () => {
   const teams = [
     {
@@ -307,6 +314,7 @@ const seed = async () => {
   await seedPermissions()
   await seedOwnerPermissions()
   await seedDefaultAdminPermissions()
+  await seedDefaultUserPermissions()
   await seedSystemUsers()
   const teamId = await seedTeams()
   await seedTestUsers(teamId)

--- a/src/middleware/auth/__tests__/admin-auth.test.ts
+++ b/src/middleware/auth/__tests__/admin-auth.test.ts
@@ -24,7 +24,7 @@ describe('Admin Authentication Middleware', () => {
   describe('Role Validation', () => {
     it('should allow Owner with Active status', async () => {
       const ownerToken = await signJwt(
-        { id: testUuids.OWNER_1, email: 'owner@example.com', role: Role.Owner, status: Status.Active },
+        { id: testUuids.OWNER_1, email: 'owner@example.com', role: Role.Owner, status: Status.Active, permissions: [] },
         { secret: env.JWT_SECRET },
       )
 
@@ -44,7 +44,7 @@ describe('Admin Authentication Middleware', () => {
 
     it('should allow Admin with Active status', async () => {
       const adminToken = await signJwt(
-        { id: testUuids.ADMIN_1, email: 'admin@example.com', role: Role.Admin, status: Status.Active },
+        { id: testUuids.ADMIN_1, email: 'admin@example.com', role: Role.Admin, status: Status.Active, permissions: [] },
         { secret: env.JWT_SECRET },
       )
 
@@ -64,7 +64,7 @@ describe('Admin Authentication Middleware', () => {
 
     it('should reject User role with Active status', async () => {
       const userToken = await signJwt(
-        { id: testUuids.USER_1, email: 'user@example.com', role: Role.User, status: Status.Active },
+        { id: testUuids.USER_1, email: 'user@example.com', role: Role.User, status: Status.Active, permissions: [] },
         { secret: env.JWT_SECRET },
       )
 
@@ -93,7 +93,7 @@ describe('Admin Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: testUuids.ADMIN_1, email: 'admin@example.com', role: Role.Admin, status },
+          { id: testUuids.ADMIN_1, email: 'admin@example.com', role: Role.Admin, status, permissions: [] },
           { secret: env.JWT_SECRET },
         )
 

--- a/src/middleware/auth/__tests__/factory.test.ts
+++ b/src/middleware/auth/__tests__/factory.test.ts
@@ -21,6 +21,7 @@ describe('Auth Middleware Factory', () => {
     email: 'test@example.com',
     role: Role.User,
     status: Status.Verified,
+    permissions: [],
   }
 
   beforeEach(() => {

--- a/src/middleware/auth/__tests__/new-user-access.test.ts
+++ b/src/middleware/auth/__tests__/new-user-access.test.ts
@@ -24,7 +24,13 @@ describe('Auth Middleware - New User Access', () => {
   describe('Strict Auth - Status Validation', () => {
     it('should reject New status', async () => {
       const token = await signJwt(
-        { id: testUuids.USER_1, email: 'user@example.com', role: Role.User, status: Status.New },
+        {
+          id: testUuids.USER_1,
+          email: 'user@example.com',
+          role: Role.User,
+          status: Status.New,
+          permissions: [],
+        },
         { secret: env.JWT_SECRET },
       )
 
@@ -51,7 +57,7 @@ describe('Auth Middleware - New User Access', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: testUuids.USER_1, email: 'user@example.com', role: Role.User, status },
+          { id: testUuids.USER_1, email: 'user@example.com', role: Role.User, status, permissions: [] },
           { secret: env.JWT_SECRET },
         )
 
@@ -80,7 +86,7 @@ describe('Auth Middleware - New User Access', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: testUuids.USER_2, email: 'user@example.com', role: Role.User, status },
+          { id: testUuids.USER_2, email: 'user@example.com', role: Role.User, status, permissions: [] },
           { secret: env.JWT_SECRET },
         )
 
@@ -101,7 +107,7 @@ describe('Auth Middleware - New User Access', () => {
 
     it('should reject Suspended status', async () => {
       const token = await signJwt(
-        { id: testUuids.USER_3, email: 'user@example.com', role: Role.User, status: Status.Suspended },
+        { id: testUuids.USER_3, email: 'user@example.com', role: Role.User, status: Status.Suspended, permissions: [] },
         { secret: env.JWT_SECRET },
       )
 

--- a/src/middleware/auth/__tests__/owner-auth.test.ts
+++ b/src/middleware/auth/__tests__/owner-auth.test.ts
@@ -24,7 +24,13 @@ describe('Owner Authentication Middleware', () => {
   describe('Role Validation', () => {
     it('should allow Owner with Active status', async () => {
       const ownerToken = await signJwt(
-        { id: testUuids.OWNER_1, email: 'owner@example.com', role: Role.Owner, status: Status.Active },
+        {
+          id: testUuids.OWNER_1,
+          email: 'owner@example.com',
+          role: Role.Owner,
+          status: Status.Active,
+          permissions: [],
+        },
         { secret: env.JWT_SECRET },
       )
 
@@ -44,7 +50,7 @@ describe('Owner Authentication Middleware', () => {
 
     it('should reject Admin even with Active status', async () => {
       const adminToken = await signJwt(
-        { id: testUuids.ADMIN_1, email: 'admin@example.com', role: Role.Admin, status: Status.Active },
+        { id: testUuids.ADMIN_1, email: 'admin@example.com', role: Role.Admin, status: Status.Active, permissions: [] },
         { secret: env.JWT_SECRET },
       )
 
@@ -65,7 +71,7 @@ describe('Owner Authentication Middleware', () => {
 
     it('should reject User role with Active status', async () => {
       const userToken = await signJwt(
-        { id: testUuids.USER_1, email: 'user@example.com', role: Role.User, status: Status.Active },
+        { id: testUuids.USER_1, email: 'user@example.com', role: Role.User, status: Status.Active, permissions: [] },
         { secret: env.JWT_SECRET },
       )
 
@@ -94,7 +100,7 @@ describe('Owner Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: testUuids.OWNER_1, email: 'owner@example.com', role: Role.Owner, status },
+          { id: testUuids.OWNER_1, email: 'owner@example.com', role: Role.Owner, status, permissions: [] },
           { secret: env.JWT_SECRET },
         )
 

--- a/src/middleware/auth/__tests__/user-relaxed-auth.test.ts
+++ b/src/middleware/auth/__tests__/user-relaxed-auth.test.ts
@@ -30,7 +30,7 @@ describe('User Relaxed Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: testUuids.USER_1, email: 'test@example.com', role, status: Status.Active },
+          { id: testUuids.USER_1, email: 'test@example.com', role, status: Status.Active, permissions: [] },
           { secret: env.JWT_SECRET },
         )
 
@@ -59,7 +59,7 @@ describe('User Relaxed Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: testUuids.USER_2, email: 'user@example.com', role: Role.User, status },
+          { id: testUuids.USER_2, email: 'user@example.com', role: Role.User, status, permissions: [] },
           { secret: env.JWT_SECRET },
         )
 
@@ -86,7 +86,7 @@ describe('User Relaxed Authentication Middleware', () => {
         testApp.onError(onError)
 
         const token = await signJwt(
-          { id: testUuids.USER_3, email: 'user@example.com', role: Role.User, status },
+          { id: testUuids.USER_3, email: 'user@example.com', role: Role.User, status, permissions: [] },
           { secret: env.JWT_SECRET },
         )
 

--- a/src/middleware/team-access/__tests__/team-access.test.ts
+++ b/src/middleware/team-access/__tests__/team-access.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import { Hono } from 'hono'
 
 import type { AppContext } from '@/context'
+import type { Permission } from '@/types'
 
 import { testUuids } from '@/__tests__'
 import { ErrorCode } from '@/errors'
@@ -44,6 +45,7 @@ describe('Team Access Middleware', () => {
           email: 'user@example.com',
           role: Role.User,
           status: Status.Active,
+          permissions: [] as Permission[],
         })
         await next()
       })
@@ -68,6 +70,7 @@ describe('Team Access Middleware', () => {
           email: 'user@example.com',
           role: Role.User,
           status: Status.Active,
+          permissions: [] as Permission[],
         })
         await next()
       })
@@ -92,6 +95,7 @@ describe('Team Access Middleware', () => {
           email: 'user@example.com',
           role: Role.User,
           status: Status.Active,
+          permissions: [] as Permission[],
         })
         await next()
       })
@@ -113,6 +117,7 @@ describe('Team Access Middleware', () => {
           email: 'admin@example.com',
           role: Role.Admin,
           status: Status.Active,
+          permissions: [] as Permission[],
         })
         await next()
       })
@@ -135,6 +140,7 @@ describe('Team Access Middleware', () => {
           email: 'admin@example.com',
           role: Role.Admin,
           status: Status.Active,
+          permissions: [] as Permission[],
         })
         await next()
       })
@@ -156,6 +162,7 @@ describe('Team Access Middleware', () => {
           email: 'owner@example.com',
           role: Role.Owner,
           status: Status.Active,
+          permissions: [] as Permission[],
         })
         await next()
       })
@@ -178,6 +185,7 @@ describe('Team Access Middleware', () => {
           email: 'owner@example.com',
           role: Role.Owner,
           status: Status.Active,
+          permissions: [] as Permission[],
         })
         await next()
       })
@@ -199,6 +207,7 @@ describe('Team Access Middleware', () => {
           email: 'admin@example.com',
           role: Role.Admin,
           status: Status.Active,
+          permissions: [] as Permission[],
         })
         await next()
       })
@@ -217,6 +226,7 @@ describe('Team Access Middleware', () => {
           email: 'owner@example.com',
           role: Role.Owner,
           status: Status.Active,
+          permissions: [] as Permission[],
         })
         await next()
       })
@@ -240,6 +250,7 @@ describe('Team Access Middleware', () => {
           email: 'user@example.com',
           role: Role.User,
           status: Status.Active,
+          permissions: [] as Permission[],
         })
         await next()
       })
@@ -263,6 +274,7 @@ describe('Team Access Middleware', () => {
           email: 'user@example.com',
           role: Role.User,
           status: Status.Active,
+          permissions: [] as Permission[],
         })
         await next()
       })
@@ -289,6 +301,7 @@ describe('Team Access Middleware', () => {
           email: 'user@example.com',
           role: Role.User,
           status: Status.Active,
+          permissions: [] as Permission[],
         })
         await next()
       })

--- a/src/routes/admin/users/__tests__/endpoint.test.ts
+++ b/src/routes/admin/users/__tests__/endpoint.test.ts
@@ -67,6 +67,7 @@ describe('Admin Users Endpoint', () => {
       email: 'admin@example.com',
       role: Role.Admin,
       status: Status.Active,
+      permissions: [],
     }
 
     const adminMiddleware: any = async (c: any, next: any) => {

--- a/src/routes/auth/signup/__tests__/endpoint.test.ts
+++ b/src/routes/auth/signup/__tests__/endpoint.test.ts
@@ -16,35 +16,23 @@ describe('Signup Endpoint', () => {
 
   let app: Hono
   let mockSignUpWithEmail: any
-  let mockSetRefreshCookie: any
-  let mockGetDeviceInfo: any
 
   beforeEach(async () => {
     mockSignUpWithEmail = mock(async () => ({
-      data: {
-        user: {
-          id: testUuids.USER_1,
-          firstName: 'John',
-          lastName: 'Doe',
-          email: 'test@example.com',
-          role: Role.User,
-          status: Status.New,
-          createdAt: new Date('2024-01-01'),
-          updatedAt: new Date('2024-01-01'),
-        },
-        accessToken: 'signup-jwt-token',
+      user: {
+        id: testUuids.USER_1,
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'test@example.com',
+        role: Role.User,
+        status: Status.New,
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-01'),
       },
-      refreshToken: 'refresh-token-123',
     }))
 
     await moduleMocker.mock('@/use-cases/auth/signup', () => ({
       default: mockSignUpWithEmail,
-    }))
-
-    mockSetRefreshCookie = mock(() => {})
-    mockGetDeviceInfo = mock(() => ({
-      ipAddress: '192.168.1.1',
-      userAgent: 'Mozilla/5.0 (Test)',
     }))
 
     await moduleMocker.mock('@/net/http', () => ({
@@ -55,8 +43,6 @@ describe('Signup Endpoint', () => {
         BAD_REQUEST: 400,
         NOT_FOUND: 404,
       },
-      setRefreshCookie: mockSetRefreshCookie,
-      getDeviceInfo: mockGetDeviceInfo,
     }))
 
     await mockCaptchaSuccess()
@@ -94,16 +80,11 @@ describe('Signup Endpoint', () => {
           createdAt: '2024-01-01T00:00:00.000Z',
           updatedAt: '2024-01-01T00:00:00.000Z',
         },
-        accessToken: 'signup-jwt-token',
       })
-
-      expect(mockSetRefreshCookie).toHaveBeenCalledTimes(1)
-      expect(mockSetRefreshCookie).toHaveBeenCalledWith(expect.any(Object), 'refresh-token-123')
 
       expect(mockSignUpWithEmail).toHaveBeenCalledTimes(1)
       expect(mockSignUpWithEmail).toHaveBeenCalledWith(
         { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'ValidPass123!' },
-        { ipAddress: '192.168.1.1', userAgent: 'Mozilla/5.0 (Test)' },
         undefined,
       )
     })
@@ -124,7 +105,6 @@ describe('Signup Endpoint', () => {
 
       expect(mockSignUpWithEmail).toHaveBeenCalledWith(
         { firstName: 'John', lastName: 'Doe', email: 'test@example.com', password: 'ValidPass123!' },
-        { ipAddress: '192.168.1.1', userAgent: 'Mozilla/5.0 (Test)' },
         { locale: 'uk', theme: 'dark' },
       )
     })
@@ -202,7 +182,6 @@ describe('Signup Endpoint', () => {
       })
 
       expect(res.status).toBe(HttpStatus.INTERNAL_SERVER_ERROR)
-      expect(mockSetRefreshCookie).not.toHaveBeenCalled()
       expect(mockSignUpWithEmail).toHaveBeenCalledTimes(1)
     })
   })

--- a/src/routes/auth/signup/handler.ts
+++ b/src/routes/auth/signup/handler.ts
@@ -1,19 +1,12 @@
-import { getDeviceInfo, HttpStatus, setRefreshCookie } from '@/net/http'
+import { HttpStatus } from '@/net/http'
 import signUpWithEmail from '@/use-cases/auth/signup'
 
 import type { SignupCtx } from './schema'
 
 export const signupHandler = async (c: SignupCtx) => {
   const { firstName, lastName, email, password, preferences } = c.req.valid('json')
-  const deviceInfo = getDeviceInfo(c)
 
-  const result = await signUpWithEmail(
-    { firstName, lastName, email, password },
-    deviceInfo,
-    preferences,
-  )
+  const result = await signUpWithEmail({ firstName, lastName, email, password }, preferences)
 
-  setRefreshCookie(c, result.refreshToken)
-
-  return c.json(result.data, HttpStatus.CREATED)
+  return c.json(result, HttpStatus.CREATED)
 }

--- a/src/routes/user/me/__tests__/endpoint.test.ts
+++ b/src/routes/user/me/__tests__/endpoint.test.ts
@@ -73,6 +73,7 @@ describe('Me Endpoint', () => {
       email: 'test@example.com',
       role: Role.User,
       status: Status.Active,
+      permissions: [],
     }
 
     const userMiddleware: any = async (c: any, next: any) => {

--- a/src/security/jwt/__tests__/jwt.integration.test.ts
+++ b/src/security/jwt/__tests__/jwt.integration.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test'
 
 import { testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
-import { Role, Status } from '@/types'
+import { Permission, Role, Status } from '@/types'
 
 import { signJwt, verifyJwt } from '../jwt'
 
@@ -12,6 +12,7 @@ describe('JWT Integration Tests', () => {
     email: 'test@example.com',
     role: Role.User,
     status: Status.Active,
+    permissions: [Permission.ViewUsers],
   }
 
   describe('signJwt + verifyJwt round-trip', () => {
@@ -29,6 +30,7 @@ describe('JWT Integration Tests', () => {
       expect(resultUserClaims.email).toBe(testUserClaims.email)
       expect(resultUserClaims.role).toBe(testUserClaims.role)
       expect(resultUserClaims.status).toBe(testUserClaims.status)
+      expect(resultUserClaims.permissions).toEqual(testUserClaims.permissions)
     })
 
     it('should respect custom expiration time', async () => {

--- a/src/security/jwt/__tests__/jwt.test.ts
+++ b/src/security/jwt/__tests__/jwt.test.ts
@@ -39,6 +39,7 @@ describe('JWT Unit Tests', () => {
           email: 'test@example.com',
           role: Role.User,
           status: Status.Active,
+          permissions: [],
         },
         { secret: 'test-secret' },
       )
@@ -53,6 +54,7 @@ describe('JWT Unit Tests', () => {
         email: 'test@example.com',
         role: Role.User,
         status: Status.Active,
+        permissions: [],
       })
       expect(payload.iat).toBeGreaterThanOrEqual(now - 1)
       expect(payload.nbf).toBeGreaterThanOrEqual(now - 1)
@@ -69,6 +71,7 @@ describe('JWT Unit Tests', () => {
         email: 'test@example.com',
         role: Role.User,
         status: Status.Active,
+        permissions: [],
         exp: nowInSeconds() + 3600,
       }))
 
@@ -122,6 +125,7 @@ describe('JWT Unit Tests', () => {
           email: 'test@example.com',
           role: Role.User,
           status: Status.Active,
+          permissions: [],
           exp: nowInSeconds() + 3600,
         }
 
@@ -152,6 +156,7 @@ describe('JWT Unit Tests', () => {
           email: 'test@example.com',
           role: Role.User,
           status: Status.Active,
+          permissions: [],
           exp: nowInSeconds() + 3600,
         }
 

--- a/src/security/jwt/claims/user.ts
+++ b/src/security/jwt/claims/user.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod'
 
-import { Role, Status } from '@/types'
+import { Permission, Role, Status } from '@/types'
 
 export const userClaimsSchema = z.object({
   id: z.uuid(),
   email: z.email(),
   role: z.nativeEnum(Role),
   status: z.nativeEnum(Status),
+  permissions: z.array(z.nativeEnum(Permission)),
 })
 
 export type UserClaims = z.infer<typeof userClaimsSchema>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ export { default as Action } from './action'
 
 export { default as AuthProvider } from './auth-providers'
 
-export { ALL_PERMISSIONS, default as Permission } from './permission'
+export { default as Permission } from './permission'
 
 export { default as Resource } from './resource'
 export { isAdmin, isOwner, isUser, isUserOrAdmin, default as Role } from './role'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,8 @@ export { default as Action } from './action'
 
 export { default as AuthProvider } from './auth-providers'
 
+export { ALL_PERMISSIONS, default as Permission } from './permission'
+
 export { default as Resource } from './resource'
 export { isAdmin, isOwner, isUser, isUserOrAdmin, default as Role } from './role'
 export { isActive, isActiveOnly, isNewOrActive, default as Status } from './status'

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -7,6 +7,4 @@ enum Permission {
   ManageTeams = 'manage:teams',
 }
 
-export const ALL_PERMISSIONS = Object.values(Permission)
-
 export default Permission

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -1,0 +1,12 @@
+enum Permission {
+  ViewUsers = 'view:users',
+  ViewAdmins = 'view:admins',
+  ViewTeams = 'view:teams',
+  ManageUsers = 'manage:users',
+  ManageAdmins = 'manage:admins',
+  ManageTeams = 'manage:teams',
+}
+
+export const ALL_PERMISSIONS = Object.values(Permission)
+
+export default Permission

--- a/src/use-cases/auth/__tests__/accept-invite.test.ts
+++ b/src/use-cases/auth/__tests__/accept-invite.test.ts
@@ -90,7 +90,7 @@ describe('Accept Invite', () => {
       create: mock(async () => {}),
     }
     mockTeamRepo = {
-      findUserTeam: mock(async () => null),
+      findUserTeam: mock(async () => undefined),
     }
     mockTransaction = {
       transaction: mock(async (callback: any) => callback({}) as Promise<void>),
@@ -175,7 +175,7 @@ describe('Accept Invite', () => {
       expect(result).toEqual({
         data: {
           user: mockActivatedUser,
-          team: null,
+          team: undefined,
           accessToken: mockAccessToken,
           permissions: [],
         },
@@ -397,7 +397,7 @@ describe('Accept Invite', () => {
       expect(result).toEqual({
         data: {
           user: mockActivatedUser,
-          team: null,
+          team: undefined,
           accessToken: mockAccessToken,
           permissions: [],
         },

--- a/src/use-cases/auth/__tests__/accept-invite.test.ts
+++ b/src/use-cases/auth/__tests__/accept-invite.test.ts
@@ -102,6 +102,7 @@ describe('Accept Invite', () => {
       userRepo: mockUserRepo,
       refreshTokenRepo: mockRefreshTokenRepo,
       teamRepo: mockTeamRepo,
+      rbacRepo: { findUserPermissions: mock(async () => []) },
       db: mockTransaction,
     }))
 
@@ -172,7 +173,12 @@ describe('Accept Invite', () => {
       expect(mockRefreshTokenRepo.create).toHaveBeenCalledTimes(1)
 
       expect(result).toEqual({
-        data: { user: mockActivatedUser, team: null, accessToken: mockAccessToken },
+        data: {
+          user: mockActivatedUser,
+          team: null,
+          accessToken: mockAccessToken,
+          permissions: [],
+        },
         refreshToken: mockRefreshToken,
       })
     })
@@ -389,7 +395,12 @@ describe('Accept Invite', () => {
       )
 
       expect(result).toEqual({
-        data: { user: mockActivatedUser, team: null, accessToken: mockAccessToken },
+        data: {
+          user: mockActivatedUser,
+          team: null,
+          accessToken: mockAccessToken,
+          permissions: [],
+        },
         refreshToken: mockRefreshToken,
       })
 

--- a/src/use-cases/auth/__tests__/check-invite.test.ts
+++ b/src/use-cases/auth/__tests__/check-invite.test.ts
@@ -110,7 +110,7 @@ describe('Check Invite', () => {
 
   describe('when token is valid for admin invite', () => {
     beforeEach(() => {
-      mockTeamRepo.findUserTeam.mockResolvedValue(null)
+      mockTeamRepo.findUserTeam.mockResolvedValue(undefined)
     })
 
     it('should return admin type and company name for admin invitation token', async () => {
@@ -216,7 +216,7 @@ describe('Check Invite', () => {
 
   describe('when user has no team membership and no admin role', () => {
     it('should throw InternalError', async () => {
-      mockTeamRepo.findUserTeam.mockResolvedValue(null)
+      mockTeamRepo.findUserTeam.mockResolvedValue(undefined)
       mockUserRoleRepo.findByUserId.mockResolvedValue(undefined)
 
       try {
@@ -235,7 +235,7 @@ describe('Check Invite', () => {
 
   describe('when user has non-admin role', () => {
     it('should throw InternalError', async () => {
-      mockTeamRepo.findUserTeam.mockResolvedValue(null)
+      mockTeamRepo.findUserTeam.mockResolvedValue(undefined)
       mockUserRoleRepo.findByUserId.mockResolvedValue({
         ...mockAdminRole,
         role: Role.User,

--- a/src/use-cases/auth/__tests__/check-invite.test.ts
+++ b/src/use-cases/auth/__tests__/check-invite.test.ts
@@ -110,7 +110,7 @@ describe('Check Invite', () => {
 
   describe('when token is valid for admin invite', () => {
     beforeEach(() => {
-      mockTeamRepo.findUserTeam.mockResolvedValue(undefined)
+      mockTeamRepo.findUserTeam.mockResolvedValue(null)
     })
 
     it('should return admin type and company name for admin invitation token', async () => {
@@ -216,7 +216,7 @@ describe('Check Invite', () => {
 
   describe('when user has no team membership and no admin role', () => {
     it('should throw InternalError', async () => {
-      mockTeamRepo.findUserTeam.mockResolvedValue(undefined)
+      mockTeamRepo.findUserTeam.mockResolvedValue(null)
       mockUserRoleRepo.findByUserId.mockResolvedValue(undefined)
 
       try {
@@ -235,7 +235,7 @@ describe('Check Invite', () => {
 
   describe('when user has non-admin role', () => {
     it('should throw InternalError', async () => {
-      mockTeamRepo.findUserTeam.mockResolvedValue(undefined)
+      mockTeamRepo.findUserTeam.mockResolvedValue(null)
       mockUserRoleRepo.findByUserId.mockResolvedValue({
         ...mockAdminRole,
         role: Role.User,

--- a/src/use-cases/auth/__tests__/login.test.ts
+++ b/src/use-cases/auth/__tests__/login.test.ts
@@ -79,6 +79,7 @@ describe('Login with Email', () => {
       authRepo: mockAuthRepo,
       refreshTokenRepo: mockRefreshTokenRepo,
       teamRepo: mockTeamRepo,
+      rbacRepo: { findUserPermissions: mock(async () => []) },
     }))
 
     mockComparePasswords = mock(async () => true)

--- a/src/use-cases/auth/__tests__/login.test.ts
+++ b/src/use-cases/auth/__tests__/login.test.ts
@@ -22,7 +22,7 @@ describe('Login with Email', () => {
   let mockAuthRepo: any
   let mockRefreshTokenRepo: any
   let mockTeamRepo: any
-  let mockTeam: UserTeamInfo | undefined
+  let mockTeam: UserTeamInfo | null
 
   let mockComparePasswords: any
 
@@ -69,7 +69,7 @@ describe('Login with Email', () => {
     mockRefreshTokenRepo = {
       create: mock(async () => 1),
     }
-    mockTeam = undefined
+    mockTeam = null
     mockTeamRepo = {
       findUserTeam: mock(async () => mockTeam),
     }

--- a/src/use-cases/auth/__tests__/login.test.ts
+++ b/src/use-cases/auth/__tests__/login.test.ts
@@ -22,7 +22,7 @@ describe('Login with Email', () => {
   let mockAuthRepo: any
   let mockRefreshTokenRepo: any
   let mockTeamRepo: any
-  let mockTeam: UserTeamInfo | null
+  let mockTeam: UserTeamInfo | undefined
 
   let mockComparePasswords: any
 
@@ -69,7 +69,7 @@ describe('Login with Email', () => {
     mockRefreshTokenRepo = {
       create: mock(async () => 1),
     }
-    mockTeam = null
+    mockTeam = undefined
     mockTeamRepo = {
       findUserTeam: mock(async () => mockTeam),
     }
@@ -118,7 +118,7 @@ describe('Login with Email', () => {
       expect(result).toHaveProperty('data')
       expect(result).toHaveProperty('refreshToken')
       expect(result.data.accessToken).toBe(mockJwtToken)
-      expect(result.data.team).toBeNull()
+      expect(result.data.team).toBeUndefined()
       expect(result.refreshToken).toBe('refresh_token_123')
       expect(result.data.user).not.toHaveProperty('tokenVersion')
       expect(result.data.user.email).toBe(mockLoginParams.email)

--- a/src/use-cases/auth/__tests__/refresh-token.test.ts
+++ b/src/use-cases/auth/__tests__/refresh-token.test.ts
@@ -75,6 +75,8 @@ describe('Refresh Auth Tokens', () => {
       db: mockDb,
       userRepo: mockUserRepo,
       refreshTokenRepo: mockRefreshTokenRepo,
+      teamRepo: { findUserTeam: mock(async () => null) },
+      rbacRepo: { findUserPermissions: mock(async () => []) },
     }))
 
     mockHashToken = mock(async () => 'hashed_token_123')
@@ -380,6 +382,7 @@ describe('Refresh Auth Tokens', () => {
         email: mockUser.email,
         role: mockUser.role,
         status: mockUser.status,
+        permissions: [],
       })
     })
 

--- a/src/use-cases/auth/__tests__/refresh-token.test.ts
+++ b/src/use-cases/auth/__tests__/refresh-token.test.ts
@@ -75,7 +75,7 @@ describe('Refresh Auth Tokens', () => {
       db: mockDb,
       userRepo: mockUserRepo,
       refreshTokenRepo: mockRefreshTokenRepo,
-      teamRepo: { findUserTeam: mock(async () => null) },
+      teamRepo: { findUserTeam: mock(async () => undefined) },
       rbacRepo: { findUserPermissions: mock(async () => []) },
     }))
 

--- a/src/use-cases/auth/__tests__/reset-password.test.ts
+++ b/src/use-cases/auth/__tests__/reset-password.test.ts
@@ -25,7 +25,7 @@ describe('Reset Password', () => {
   let mockUserRepo: any
   let mockRefreshTokenRepo: any
   let mockTeamRepo: any
-  let mockTeam: UserTeamInfo | undefined
+  let mockTeam: UserTeamInfo | null
   let mockTransaction: any
 
   let mockTokenValidator: any
@@ -83,7 +83,7 @@ describe('Reset Password', () => {
     mockRefreshTokenRepo = {
       create: mock(async () => {}),
     }
-    mockTeam = undefined
+    mockTeam = null
     mockTeamRepo = {
       findUserTeam: mock(async () => mockTeam),
     }

--- a/src/use-cases/auth/__tests__/reset-password.test.ts
+++ b/src/use-cases/auth/__tests__/reset-password.test.ts
@@ -97,6 +97,7 @@ describe('Reset Password', () => {
       userRepo: mockUserRepo,
       refreshTokenRepo: mockRefreshTokenRepo,
       teamRepo: mockTeamRepo,
+      rbacRepo: { findUserPermissions: mock(async () => []) },
       db: mockTransaction,
     }))
 
@@ -162,7 +163,7 @@ describe('Reset Password', () => {
       expect(mockRefreshTokenRepo.create).toHaveBeenCalledTimes(1)
 
       expect(result).toEqual({
-        data: { user: mockUser, team: null, accessToken: mockAccessToken },
+        data: { user: mockUser, team: null, accessToken: mockAccessToken, permissions: [] },
         refreshToken: mockRefreshToken,
       })
     })
@@ -366,7 +367,7 @@ describe('Reset Password', () => {
       )
 
       expect(result).toEqual({
-        data: { user: mockUser, team: null, accessToken: mockAccessToken },
+        data: { user: mockUser, team: null, accessToken: mockAccessToken, permissions: [] },
         refreshToken: mockRefreshToken,
       })
 

--- a/src/use-cases/auth/__tests__/reset-password.test.ts
+++ b/src/use-cases/auth/__tests__/reset-password.test.ts
@@ -25,7 +25,7 @@ describe('Reset Password', () => {
   let mockUserRepo: any
   let mockRefreshTokenRepo: any
   let mockTeamRepo: any
-  let mockTeam: UserTeamInfo | null
+  let mockTeam: UserTeamInfo | undefined
   let mockTransaction: any
 
   let mockTokenValidator: any
@@ -83,7 +83,7 @@ describe('Reset Password', () => {
     mockRefreshTokenRepo = {
       create: mock(async () => {}),
     }
-    mockTeam = null
+    mockTeam = undefined
     mockTeamRepo = {
       findUserTeam: mock(async () => mockTeam),
     }
@@ -163,7 +163,7 @@ describe('Reset Password', () => {
       expect(mockRefreshTokenRepo.create).toHaveBeenCalledTimes(1)
 
       expect(result).toEqual({
-        data: { user: mockUser, team: null, accessToken: mockAccessToken, permissions: [] },
+        data: { user: mockUser, team: undefined, accessToken: mockAccessToken, permissions: [] },
         refreshToken: mockRefreshToken,
       })
     })
@@ -367,7 +367,7 @@ describe('Reset Password', () => {
       )
 
       expect(result).toEqual({
-        data: { user: mockUser, team: null, accessToken: mockAccessToken, permissions: [] },
+        data: { user: mockUser, team: undefined, accessToken: mockAccessToken, permissions: [] },
         refreshToken: mockRefreshToken,
       })
 

--- a/src/use-cases/auth/__tests__/signup.test.ts
+++ b/src/use-cases/auth/__tests__/signup.test.ts
@@ -6,7 +6,7 @@ import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { TokenType } from '@/security/token'
 import { AuthProvider, Role, Status } from '@/types'
-import { days, hours, nowPlus } from '@/utils/chrono'
+import { hours, nowPlus } from '@/utils/chrono'
 
 import type { SignupParams } from '../signup'
 
@@ -16,13 +16,11 @@ describe('Signup with Email', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
   let mockSignupParams: SignupParams
-  let mockDeviceInfo: { ipAddress: string, userAgent: string }
 
   let mockNewUser: User
   let mockUserRepo: any
   let mockAuthRepo: any
   let mockTokenRepo: any
-  let mockRefreshTokenRepo: any
   let mockTransaction: any
 
   let mockHashedPassword: string
@@ -32,15 +30,7 @@ describe('Signup with Email', () => {
   let mockExpiresAt: Date
   let mockGenerateToken: any
 
-  let mockRefreshToken: string
-  let mockRefreshTokenHash: string
-  let mockRefreshExpiresAt: Date
-  let mockGenerateHashedToken: any
-
   let mockEmailAgent: any
-
-  let mockJwtToken: string
-  let mockCreateJwt: any
 
   beforeEach(async () => {
     mockSignupParams = {
@@ -48,10 +38,6 @@ describe('Signup with Email', () => {
       lastName: 'Doe',
       email: 'john@example.com',
       password: 'ValidPass123!',
-    }
-    mockDeviceInfo = {
-      ipAddress: '192.168.1.1',
-      userAgent: 'Mozilla/5.0 (Test)',
     }
 
     mockNewUser = {
@@ -74,9 +60,6 @@ describe('Signup with Email', () => {
     mockTokenRepo = {
       issue: mock(async () => {}),
     }
-    mockRefreshTokenRepo = {
-      create: mock(async () => 1),
-    }
     mockTransaction = {
       transaction: mock(async (callback: any) => callback({}) as Promise<void>),
     }
@@ -85,7 +68,6 @@ describe('Signup with Email', () => {
       userRepo: mockUserRepo,
       authRepo: mockAuthRepo,
       tokenRepo: mockTokenRepo,
-      refreshTokenRepo: mockRefreshTokenRepo,
       db: mockTransaction,
     }))
 
@@ -104,19 +86,9 @@ describe('Signup with Email', () => {
       expiresAt: mockExpiresAt,
     }))
 
-    mockRefreshToken = 'refresh_token_123'
-    mockRefreshTokenHash = 'hashed_refresh_token_123'
-    mockRefreshExpiresAt = nowPlus(days(7))
-    mockGenerateHashedToken = mock(async () => ({
-      token: { raw: mockRefreshToken, hashed: mockRefreshTokenHash },
-      expiresAt: mockRefreshExpiresAt,
-      type: 'refresh_token',
-    }))
-
     await moduleMocker.mock('@/security/token', () => ({
       generateToken: mockGenerateToken,
-      generateHashedToken: mockGenerateHashedToken,
-      TokenType: { EmailVerification: 'email_verification', RefreshToken: 'refresh_token' },
+      TokenType: { EmailVerification: 'email_verification' },
     }))
 
     mockEmailAgent = {
@@ -126,13 +98,6 @@ describe('Signup with Email', () => {
     await moduleMocker.mock('@/services', () => ({
       emailAgent: mockEmailAgent,
     }))
-
-    mockJwtToken = 'mock-signup-jwt-token'
-    mockCreateJwt = mock(async () => mockJwtToken)
-
-    await moduleMocker.mock('@/security/jwt', () => ({
-      signJwt: mockCreateJwt,
-    }))
   })
 
   afterEach(async () => {
@@ -141,7 +106,7 @@ describe('Signup with Email', () => {
 
   describe('when signup is successful', () => {
     it('should create a new user with correct data', async () => {
-      const result = await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+      const result = await signUpWithEmail(mockSignupParams)
 
       expect(mockTransaction.transaction).toHaveBeenCalledTimes(1)
       expect(mockUserRepo.create).toHaveBeenCalledWith(
@@ -154,16 +119,11 @@ describe('Signup with Email', () => {
         expect.anything(),
       )
       expect(mockUserRepo.create).toHaveBeenCalledTimes(1)
-      const expectedUser = mockNewUser
-      expect(result.data.user).toEqual(expectedUser)
-      expect(result).toHaveProperty('refreshToken')
-      expect(result.refreshToken).toBe(mockRefreshToken)
-      expect(result.data).toHaveProperty('accessToken')
-      expect(result.data.accessToken).toBe(mockJwtToken)
+      expect(result.user).toEqual(mockNewUser)
     })
 
     it('should create auth record with hashed password', async () => {
-      await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+      await signUpWithEmail(mockSignupParams)
 
       expect(mockAuthRepo.create).toHaveBeenCalledWith(
         {
@@ -178,7 +138,7 @@ describe('Signup with Email', () => {
     })
 
     it('should hash the password correctly', async () => {
-      await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+      await signUpWithEmail(mockSignupParams)
 
       expect(mockUserRepo.findByEmail).toHaveBeenCalledWith(mockSignupParams.email)
       expect(mockUserRepo.create).toHaveBeenCalledTimes(1)
@@ -194,7 +154,7 @@ describe('Signup with Email', () => {
     })
 
     it('should create email verification token', async () => {
-      await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+      await signUpWithEmail(mockSignupParams)
 
       expect(mockTokenRepo.issue).toHaveBeenCalledWith(
         mockNewUser.id,
@@ -210,7 +170,7 @@ describe('Signup with Email', () => {
     })
 
     it('should send email verification email with verification token', async () => {
-      await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+      await signUpWithEmail(mockSignupParams)
 
       expect(mockEmailAgent.sendEmailVerificationEmail).toHaveBeenCalledWith(
         mockNewUser.firstName,
@@ -221,49 +181,22 @@ describe('Signup with Email', () => {
       expect(mockEmailAgent.sendEmailVerificationEmail).toHaveBeenCalledTimes(1)
     })
 
-    it('should generate JWT token for immediate authentication', async () => {
-      const result = await signUpWithEmail(mockSignupParams, mockDeviceInfo)
-
-      expect(result.data).toHaveProperty('accessToken')
-      expect(result.data.accessToken).toBe(mockJwtToken)
-      expect(result).toHaveProperty('refreshToken')
-      expect(result.refreshToken).toBe(mockRefreshToken)
-      expect(result).toHaveProperty('data')
-    })
-
-    it('should create refresh token with device info', async () => {
-      await signUpWithEmail(mockSignupParams, mockDeviceInfo)
-
-      expect(mockRefreshTokenRepo.create).toHaveBeenCalledWith({
-        userId: mockNewUser.id,
-        tokenHash: mockRefreshTokenHash,
-        ipAddress: mockDeviceInfo.ipAddress,
-        userAgent: mockDeviceInfo.userAgent,
-        expiresAt: mockRefreshExpiresAt,
-      })
-      expect(mockRefreshTokenRepo.create).toHaveBeenCalledTimes(1)
-    })
-
     it('should not return sensitive fields in the response', async () => {
-      const result = await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+      const result = await signUpWithEmail(mockSignupParams)
 
-      // Ensure tokenVersion is not included in the response
-      expect(result.data.user).not.toHaveProperty('tokenVersion')
-      // createdAt and updatedAt are now included in the response
-      expect(result.data.user).toHaveProperty('createdAt')
-      expect(result.data.user).toHaveProperty('updatedAt')
-
-      // Ensure expected fields are present
-      expect(result.data.user).toHaveProperty('id')
-      expect(result.data.user).toHaveProperty('firstName')
-      expect(result.data.user).toHaveProperty('lastName')
-      expect(result.data.user).toHaveProperty('email')
-      expect(result.data.user).toHaveProperty('status')
-      expect(result.data.user).toHaveProperty('role')
+      expect(result.user).not.toHaveProperty('tokenVersion')
+      expect(result.user).toHaveProperty('createdAt')
+      expect(result.user).toHaveProperty('updatedAt')
+      expect(result.user).toHaveProperty('id')
+      expect(result.user).toHaveProperty('firstName')
+      expect(result.user).toHaveProperty('lastName')
+      expect(result.user).toHaveProperty('email')
+      expect(result.user).toHaveProperty('status')
+      expect(result.user).toHaveProperty('role')
     })
 
     it('should check for existing user first', async () => {
-      await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+      await signUpWithEmail(mockSignupParams)
 
       expect(mockUserRepo.findByEmail).toHaveBeenCalledWith(mockSignupParams.email)
       expect(mockUserRepo.findByEmail).toHaveBeenCalledTimes(1)
@@ -286,7 +219,7 @@ describe('Signup with Email', () => {
       mockUserRepo.findByEmail.mockImplementation(async () => existingUser)
 
       try {
-        await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+        await signUpWithEmail(mockSignupParams)
         expect(true).toBe(false)
       } catch (error) {
         expect(error).toBeInstanceOf(AppError)
@@ -310,7 +243,7 @@ describe('Signup with Email', () => {
       })
 
       try {
-        await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+        await signUpWithEmail(mockSignupParams)
         expect(true).toBe(false)
       } catch (error) {
         expect(error).toBeInstanceOf(Error)
@@ -334,7 +267,7 @@ describe('Signup with Email', () => {
       })
 
       try {
-        await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+        await signUpWithEmail(mockSignupParams)
         expect(true).toBe(false)
       } catch (error) {
         expect(error).toBeInstanceOf(Error)
@@ -358,7 +291,7 @@ describe('Signup with Email', () => {
       })
 
       try {
-        await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+        await signUpWithEmail(mockSignupParams)
         expect(true).toBe(false)
       } catch (error) {
         expect(error).toBeInstanceOf(Error)
@@ -381,13 +314,9 @@ describe('Signup with Email', () => {
         throw new Error('Email service unavailable')
       })
 
-      const result = await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+      const result = await signUpWithEmail(mockSignupParams)
 
-      expect(result).toHaveProperty('data')
-      expect(result).toHaveProperty('refreshToken')
-      expect(result.refreshToken).toBe(mockRefreshToken)
-      const expectedUser = mockNewUser
-      expect(result.data.user).toEqual(expectedUser)
+      expect(result.user).toEqual(mockNewUser)
 
       expect(mockUserRepo.findByEmail).toHaveBeenCalledWith(mockSignupParams.email)
       expect(mockTransaction.transaction).toHaveBeenCalledTimes(1)
@@ -404,7 +333,7 @@ describe('Signup with Email', () => {
       const uppercaseEmail = mockSignupParams.email.toUpperCase()
       const paramsWithUppercaseEmail = { ...mockSignupParams, email: uppercaseEmail }
 
-      const result = await signUpWithEmail(paramsWithUppercaseEmail, mockDeviceInfo)
+      const result = await signUpWithEmail(paramsWithUppercaseEmail)
 
       expect(mockUserRepo.findByEmail).toHaveBeenCalledWith(uppercaseEmail)
       expect(mockUserRepo.create).toHaveBeenCalledWith(
@@ -416,8 +345,7 @@ describe('Signup with Email', () => {
         },
         expect.anything(),
       )
-      const expectedUser = mockNewUser
-      expect(result.data.user).toEqual(expectedUser)
+      expect(result.user).toEqual(mockNewUser)
     })
 
     it('should handle users with minimal names', async () => {
@@ -430,7 +358,7 @@ describe('Signup with Email', () => {
       const userWithShortNames = { ...mockNewUser, firstName: 'Al', lastName: 'Bo' }
       mockUserRepo.create.mockImplementation(async () => userWithShortNames)
 
-      await signUpWithEmail(paramsWithShortNames, mockDeviceInfo)
+      await signUpWithEmail(paramsWithShortNames)
 
       expect(mockUserRepo.create).toHaveBeenCalledWith(
         {
@@ -451,17 +379,17 @@ describe('Signup with Email', () => {
     })
 
     it('should return user with default User role', async () => {
-      const result = await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+      const result = await signUpWithEmail(mockSignupParams)
 
-      expect(result.data.user).toEqual(mockNewUser)
-      expect(result.data.user.role).toBe(Role.User)
+      expect(result.user).toEqual(mockNewUser)
+      expect(result.user.role).toBe(Role.User)
     })
 
     it('should handle complex passwords', async () => {
       const complexPassword = 'VeryComplex@Password123!#$'
       const paramsWithComplexPassword = { ...mockSignupParams, password: complexPassword }
 
-      await signUpWithEmail(paramsWithComplexPassword, mockDeviceInfo)
+      await signUpWithEmail(paramsWithComplexPassword)
 
       expect(mockUserRepo.create).toHaveBeenCalledTimes(1)
       expect(mockAuthRepo.create).toHaveBeenCalledWith(
@@ -484,7 +412,7 @@ describe('Signup with Email', () => {
         lastName: longLastName,
       }
 
-      await signUpWithEmail(paramsWithLongNames, mockDeviceInfo)
+      await signUpWithEmail(paramsWithLongNames)
 
       expect(mockUserRepo.create).toHaveBeenCalledWith(
         {
@@ -505,7 +433,7 @@ describe('Signup with Email', () => {
       })
 
       try {
-        await signUpWithEmail(mockSignupParams, mockDeviceInfo)
+        await signUpWithEmail(mockSignupParams)
         expect(true).toBe(false) // should not reach here
       } catch (error) {
         expect(error).toBeInstanceOf(Error)
@@ -517,30 +445,6 @@ describe('Signup with Email', () => {
       expect(mockUserRepo.create).not.toHaveBeenCalled()
       expect(mockAuthRepo.create).not.toHaveBeenCalled()
       expect(mockTokenRepo.issue).not.toHaveBeenCalled()
-
-      expect(mockEmailAgent.sendEmailVerificationEmail).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('when token replacement fails', () => {
-    it('should throw the error and rollback transaction', async () => {
-      mockTokenRepo.issue.mockImplementation(async () => {
-        throw new Error('Token replacement failed')
-      })
-
-      try {
-        await signUpWithEmail(mockSignupParams, mockDeviceInfo)
-        expect(true).toBe(false)
-      } catch (error) {
-        expect(error).toBeInstanceOf(Error)
-        expect((error as Error).message).toBe('Token replacement failed')
-      }
-
-      expect(mockUserRepo.findByEmail).toHaveBeenCalledWith(mockSignupParams.email)
-      expect(mockTransaction.transaction).toHaveBeenCalledTimes(1)
-      expect(mockUserRepo.create).toHaveBeenCalledTimes(1)
-      expect(mockAuthRepo.create).toHaveBeenCalledTimes(1)
-      expect(mockTokenRepo.issue).toHaveBeenCalledTimes(1)
 
       expect(mockEmailAgent.sendEmailVerificationEmail).not.toHaveBeenCalled()
     })

--- a/src/use-cases/auth/__tests__/verify-email.test.ts
+++ b/src/use-cases/auth/__tests__/verify-email.test.ts
@@ -77,6 +77,8 @@ describe('Verify Email', () => {
       tokenRepo: mockTokenRepo,
       userRepo: mockUserRepo,
       refreshTokenRepo: mockRefreshTokenRepo,
+      teamRepo: { findUserTeam: mock(async () => null) },
+      rbacRepo: { findUserPermissions: mock(async () => []) },
       authRepo: {},
       db: mockTransaction,
     }))

--- a/src/use-cases/auth/__tests__/verify-email.test.ts
+++ b/src/use-cases/auth/__tests__/verify-email.test.ts
@@ -77,7 +77,7 @@ describe('Verify Email', () => {
       tokenRepo: mockTokenRepo,
       userRepo: mockUserRepo,
       refreshTokenRepo: mockRefreshTokenRepo,
-      teamRepo: { findUserTeam: mock(async () => null) },
+      teamRepo: { findUserTeam: mock(async () => undefined) },
       rbacRepo: { findUserPermissions: mock(async () => []) },
       authRepo: {},
       db: mockTransaction,

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -1,7 +1,7 @@
 import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { authRepo, db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
+import { authRepo, db, rbacRepo, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { signJwt } from '@/security/jwt'
 import { hashPassword } from '@/security/password'
@@ -11,7 +11,24 @@ import {
   TokenType,
   TokenValidator,
 } from '@/security/token'
+import { Action, Resource, Role } from '@/types'
 import Status from '@/types/status'
+
+const ALL_PERMISSIONS = Object.values(Action).flatMap(action =>
+  Object.values(Resource).map(resource => `${action}:${resource}`),
+)
+
+const specifyPermissions = async (userId: string, role: Role): Promise<string[]> => {
+  if (role === Role.Owner) {
+    return ALL_PERMISSIONS
+  }
+
+  const rows = await rbacRepo.findUserPermissions(userId, role)
+
+  return rows
+    .filter(row => row.override === true || (row.override === null && row.default))
+    .map(row => `${row.action}:${row.resource}`)
+}
 
 export interface AcceptInviteParams {
   token: string
@@ -74,14 +91,15 @@ const acceptInvite = async (
     throw new AppError(ErrorCode.InternalError, 'User not found after accepting invite')
   }
 
-  const [accessToken, refreshToken, team] = await Promise.all([
+  const [accessToken, refreshToken, team, permissions] = await Promise.all([
     createAccessToken(user),
     createRefreshToken(user.id, deviceInfo),
     teamRepo.findUserTeam(user.id),
+    specifyPermissions(user.id, user.role),
   ])
 
   return {
-    data: { user, team: team ?? null, accessToken },
+    data: { user, team: team ?? null, accessToken, permissions },
     refreshToken,
   }
 }

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -1,19 +1,12 @@
-import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
-import type { Permission } from '@/types'
 
-import { authRepo, db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
+import { authRepo, db, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
-import { signJwt } from '@/security/jwt'
 import { hashPassword } from '@/security/password'
-import {
-  generateHashedToken,
-  TokenStatus,
-  TokenType,
-  TokenValidator,
-} from '@/security/token'
+import { TokenStatus, TokenType, TokenValidator } from '@/security/token'
 import Status from '@/types/status'
 
+import { createAccessToken, createRefreshToken } from '../create-tokens'
 import { resolvePermissions } from '../resolve-permissions'
 
 export interface AcceptInviteParams {
@@ -25,30 +18,6 @@ const validateToken = async (token: string) => {
   const tokenRecord = await tokenRepo.findByToken(token)
 
   return TokenValidator.validate(tokenRecord, TokenType.UserInvite)
-}
-
-const createAccessToken = async (user: User, permissions: Permission[]) => signJwt({
-  id: user.id,
-  email: user.email,
-  role: user.role,
-  status: user.status,
-  permissions,
-})
-
-const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
-  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
-    TokenType.RefreshToken,
-  )
-
-  await refreshTokenRepo.create({
-    userId,
-    tokenHash: hashed,
-    ipAddress: deviceInfo.ipAddress,
-    userAgent: deviceInfo.userAgent,
-    expiresAt,
-  })
-
-  return raw
 }
 
 const acceptInvite = async (

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -1,7 +1,7 @@
 import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { authRepo, db, rbacRepo, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
+import { authRepo, db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { signJwt } from '@/security/jwt'
 import { hashPassword } from '@/security/password'
@@ -11,20 +11,9 @@ import {
   TokenType,
   TokenValidator,
 } from '@/security/token'
-import { ALL_PERMISSIONS, Role } from '@/types'
 import Status from '@/types/status'
 
-const specifyPermissions = async (userId: string, role: Role): Promise<string[]> => {
-  if (role === Role.Owner) {
-    return ALL_PERMISSIONS
-  }
-
-  const rows = await rbacRepo.findUserPermissions(userId, role)
-
-  return rows
-    .filter(row => row.override === true || (row.override === null && row.default))
-    .map(row => `${row.action}:${row.resource}`)
-}
+import { resolvePermissions } from '../resolve-permissions'
 
 export interface AcceptInviteParams {
   token: string
@@ -91,7 +80,7 @@ const acceptInvite = async (
     createAccessToken(user),
     createRefreshToken(user.id, deviceInfo),
     teamRepo.findUserTeam(user.id),
-    specifyPermissions(user.id, user.role),
+    resolvePermissions(user.id, user.role),
   ])
 
   return {

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -1,5 +1,6 @@
 import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
+import type { Permission } from '@/types'
 
 import { authRepo, db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
@@ -26,11 +27,12 @@ const validateToken = async (token: string) => {
   return TokenValidator.validate(tokenRecord, TokenType.UserInvite)
 }
 
-const createAccessToken = async (user: User) => signJwt({
+const createAccessToken = async (user: User, permissions: Permission[]) => signJwt({
   id: user.id,
   email: user.email,
   role: user.role,
   status: user.status,
+  permissions,
 })
 
 const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
@@ -76,15 +78,18 @@ const acceptInvite = async (
     throw new AppError(ErrorCode.InternalError, 'User not found after accepting invite')
   }
 
-  const [accessToken, refreshToken, team, permissions] = await Promise.all([
-    createAccessToken(user),
-    createRefreshToken(user.id, deviceInfo),
+  const [team, permissions] = await Promise.all([
     teamRepo.findUserTeam(user.id),
     resolvePermissions(user.id, user.role),
   ])
 
+  const [accessToken, refreshToken] = await Promise.all([
+    createAccessToken(user, permissions),
+    createRefreshToken(user.id, deviceInfo),
+  ])
+
   return {
-    data: { user, team: team ?? null, accessToken, permissions },
+    data: { user, team, accessToken, permissions },
     refreshToken,
   }
 }

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -11,12 +11,8 @@ import {
   TokenType,
   TokenValidator,
 } from '@/security/token'
-import { Action, Resource, Role } from '@/types'
+import { ALL_PERMISSIONS, Role } from '@/types'
 import Status from '@/types/status'
-
-const ALL_PERMISSIONS = Object.values(Action).flatMap(action =>
-  Object.values(Resource).map(resource => `${action}:${resource}`),
-)
 
 const specifyPermissions = async (userId: string, role: Role): Promise<string[]> => {
   if (role === Role.Owner) {

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -1,11 +1,28 @@
 import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { authRepo, refreshTokenRepo, teamRepo, userRepo } from '@/data'
+import { authRepo, rbacRepo, refreshTokenRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { signJwt } from '@/security/jwt'
 import { comparePasswordHashes } from '@/security/password'
 import { generateHashedToken, TokenType } from '@/security/token'
+import { Action, Resource, Role } from '@/types'
+
+const ALL_PERMISSIONS = Object.values(Action).flatMap(action =>
+  Object.values(Resource).map(resource => `${action}:${resource}`),
+)
+
+const specifyPermissions = async (userId: string, role: Role): Promise<string[]> => {
+  if (role === Role.Owner) {
+    return ALL_PERMISSIONS
+  }
+
+  const rows = await rbacRepo.findUserPermissions(userId, role)
+
+  return rows
+    .filter(row => row.override === true || (row.override === null && row.default))
+    .map(row => `${row.action}:${row.resource}`)
+}
 
 export interface LoginParams {
   email: string
@@ -59,14 +76,15 @@ const logInWithEmail = async (
     throw new AppError(ErrorCode.InvalidCredentials)
   }
 
-  const [accessToken, refreshToken, team] = await Promise.all([
+  const [accessToken, refreshToken, team, permissions] = await Promise.all([
     createAccessToken(user),
     createRefreshToken(user.id, deviceInfo),
     teamRepo.findUserTeam(user.id),
+    specifyPermissions(user.id, user.role),
   ])
 
   return {
-    data: { user, team: team ?? null, accessToken },
+    data: { user, team: team ?? null, accessToken, permissions },
     refreshToken,
   }
 }

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -1,44 +1,15 @@
-import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
-import type { Permission } from '@/types'
 
-import { authRepo, refreshTokenRepo, teamRepo, userRepo } from '@/data'
+import { authRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
-import { signJwt } from '@/security/jwt'
 import { comparePasswordHashes } from '@/security/password'
-import { generateHashedToken, TokenType } from '@/security/token'
 
+import { createAccessToken, createRefreshToken } from '../create-tokens'
 import { resolvePermissions } from '../resolve-permissions'
 
 export interface LoginParams {
   email: string
   password: string
-}
-
-const createAccessToken = async (user: User, permissions: Permission[]) => signJwt(
-  {
-    id: user.id,
-    email: user.email,
-    role: user.role,
-    status: user.status,
-    permissions,
-  },
-)
-
-const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
-  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
-    TokenType.RefreshToken,
-  )
-
-  await refreshTokenRepo.create({
-    userId,
-    tokenHash: hashed,
-    ipAddress: deviceInfo.ipAddress,
-    userAgent: deviceInfo.userAgent,
-    expiresAt,
-  })
-
-  return raw
 }
 
 const logInWithEmail = async (

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -1,24 +1,13 @@
 import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { authRepo, rbacRepo, refreshTokenRepo, teamRepo, userRepo } from '@/data'
+import { authRepo, refreshTokenRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { signJwt } from '@/security/jwt'
 import { comparePasswordHashes } from '@/security/password'
 import { generateHashedToken, TokenType } from '@/security/token'
-import { ALL_PERMISSIONS, Role } from '@/types'
 
-const specifyPermissions = async (userId: string, role: Role): Promise<string[]> => {
-  if (role === Role.Owner) {
-    return ALL_PERMISSIONS
-  }
-
-  const rows = await rbacRepo.findUserPermissions(userId, role)
-
-  return rows
-    .filter(row => row.override === true || (row.override === null && row.default))
-    .map(row => `${row.action}:${row.resource}`)
-}
+import { resolvePermissions } from '../resolve-permissions'
 
 export interface LoginParams {
   email: string
@@ -76,7 +65,7 @@ const logInWithEmail = async (
     createAccessToken(user),
     createRefreshToken(user.id, deviceInfo),
     teamRepo.findUserTeam(user.id),
-    specifyPermissions(user.id, user.role),
+    resolvePermissions(user.id, user.role),
   ])
 
   return {

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -6,11 +6,7 @@ import { AppError, ErrorCode } from '@/errors'
 import { signJwt } from '@/security/jwt'
 import { comparePasswordHashes } from '@/security/password'
 import { generateHashedToken, TokenType } from '@/security/token'
-import { Action, Resource, Role } from '@/types'
-
-const ALL_PERMISSIONS = Object.values(Action).flatMap(action =>
-  Object.values(Resource).map(resource => `${action}:${resource}`),
-)
+import { ALL_PERMISSIONS, Role } from '@/types'
 
 const specifyPermissions = async (userId: string, role: Role): Promise<string[]> => {
   if (role === Role.Owner) {

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -1,5 +1,6 @@
 import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
+import type { Permission } from '@/types'
 
 import { authRepo, refreshTokenRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
@@ -14,12 +15,13 @@ export interface LoginParams {
   password: string
 }
 
-const createAccessToken = async (user: User) => signJwt(
+const createAccessToken = async (user: User, permissions: Permission[]) => signJwt(
   {
     id: user.id,
     email: user.email,
     role: user.role,
     status: user.status,
+    permissions,
   },
 )
 
@@ -61,15 +63,18 @@ const logInWithEmail = async (
     throw new AppError(ErrorCode.InvalidCredentials)
   }
 
-  const [accessToken, refreshToken, team, permissions] = await Promise.all([
-    createAccessToken(user),
-    createRefreshToken(user.id, deviceInfo),
+  const [team, permissions] = await Promise.all([
     teamRepo.findUserTeam(user.id),
     resolvePermissions(user.id, user.role),
   ])
 
+  const [accessToken, refreshToken] = await Promise.all([
+    createAccessToken(user, permissions),
+    createRefreshToken(user.id, deviceInfo),
+  ])
+
   return {
-    data: { user, team: team ?? null, accessToken, permissions },
+    data: { user, team, accessToken, permissions },
     refreshToken,
   }
 }

--- a/src/use-cases/auth/refresh-token.ts
+++ b/src/use-cases/auth/refresh-token.ts
@@ -1,13 +1,11 @@
-import type { Database, User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
-import type { Permission } from '@/types'
 
 import { db, refreshTokenRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { logger } from '@/logging'
-import { signJwt } from '@/security/jwt'
-import { generateHashedToken, hashToken, TokenType } from '@/security/token'
+import { hashToken } from '@/security/token'
 
+import { createAccessToken, createRefreshToken } from '../create-tokens'
 import { resolvePermissions } from '../resolve-permissions'
 
 const validateToken = async (refreshToken: string | undefined) => {
@@ -31,36 +29,6 @@ const validateToken = async (refreshToken: string | undefined) => {
   }
 
   return { storedToken, hashedToken }
-}
-
-const createAccessToken = async (user: User, permissions: Permission[]) => signJwt(
-  {
-    id: user.id,
-    email: user.email,
-    role: user.role,
-    status: user.status,
-    permissions,
-  },
-)
-
-const createRefreshToken = async (
-  userId: string,
-  deviceInfo: DeviceInfo,
-  tx?: Database,
-) => {
-  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
-    TokenType.RefreshToken,
-  )
-
-  await refreshTokenRepo.create({
-    userId,
-    tokenHash: hashed,
-    ipAddress: deviceInfo.ipAddress,
-    userAgent: deviceInfo.userAgent,
-    expiresAt,
-  }, tx)
-
-  return raw
 }
 
 const validateDevice = (

--- a/src/use-cases/auth/refresh-token.ts
+++ b/src/use-cases/auth/refresh-token.ts
@@ -1,11 +1,14 @@
 import type { Database, User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
+import type { Permission } from '@/types'
 
-import { db, refreshTokenRepo, userRepo } from '@/data'
+import { db, refreshTokenRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { logger } from '@/logging'
 import { signJwt } from '@/security/jwt'
 import { generateHashedToken, hashToken, TokenType } from '@/security/token'
+
+import { resolvePermissions } from '../resolve-permissions'
 
 const validateToken = async (refreshToken: string | undefined) => {
   if (!refreshToken) {
@@ -30,12 +33,13 @@ const validateToken = async (refreshToken: string | undefined) => {
   return { storedToken, hashedToken }
 }
 
-const createAccessToken = async (user: User) => signJwt(
+const createAccessToken = async (user: User, permissions: Permission[]) => signJwt(
   {
     id: user.id,
     email: user.email,
     role: user.role,
     status: user.status,
+    permissions,
   },
 )
 
@@ -92,19 +96,25 @@ const refreshAuthTokens = async (
 
   validateDevice(storedToken, deviceInfo, user.id)
 
-  return db.transaction(async (tx) => {
-    // Create new tokens first (OAuth 2.0 best practice)
-    const accessToken = await createAccessToken(user)
-    const newRefreshToken = await createRefreshToken(user.id, deviceInfo, tx)
+  const [team, permissions, newRefreshToken] = await Promise.all([
+    teamRepo.findUserTeam(user.id),
+    resolvePermissions(user.id, user.role),
+    db.transaction(async (tx) => {
+      const newRefreshToken = await createRefreshToken(user.id, deviceInfo, tx)
 
-    // Revoke old token last to prevent user lockout on failures
-    await refreshTokenRepo.revokeByHash(hashedToken, tx)
+      // Revoke old token last to prevent user lockout on failures
+      await refreshTokenRepo.revokeByHash(hashedToken, tx)
 
-    return {
-      data: { user, accessToken },
-      refreshToken: newRefreshToken,
-    }
-  })
+      return newRefreshToken
+    }),
+  ])
+
+  const accessToken = await createAccessToken(user, permissions)
+
+  return {
+    data: { user, team, accessToken, permissions },
+    refreshToken: newRefreshToken,
+  }
 }
 
 export default refreshAuthTokens

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -1,5 +1,6 @@
 import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
+import type { Permission } from '@/types'
 
 import { authRepo, db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
@@ -25,11 +26,12 @@ const validateToken = async (token: string) => {
   return TokenValidator.validate(tokenRecord, TokenType.PasswordReset)
 }
 
-const createAccessToken = async (user: User) => signJwt({
+const createAccessToken = async (user: User, permissions: Permission[]) => signJwt({
   id: user.id,
   email: user.email,
   role: user.role,
   status: user.status,
+  permissions,
 })
 
 const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
@@ -72,15 +74,18 @@ const resetPassword = async (
     throw new AppError(ErrorCode.InternalError, 'User not found after password reset')
   }
 
-  const [accessToken, refreshToken, team, permissions] = await Promise.all([
-    createAccessToken(user),
-    createRefreshToken(user.id, deviceInfo),
+  const [team, permissions] = await Promise.all([
     teamRepo.findUserTeam(user.id),
     resolvePermissions(user.id, user.role),
   ])
 
+  const [accessToken, refreshToken] = await Promise.all([
+    createAccessToken(user, permissions),
+    createRefreshToken(user.id, deviceInfo),
+  ])
+
   return {
-    data: { user, team: team ?? null, accessToken, permissions },
+    data: { user, team, accessToken, permissions },
     refreshToken,
   }
 }

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -1,7 +1,7 @@
 import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { authRepo, db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
+import { authRepo, db, rbacRepo, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { signJwt } from '@/security/jwt'
 import { hashPassword } from '@/security/password'
@@ -11,6 +11,23 @@ import {
   TokenType,
   TokenValidator,
 } from '@/security/token'
+import { Action, Resource, Role } from '@/types'
+
+const ALL_PERMISSIONS = Object.values(Action).flatMap(action =>
+  Object.values(Resource).map(resource => `${action}:${resource}`),
+)
+
+const specifyPermissions = async (userId: string, role: Role): Promise<string[]> => {
+  if (role === Role.Owner) {
+    return ALL_PERMISSIONS
+  }
+
+  const rows = await rbacRepo.findUserPermissions(userId, role)
+
+  return rows
+    .filter(row => row.override === true || (row.override === null && row.default))
+    .map(row => `${row.action}:${row.resource}`)
+}
 
 export interface ResetPasswordParams {
   token: string
@@ -70,14 +87,15 @@ const resetPassword = async (
     throw new AppError(ErrorCode.InternalError, 'User not found after password reset')
   }
 
-  const [accessToken, refreshToken, team] = await Promise.all([
+  const [accessToken, refreshToken, team, permissions] = await Promise.all([
     createAccessToken(user),
     createRefreshToken(user.id, deviceInfo),
     teamRepo.findUserTeam(user.id),
+    specifyPermissions(user.id, user.role),
   ])
 
   return {
-    data: { user, team: team ?? null, accessToken },
+    data: { user, team: team ?? null, accessToken, permissions },
     refreshToken,
   }
 }

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -1,7 +1,7 @@
 import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { authRepo, db, rbacRepo, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
+import { authRepo, db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { signJwt } from '@/security/jwt'
 import { hashPassword } from '@/security/password'
@@ -11,19 +11,8 @@ import {
   TokenType,
   TokenValidator,
 } from '@/security/token'
-import { ALL_PERMISSIONS, Role } from '@/types'
 
-const specifyPermissions = async (userId: string, role: Role): Promise<string[]> => {
-  if (role === Role.Owner) {
-    return ALL_PERMISSIONS
-  }
-
-  const rows = await rbacRepo.findUserPermissions(userId, role)
-
-  return rows
-    .filter(row => row.override === true || (row.override === null && row.default))
-    .map(row => `${row.action}:${row.resource}`)
-}
+import { resolvePermissions } from '../resolve-permissions'
 
 export interface ResetPasswordParams {
   token: string
@@ -87,7 +76,7 @@ const resetPassword = async (
     createAccessToken(user),
     createRefreshToken(user.id, deviceInfo),
     teamRepo.findUserTeam(user.id),
-    specifyPermissions(user.id, user.role),
+    resolvePermissions(user.id, user.role),
   ])
 
   return {

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -11,11 +11,7 @@ import {
   TokenType,
   TokenValidator,
 } from '@/security/token'
-import { Action, Resource, Role } from '@/types'
-
-const ALL_PERMISSIONS = Object.values(Action).flatMap(action =>
-  Object.values(Resource).map(resource => `${action}:${resource}`),
-)
+import { ALL_PERMISSIONS, Role } from '@/types'
 
 const specifyPermissions = async (userId: string, role: Role): Promise<string[]> => {
   if (role === Role.Owner) {

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -1,18 +1,11 @@
-import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
-import type { Permission } from '@/types'
 
-import { authRepo, db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
+import { authRepo, db, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
-import { signJwt } from '@/security/jwt'
 import { hashPassword } from '@/security/password'
-import {
-  generateHashedToken,
-  TokenStatus,
-  TokenType,
-  TokenValidator,
-} from '@/security/token'
+import { TokenStatus, TokenType, TokenValidator } from '@/security/token'
 
+import { createAccessToken, createRefreshToken } from '../create-tokens'
 import { resolvePermissions } from '../resolve-permissions'
 
 export interface ResetPasswordParams {
@@ -24,30 +17,6 @@ const validateToken = async (token: string) => {
   const tokenRecord = await tokenRepo.findByToken(token)
 
   return TokenValidator.validate(tokenRecord, TokenType.PasswordReset)
-}
-
-const createAccessToken = async (user: User, permissions: Permission[]) => signJwt({
-  id: user.id,
-  email: user.email,
-  role: user.role,
-  status: user.status,
-  permissions,
-})
-
-const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
-  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
-    TokenType.RefreshToken,
-  )
-
-  await refreshTokenRepo.create({
-    userId,
-    tokenHash: hashed,
-    ipAddress: deviceInfo.ipAddress,
-    userAgent: deviceInfo.userAgent,
-    expiresAt,
-  })
-
-  return raw
 }
 
 const resetPassword = async (

--- a/src/use-cases/auth/signup.ts
+++ b/src/use-cases/auth/signup.ts
@@ -1,13 +1,10 @@
-import type { User } from '@/data'
-import type { DeviceInfo } from '@/net/http/device'
 import type { UserPreferences } from '@/types'
 
-import { authRepo, db, refreshTokenRepo, tokenRepo, userRepo } from '@/data'
+import { authRepo, db, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { logger } from '@/logging'
-import { signJwt } from '@/security/jwt'
 import { hashPassword } from '@/security/password'
-import { generateHashedToken, generateToken, TokenType } from '@/security/token'
+import { generateToken, TokenType } from '@/security/token'
 import { emailAgent } from '@/services'
 import { AuthProvider, Status } from '@/types'
 
@@ -56,34 +53,8 @@ const createNewUser = async (
   return { newUser, verificationToken }
 }
 
-const createAccessToken = async (user: User) => signJwt(
-  {
-    id: user.id,
-    email: user.email,
-    role: user.role,
-    status: user.status,
-  },
-)
-
-const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
-  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
-    TokenType.RefreshToken,
-  )
-
-  await refreshTokenRepo.create({
-    userId,
-    tokenHash: hashed,
-    ipAddress: deviceInfo.ipAddress,
-    userAgent: deviceInfo.userAgent,
-    expiresAt,
-  })
-
-  return raw
-}
-
 const signUpWithEmail = async (
   { firstName, lastName, email, password }: SignupParams,
-  deviceInfo: DeviceInfo,
   preferences?: UserPreferences,
 ) => {
   // Check if user exists (outside transaction for fast fail)
@@ -111,13 +82,7 @@ const signUpWithEmail = async (
     logger.error({ error }, `Failed to send email verification email to ${newUser.email}`)
   })
 
-  const accessToken = await createAccessToken(newUser)
-  const refreshToken = await createRefreshToken(newUser.id, deviceInfo)
-
-  return {
-    data: { user: newUser, accessToken },
-    refreshToken,
-  }
+  return { user: newUser }
 }
 
 export default signUpWithEmail

--- a/src/use-cases/auth/verify-email.ts
+++ b/src/use-cases/auth/verify-email.ts
@@ -1,12 +1,10 @@
-import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
-import type { Permission } from '@/types'
 
-import { db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
-import { signJwt } from '@/security/jwt'
-import { generateHashedToken, TokenStatus, TokenType, TokenValidator } from '@/security/token'
+import { db, teamRepo, tokenRepo, userRepo } from '@/data'
+import { TokenStatus, TokenType, TokenValidator } from '@/security/token'
 import { Status } from '@/types'
 
+import { createAccessToken, createRefreshToken } from '../create-tokens'
 import { resolvePermissions } from '../resolve-permissions'
 
 export interface VerifyEmailParams {
@@ -17,32 +15,6 @@ const validateToken = async (token: string) => {
   const tokenRecord = await tokenRepo.findByToken(token)
 
   return TokenValidator.validate(tokenRecord, TokenType.EmailVerification)
-}
-
-const createAccessToken = async (user: User, permissions: Permission[]) => signJwt(
-  {
-    id: user.id,
-    email: user.email,
-    role: user.role,
-    status: user.status,
-    permissions,
-  },
-)
-
-const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
-  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
-    TokenType.RefreshToken,
-  )
-
-  await refreshTokenRepo.create({
-    userId,
-    tokenHash: hashed,
-    ipAddress: deviceInfo.ipAddress,
-    userAgent: deviceInfo.userAgent,
-    expiresAt,
-  })
-
-  return raw
 }
 
 const verifyEmail = async ({ token }: VerifyEmailParams, deviceInfo: DeviceInfo) => {

--- a/src/use-cases/auth/verify-email.ts
+++ b/src/use-cases/auth/verify-email.ts
@@ -1,10 +1,13 @@
 import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
+import type { Permission } from '@/types'
 
-import { db, refreshTokenRepo, tokenRepo, userRepo } from '@/data'
+import { db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
 import { signJwt } from '@/security/jwt'
 import { generateHashedToken, TokenStatus, TokenType, TokenValidator } from '@/security/token'
 import { Status } from '@/types'
+
+import { resolvePermissions } from '../resolve-permissions'
 
 export interface VerifyEmailParams {
   token: string
@@ -16,12 +19,13 @@ const validateToken = async (token: string) => {
   return TokenValidator.validate(tokenRecord, TokenType.EmailVerification)
 }
 
-const createAccessToken = async (user: User) => signJwt(
+const createAccessToken = async (user: User, permissions: Permission[]) => signJwt(
   {
     id: user.id,
     email: user.email,
     role: user.role,
     status: user.status,
+    permissions,
   },
 )
 
@@ -55,11 +59,18 @@ const verifyEmail = async ({ token }: VerifyEmailParams, deviceInfo: DeviceInfo)
     return userRepo.update(validatedToken.userId, { status: Status.Verified }, tx)
   })
 
-  const accessToken = await createAccessToken(updatedUser)
-  const refreshToken = await createRefreshToken(updatedUser.id, deviceInfo)
+  const [team, permissions] = await Promise.all([
+    teamRepo.findUserTeam(updatedUser.id),
+    resolvePermissions(updatedUser.id, updatedUser.role),
+  ])
+
+  const [accessToken, refreshToken] = await Promise.all([
+    createAccessToken(updatedUser, permissions),
+    createRefreshToken(updatedUser.id, deviceInfo),
+  ])
 
   return {
-    data: { user: updatedUser, accessToken },
+    data: { user: updatedUser, team, accessToken, permissions },
     refreshToken,
   }
 }

--- a/src/use-cases/create-tokens.ts
+++ b/src/use-cases/create-tokens.ts
@@ -1,0 +1,29 @@
+import type { Database, User } from '@/data'
+import type { DeviceInfo } from '@/net/http/device'
+import type { Permission } from '@/types'
+
+import { refreshTokenRepo } from '@/data'
+import { signJwt } from '@/security/jwt'
+import { generateHashedToken, TokenType } from '@/security/token'
+
+export const createAccessToken = async (user: User, permissions: Permission[]) => signJwt({
+  id: user.id,
+  email: user.email,
+  role: user.role,
+  status: user.status,
+  permissions,
+})
+
+export const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo, tx?: Database) => {
+  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(TokenType.RefreshToken)
+
+  await refreshTokenRepo.create({
+    userId,
+    tokenHash: hashed,
+    ipAddress: deviceInfo.ipAddress,
+    userAgent: deviceInfo.userAgent,
+    expiresAt,
+  }, tx)
+
+  return raw
+}

--- a/src/use-cases/resolve-permissions.ts
+++ b/src/use-cases/resolve-permissions.ts
@@ -1,0 +1,14 @@
+import type Permission from '@/types/permission'
+
+import { rbacRepo } from '@/data'
+import { ALL_PERMISSIONS, Role } from '@/types'
+
+export const resolvePermissions = async (userId: string, role: Role): Promise<Permission[]> => {
+  if (role === Role.Owner) {
+    return ALL_PERMISSIONS
+  }
+
+  const rows = await rbacRepo.findUserPermissions(userId, role)
+
+  return rows.map(row => `${row.action}:${row.resource}` as Permission)
+}

--- a/src/use-cases/resolve-permissions.ts
+++ b/src/use-cases/resolve-permissions.ts
@@ -1,13 +1,8 @@
-import type Permission from '@/types/permission'
+import type { Permission, Role } from '@/types'
 
 import { rbacRepo } from '@/data'
-import { ALL_PERMISSIONS, Role } from '@/types'
 
 export const resolvePermissions = async (userId: string, role: Role): Promise<Permission[]> => {
-  if (role === Role.Owner) {
-    return ALL_PERMISSIONS
-  }
-
   const rows = await rbacRepo.findUserPermissions(userId, role)
 
   return rows.map(row => `${row.action}:${row.resource}` as Permission)

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -15,7 +15,7 @@ describe('User Me Use Cases', () => {
   let mockUser: User
   let mockUserRepo: any
   let mockTeamRepo: any
-  let mockTeam: UserTeamInfo | null
+  let mockTeam: UserTeamInfo | undefined
   let mockPermissions: Permission[]
   let mockResolvePermissions: any
 
@@ -37,7 +37,7 @@ describe('User Me Use Cases', () => {
         ...updates,
       })),
     }
-    mockTeam = null
+    mockTeam = undefined
     mockTeamRepo = {
       findUserTeam: mock(async () => mockTeam),
     }
@@ -61,7 +61,7 @@ describe('User Me Use Cases', () => {
     it('should return user and team null when user has no team', async () => {
       const result = await getUser(testUuids.USER_1)
 
-      expect(result).toEqual({ user: mockUser, team: null, permissions: mockPermissions })
+      expect(result).toEqual({ user: mockUser, team: undefined, permissions: mockPermissions })
       expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
       expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(testUuids.USER_1)
       expect(mockResolvePermissions).toHaveBeenCalledWith(mockUser.id, mockUser.role)
@@ -98,7 +98,7 @@ describe('User Me Use Cases', () => {
 
       expect(result.user.firstName).toBe('Jane')
       expect(result.user.lastName).toBe('Smith')
-      expect(result.team).toBeNull()
+      expect(result.team).toBeUndefined()
       expect(result.permissions).toEqual(mockPermissions)
 
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
@@ -112,7 +112,7 @@ describe('User Me Use Cases', () => {
       const result = await updateUser(testUuids.USER_1, { firstName: 'Jane' })
 
       expect(result.user.firstName).toBe('Jane')
-      expect(result.team).toBeNull()
+      expect(result.team).toBeUndefined()
       expect(result.permissions).toEqual(mockPermissions)
 
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
@@ -125,7 +125,7 @@ describe('User Me Use Cases', () => {
       const result = await updateUser(testUuids.USER_1, { lastName: 'Smith' })
 
       expect(result.user.lastName).toBe('Smith')
-      expect(result.team).toBeNull()
+      expect(result.team).toBeUndefined()
       expect(result.permissions).toEqual(mockPermissions)
 
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
@@ -137,7 +137,7 @@ describe('User Me Use Cases', () => {
     it('should return current user and team when no valid updates provided', async () => {
       const result = await updateUser(testUuids.USER_1, {})
 
-      expect(result).toEqual({ user: mockUser, team: null, permissions: mockPermissions })
+      expect(result).toEqual({ user: mockUser, team: undefined, permissions: mockPermissions })
 
       expect(mockUserRepo.update).not.toHaveBeenCalled()
       expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
@@ -150,7 +150,7 @@ describe('User Me Use Cases', () => {
       expect(result.user.firstName).toBe('Jane')
       expect(result.user.lastName).toBe('')
 
-      expect(result.team).toBeNull()
+      expect(result.team).toBeUndefined()
       expect(result.permissions).toEqual(mockPermissions)
 
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
@@ -165,7 +165,7 @@ describe('User Me Use Cases', () => {
       const result = await updateUser(testUuids.USER_1, { firstName: undefined, lastName: 'Smith' })
 
       expect(result.user.lastName).toBe('Smith')
-      expect(result.team).toBeNull()
+      expect(result.team).toBeUndefined()
       expect(result.permissions).toEqual(mockPermissions)
 
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -5,6 +5,7 @@ import type { UpdateUserInput, User, UserTeamInfo } from '@/data'
 import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { Role, Status } from '@/types'
+import Permission from '@/types/permission'
 
 import { getUser, updateUser } from '../me'
 
@@ -15,6 +16,8 @@ describe('User Me Use Cases', () => {
   let mockUserRepo: any
   let mockTeamRepo: any
   let mockTeam: UserTeamInfo | undefined
+  let mockPermissions: Permission[]
+  let mockResolvePermissions: any
 
   beforeEach(async () => {
     mockUser = {
@@ -38,10 +41,15 @@ describe('User Me Use Cases', () => {
     mockTeamRepo = {
       findUserTeam: mock(async () => mockTeam),
     }
+    mockPermissions = [Permission.ViewTeams, Permission.ManageTeams]
+    mockResolvePermissions = mock(async () => mockPermissions)
 
     await moduleMocker.mock('@/data', () => ({
       userRepo: mockUserRepo,
       teamRepo: mockTeamRepo,
+    }))
+    await moduleMocker.mock('../../resolve-permissions', () => ({
+      resolvePermissions: mockResolvePermissions,
     }))
   })
 
@@ -53,9 +61,10 @@ describe('User Me Use Cases', () => {
     it('should return user and team null when user has no team', async () => {
       const result = await getUser(testUuids.USER_1)
 
-      expect(result).toEqual({ user: mockUser, team: null })
+      expect(result).toEqual({ user: mockUser, team: null, permissions: mockPermissions })
       expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
       expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(testUuids.USER_1)
+      expect(mockResolvePermissions).toHaveBeenCalledWith(mockUser.id, mockUser.role)
     })
 
     it('should return user and team info when user belongs to a team', async () => {
@@ -68,8 +77,9 @@ describe('User Me Use Cases', () => {
 
       const result = await getUser(testUuids.USER_1)
 
-      expect(result).toEqual({ user: mockUser, team: mockTeam })
+      expect(result).toEqual({ user: mockUser, team: mockTeam, permissions: mockPermissions })
       expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(testUuids.USER_1)
+      expect(mockResolvePermissions).toHaveBeenCalledWith(mockUser.id, mockUser.role)
     })
 
     it('should throw InternalError when user not found', async () => {
@@ -89,6 +99,7 @@ describe('User Me Use Cases', () => {
       expect(result.user.firstName).toBe('Jane')
       expect(result.user.lastName).toBe('Smith')
       expect(result.team).toBeNull()
+      expect(result.permissions).toEqual(mockPermissions)
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: 'Smith',
@@ -101,6 +112,7 @@ describe('User Me Use Cases', () => {
 
       expect(result.user.firstName).toBe('Jane')
       expect(result.team).toBeNull()
+      expect(result.permissions).toEqual(mockPermissions)
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         updatedAt: expect.any(Date),
@@ -112,6 +124,7 @@ describe('User Me Use Cases', () => {
 
       expect(result.user.lastName).toBe('Smith')
       expect(result.team).toBeNull()
+      expect(result.permissions).toEqual(mockPermissions)
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         lastName: 'Smith',
         updatedAt: expect.any(Date),
@@ -121,7 +134,7 @@ describe('User Me Use Cases', () => {
     it('should return current user and team when no valid updates provided', async () => {
       const result = await updateUser(testUuids.USER_1, {})
 
-      expect(result).toEqual({ user: mockUser, team: null })
+      expect(result).toEqual({ user: mockUser, team: null, permissions: mockPermissions })
       expect(mockUserRepo.update).not.toHaveBeenCalled()
       expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
     })
@@ -133,6 +146,7 @@ describe('User Me Use Cases', () => {
       expect(result.user.firstName).toBe('Jane')
       expect(result.user.lastName).toBe('')
       expect(result.team).toBeNull()
+      expect(result.permissions).toEqual(mockPermissions)
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: '',
@@ -146,6 +160,7 @@ describe('User Me Use Cases', () => {
 
       expect(result.user.lastName).toBe('Smith')
       expect(result.team).toBeNull()
+      expect(result.permissions).toEqual(mockPermissions)
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         lastName: 'Smith',
         updatedAt: expect.any(Date),

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -15,7 +15,7 @@ describe('User Me Use Cases', () => {
   let mockUser: User
   let mockUserRepo: any
   let mockTeamRepo: any
-  let mockTeam: UserTeamInfo | undefined
+  let mockTeam: UserTeamInfo | null
   let mockPermissions: Permission[]
   let mockResolvePermissions: any
 
@@ -37,7 +37,7 @@ describe('User Me Use Cases', () => {
         ...updates,
       })),
     }
-    mockTeam = undefined
+    mockTeam = null
     mockTeamRepo = {
       findUserTeam: mock(async () => mockTeam),
     }

--- a/src/use-cases/user/me.ts
+++ b/src/use-cases/user/me.ts
@@ -3,6 +3,8 @@ import type { UpdateUserInput } from '@/data'
 import { teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 
+import { resolvePermissions } from '../resolve-permissions'
+
 const prepareValidUpdates = (updates: UpdateUserInput): UpdateUserInput => {
   return Object.fromEntries(
     Object.entries(updates).filter(([_, v]) => v !== undefined),
@@ -21,7 +23,9 @@ export const getUser = async (userId: string) => {
     throw new AppError(ErrorCode.InternalError)
   }
 
-  return { user, team: team ?? null }
+  const permissions = await resolvePermissions(user.id, user.role)
+
+  return { user, team: team ?? null, permissions }
 }
 
 export const updateUser = async (userId: string, updates: UpdateUserInput) => {
@@ -39,5 +43,7 @@ export const updateUser = async (userId: string, updates: UpdateUserInput) => {
     teamRepo.findUserTeam(userId),
   ])
 
-  return { user: updatedUser, team: team ?? null }
+  const permissions = await resolvePermissions(updatedUser.id, updatedUser.role)
+
+  return { user: updatedUser, team: team ?? null, permissions }
 }

--- a/src/use-cases/user/me.ts
+++ b/src/use-cases/user/me.ts
@@ -25,7 +25,7 @@ export const getUser = async (userId: string) => {
 
   const permissions = await resolvePermissions(user.id, user.role)
 
-  return { user, team: team ?? null, permissions }
+  return { user, team, permissions }
 }
 
 export const updateUser = async (userId: string, updates: UpdateUserInput) => {
@@ -45,5 +45,5 @@ export const updateUser = async (userId: string, updates: UpdateUserInput) => {
 
   const permissions = await resolvePermissions(updatedUser.id, updatedUser.role)
 
-  return { user: updatedUser, team: team ?? null, permissions }
+  return { user: updatedUser, team, permissions }
 }


### PR DESCRIPTION
1. [Feature]: Return effective user permissions in login, reset-password, accept-invite, and /me responses
2. [Feature]: Add default Teams permissions for User role in database seeding
3. [Improvement]: Extract Permission enum and resolvePermissions shared use-case helper
4. [Improvement]: Move permission filtering to SQL query level, replacing in-memory filter logic
5. [Improvement]: Permission fetch runs in parallel with token and team queries
6. [Improvement]: Change findUserTeam return type to undefined, omitting absent team from JSON responses