### PR TITLE
Extract shared token creation utilities

### DIFF
--- a/src/use-cases/auth/__tests__/accept-invite.test.ts
+++ b/src/use-cases/auth/__tests__/accept-invite.test.ts
@@ -90,7 +90,7 @@ describe('Accept Invite', () => {
       create: mock(async () => {}),
     }
     mockTeamRepo = {
-      findUserTeam: mock(async () => null),
+      findUserTeam: mock(async () => undefined),
     }
     mockTransaction = {
       transaction: mock(async (callback: any) => callback({}) as Promise<void>),
@@ -172,7 +172,7 @@ describe('Accept Invite', () => {
       expect(mockRefreshTokenRepo.create).toHaveBeenCalledTimes(1)
 
       expect(result).toEqual({
-        data: { user: mockActivatedUser, team: null, accessToken: mockAccessToken },
+        data: { user: mockActivatedUser, team: undefined, accessToken: mockAccessToken },
         refreshToken: mockRefreshToken,
       })
     })
@@ -389,7 +389,7 @@ describe('Accept Invite', () => {
       )
 
       expect(result).toEqual({
-        data: { user: mockActivatedUser, team: null, accessToken: mockAccessToken },
+        data: { user: mockActivatedUser, team: undefined, accessToken: mockAccessToken },
         refreshToken: mockRefreshToken,
       })
 

--- a/src/use-cases/auth/__tests__/login.test.ts
+++ b/src/use-cases/auth/__tests__/login.test.ts
@@ -117,7 +117,7 @@ describe('Login with Email', () => {
       expect(result).toHaveProperty('data')
       expect(result).toHaveProperty('refreshToken')
       expect(result.data.accessToken).toBe(mockJwtToken)
-      expect(result.data.team).toBeNull()
+      expect(result.data.team).toBeUndefined()
       expect(result.refreshToken).toBe('refresh_token_123')
       expect(result.data.user).not.toHaveProperty('tokenVersion')
       expect(result.data.user.email).toBe(mockLoginParams.email)

--- a/src/use-cases/auth/__tests__/reset-password.test.ts
+++ b/src/use-cases/auth/__tests__/reset-password.test.ts
@@ -162,7 +162,7 @@ describe('Reset Password', () => {
       expect(mockRefreshTokenRepo.create).toHaveBeenCalledTimes(1)
 
       expect(result).toEqual({
-        data: { user: mockUser, team: null, accessToken: mockAccessToken },
+        data: { user: mockUser, team: undefined, accessToken: mockAccessToken },
         refreshToken: mockRefreshToken,
       })
     })
@@ -366,7 +366,7 @@ describe('Reset Password', () => {
       )
 
       expect(result).toEqual({
-        data: { user: mockUser, team: null, accessToken: mockAccessToken },
+        data: { user: mockUser, team: undefined, accessToken: mockAccessToken },
         refreshToken: mockRefreshToken,
       })
 

--- a/src/use-cases/auth/__tests__/signup.test.ts
+++ b/src/use-cases/auth/__tests__/signup.test.ts
@@ -240,7 +240,7 @@ describe('Signup with Email', () => {
         ipAddress: mockDeviceInfo.ipAddress,
         userAgent: mockDeviceInfo.userAgent,
         expiresAt: mockRefreshExpiresAt,
-      })
+      }, undefined)
       expect(mockRefreshTokenRepo.create).toHaveBeenCalledTimes(1)
     })
 

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -1,17 +1,12 @@
-import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { authRepo, db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
+import { authRepo, db, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
-import { signJwt } from '@/security/jwt'
 import { hashPassword } from '@/security/password'
-import {
-  generateHashedToken,
-  TokenStatus,
-  TokenType,
-  TokenValidator,
-} from '@/security/token'
+import { TokenStatus, TokenType, TokenValidator } from '@/security/token'
 import Status from '@/types/status'
+
+import { createAccessToken, createRefreshToken } from '../create-tokens'
 
 export interface AcceptInviteParams {
   token: string
@@ -22,29 +17,6 @@ const validateToken = async (token: string) => {
   const tokenRecord = await tokenRepo.findByToken(token)
 
   return TokenValidator.validate(tokenRecord, TokenType.UserInvite)
-}
-
-const createAccessToken = async (user: User) => signJwt({
-  id: user.id,
-  email: user.email,
-  role: user.role,
-  status: user.status,
-})
-
-const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
-  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
-    TokenType.RefreshToken,
-  )
-
-  await refreshTokenRepo.create({
-    userId,
-    tokenHash: hashed,
-    ipAddress: deviceInfo.ipAddress,
-    userAgent: deviceInfo.userAgent,
-    expiresAt,
-  })
-
-  return raw
 }
 
 const acceptInvite = async (

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -53,7 +53,7 @@ const acceptInvite = async (
   ])
 
   return {
-    data: { user, team: team ?? null, accessToken },
+    data: { user, team, accessToken },
     refreshToken,
   }
 }

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -40,7 +40,7 @@ const logInWithEmail = async (
   ])
 
   return {
-    data: { user, team: team ?? null, accessToken },
+    data: { user, team, accessToken },
     refreshToken,
   }
 }

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -1,40 +1,14 @@
-import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { authRepo, refreshTokenRepo, teamRepo, userRepo } from '@/data'
+import { authRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
-import { signJwt } from '@/security/jwt'
 import { comparePasswordHashes } from '@/security/password'
-import { generateHashedToken, TokenType } from '@/security/token'
+
+import { createAccessToken, createRefreshToken } from '../create-tokens'
 
 export interface LoginParams {
   email: string
   password: string
-}
-
-const createAccessToken = async (user: User) => signJwt(
-  {
-    id: user.id,
-    email: user.email,
-    role: user.role,
-    status: user.status,
-  },
-)
-
-const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
-  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
-    TokenType.RefreshToken,
-  )
-
-  await refreshTokenRepo.create({
-    userId,
-    tokenHash: hashed,
-    ipAddress: deviceInfo.ipAddress,
-    userAgent: deviceInfo.userAgent,
-    expiresAt,
-  })
-
-  return raw
 }
 
 const logInWithEmail = async (

--- a/src/use-cases/auth/refresh-token.ts
+++ b/src/use-cases/auth/refresh-token.ts
@@ -1,11 +1,11 @@
-import type { Database, User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
 import { db, refreshTokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { logger } from '@/logging'
-import { signJwt } from '@/security/jwt'
-import { generateHashedToken, hashToken, TokenType } from '@/security/token'
+import { hashToken } from '@/security/token'
+
+import { createAccessToken, createRefreshToken } from '../create-tokens'
 
 const validateToken = async (refreshToken: string | undefined) => {
   if (!refreshToken) {
@@ -28,35 +28,6 @@ const validateToken = async (refreshToken: string | undefined) => {
   }
 
   return { storedToken, hashedToken }
-}
-
-const createAccessToken = async (user: User) => signJwt(
-  {
-    id: user.id,
-    email: user.email,
-    role: user.role,
-    status: user.status,
-  },
-)
-
-const createRefreshToken = async (
-  userId: string,
-  deviceInfo: DeviceInfo,
-  tx?: Database,
-) => {
-  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
-    TokenType.RefreshToken,
-  )
-
-  await refreshTokenRepo.create({
-    userId,
-    tokenHash: hashed,
-    ipAddress: deviceInfo.ipAddress,
-    userAgent: deviceInfo.userAgent,
-    expiresAt,
-  }, tx)
-
-  return raw
 }
 
 const validateDevice = (

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -1,16 +1,11 @@
-import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { authRepo, db, refreshTokenRepo, teamRepo, tokenRepo, userRepo } from '@/data'
+import { authRepo, db, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
-import { signJwt } from '@/security/jwt'
 import { hashPassword } from '@/security/password'
-import {
-  generateHashedToken,
-  TokenStatus,
-  TokenType,
-  TokenValidator,
-} from '@/security/token'
+import { TokenStatus, TokenType, TokenValidator } from '@/security/token'
+
+import { createAccessToken, createRefreshToken } from '../create-tokens'
 
 export interface ResetPasswordParams {
   token: string
@@ -21,29 +16,6 @@ const validateToken = async (token: string) => {
   const tokenRecord = await tokenRepo.findByToken(token)
 
   return TokenValidator.validate(tokenRecord, TokenType.PasswordReset)
-}
-
-const createAccessToken = async (user: User) => signJwt({
-  id: user.id,
-  email: user.email,
-  role: user.role,
-  status: user.status,
-})
-
-const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
-  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
-    TokenType.RefreshToken,
-  )
-
-  await refreshTokenRepo.create({
-    userId,
-    tokenHash: hashed,
-    ipAddress: deviceInfo.ipAddress,
-    userAgent: deviceInfo.userAgent,
-    expiresAt,
-  })
-
-  return raw
 }
 
 const resetPassword = async (

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -49,7 +49,7 @@ const resetPassword = async (
   ])
 
   return {
-    data: { user, team: team ?? null, accessToken },
+    data: { user, team, accessToken },
     refreshToken,
   }
 }

--- a/src/use-cases/auth/signup.ts
+++ b/src/use-cases/auth/signup.ts
@@ -1,15 +1,15 @@
-import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 import type { UserPreferences } from '@/types'
 
-import { authRepo, db, refreshTokenRepo, tokenRepo, userRepo } from '@/data'
+import { authRepo, db, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { logger } from '@/logging'
-import { signJwt } from '@/security/jwt'
 import { hashPassword } from '@/security/password'
-import { generateHashedToken, generateToken, TokenType } from '@/security/token'
+import { generateToken, TokenType } from '@/security/token'
 import { emailAgent } from '@/services'
 import { AuthProvider, Status } from '@/types'
+
+import { createAccessToken, createRefreshToken } from '../create-tokens'
 
 export interface SignupParams {
   firstName: string
@@ -54,31 +54,6 @@ const createNewUser = async (
   })
 
   return { newUser, verificationToken }
-}
-
-const createAccessToken = async (user: User) => signJwt(
-  {
-    id: user.id,
-    email: user.email,
-    role: user.role,
-    status: user.status,
-  },
-)
-
-const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
-  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
-    TokenType.RefreshToken,
-  )
-
-  await refreshTokenRepo.create({
-    userId,
-    tokenHash: hashed,
-    ipAddress: deviceInfo.ipAddress,
-    userAgent: deviceInfo.userAgent,
-    expiresAt,
-  })
-
-  return raw
 }
 
 const signUpWithEmail = async (

--- a/src/use-cases/auth/verify-email.ts
+++ b/src/use-cases/auth/verify-email.ts
@@ -1,10 +1,10 @@
-import type { User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { db, refreshTokenRepo, tokenRepo, userRepo } from '@/data'
-import { signJwt } from '@/security/jwt'
-import { generateHashedToken, TokenStatus, TokenType, TokenValidator } from '@/security/token'
+import { db, tokenRepo, userRepo } from '@/data'
+import { TokenStatus, TokenType, TokenValidator } from '@/security/token'
 import { Status } from '@/types'
+
+import { createAccessToken, createRefreshToken } from '../create-tokens'
 
 export interface VerifyEmailParams {
   token: string
@@ -14,31 +14,6 @@ const validateToken = async (token: string) => {
   const tokenRecord = await tokenRepo.findByToken(token)
 
   return TokenValidator.validate(tokenRecord, TokenType.EmailVerification)
-}
-
-const createAccessToken = async (user: User) => signJwt(
-  {
-    id: user.id,
-    email: user.email,
-    role: user.role,
-    status: user.status,
-  },
-)
-
-const createRefreshToken = async (userId: string, deviceInfo: DeviceInfo) => {
-  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
-    TokenType.RefreshToken,
-  )
-
-  await refreshTokenRepo.create({
-    userId,
-    tokenHash: hashed,
-    ipAddress: deviceInfo.ipAddress,
-    userAgent: deviceInfo.userAgent,
-    expiresAt,
-  })
-
-  return raw
 }
 
 const verifyEmail = async ({ token }: VerifyEmailParams, deviceInfo: DeviceInfo) => {

--- a/src/use-cases/create-tokens.ts
+++ b/src/use-cases/create-tokens.ts
@@ -1,0 +1,33 @@
+import type { Database, User } from '@/data'
+import type { DeviceInfo } from '@/net/http/device'
+
+import { refreshTokenRepo } from '@/data'
+import { signJwt } from '@/security/jwt'
+import { generateHashedToken, TokenType } from '@/security/token'
+
+export const createAccessToken = async (user: User) => signJwt({
+  id: user.id,
+  email: user.email,
+  role: user.role,
+  status: user.status,
+})
+
+export const createRefreshToken = async (
+  userId: string,
+  deviceInfo: DeviceInfo,
+  tx?: Database,
+) => {
+  const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
+    TokenType.RefreshToken,
+  )
+
+  await refreshTokenRepo.create({
+    userId,
+    tokenHash: hashed,
+    ipAddress: deviceInfo.ipAddress,
+    userAgent: deviceInfo.userAgent,
+    expiresAt,
+  }, tx)
+
+  return raw
+}

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -50,10 +50,10 @@ describe('User Me Use Cases', () => {
   })
 
   describe('getUser', () => {
-    it('should return user and team null when user has no team', async () => {
+    it('should return user and team undefined when user has no team', async () => {
       const result = await getUser(testUuids.USER_1)
 
-      expect(result).toEqual({ user: mockUser, team: null })
+      expect(result).toEqual({ user: mockUser, team: undefined })
       expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
       expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(testUuids.USER_1)
     })
@@ -88,7 +88,7 @@ describe('User Me Use Cases', () => {
 
       expect(result.user.firstName).toBe('Jane')
       expect(result.user.lastName).toBe('Smith')
-      expect(result.team).toBeNull()
+      expect(result.team).toBeUndefined()
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: 'Smith',
@@ -100,7 +100,7 @@ describe('User Me Use Cases', () => {
       const result = await updateUser(testUuids.USER_1, { firstName: 'Jane' })
 
       expect(result.user.firstName).toBe('Jane')
-      expect(result.team).toBeNull()
+      expect(result.team).toBeUndefined()
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         updatedAt: expect.any(Date),
@@ -111,7 +111,7 @@ describe('User Me Use Cases', () => {
       const result = await updateUser(testUuids.USER_1, { lastName: 'Smith' })
 
       expect(result.user.lastName).toBe('Smith')
-      expect(result.team).toBeNull()
+      expect(result.team).toBeUndefined()
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         lastName: 'Smith',
         updatedAt: expect.any(Date),
@@ -121,7 +121,7 @@ describe('User Me Use Cases', () => {
     it('should return current user and team when no valid updates provided', async () => {
       const result = await updateUser(testUuids.USER_1, {})
 
-      expect(result).toEqual({ user: mockUser, team: null })
+      expect(result).toEqual({ user: mockUser, team: undefined })
       expect(mockUserRepo.update).not.toHaveBeenCalled()
       expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
     })
@@ -132,7 +132,7 @@ describe('User Me Use Cases', () => {
 
       expect(result.user.firstName).toBe('Jane')
       expect(result.user.lastName).toBe('')
-      expect(result.team).toBeNull()
+      expect(result.team).toBeUndefined()
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         firstName: 'Jane',
         lastName: '',
@@ -145,7 +145,7 @@ describe('User Me Use Cases', () => {
       const result = await updateUser(testUuids.USER_1, { firstName: undefined, lastName: 'Smith' })
 
       expect(result.user.lastName).toBe('Smith')
-      expect(result.team).toBeNull()
+      expect(result.team).toBeUndefined()
       expect(mockUserRepo.update).toHaveBeenCalledWith(testUuids.USER_1, {
         lastName: 'Smith',
         updatedAt: expect.any(Date),

--- a/src/use-cases/user/me.ts
+++ b/src/use-cases/user/me.ts
@@ -21,7 +21,7 @@ export const getUser = async (userId: string) => {
     throw new AppError(ErrorCode.InternalError)
   }
 
-  return { user, team: team ?? null }
+  return { user, team }
 }
 
 export const updateUser = async (userId: string, updates: UpdateUserInput) => {
@@ -39,5 +39,5 @@ export const updateUser = async (userId: string, updates: UpdateUserInput) => {
     teamRepo.findUserTeam(userId),
   ])
 
-  return { user: updatedUser, team: team ?? null }
+  return { user: updatedUser, team }
 }


### PR DESCRIPTION
1. [Improvement]: Extract `createAccessToken` and `createRefreshToken` into `src/use-cases/create-tokens.ts`, eliminating duplication across 6 auth use-cases
2. [Improvement]: Unify `createRefreshToken` signature with optional `tx` parameter, replacing the transaction-specific variant in `refresh-token.ts`
3. [Fix]: Replace `team ?? null` with `team` across auth use-cases and `user/me.ts`, aligning return types with `undefined`
4. [Fix]: Update all affected tests to assert `undefined` instead of `null` for missing team data