### PR TITLE
Fix updateUser to return real role via findUserById

### DIFF
--- a/src/data/repositories/user/mutations.ts
+++ b/src/data/repositories/user/mutations.ts
@@ -8,6 +8,7 @@ import type { CreateUserInput, UpdateUserInput, User } from './types'
 
 import { db } from '../../clients'
 import { usersTable } from '../../schema'
+import { findUserById } from './queries'
 
 export const createUser = async (user: CreateUserInput, tx?: Database): Promise<User> => {
   const executor = tx || db
@@ -42,8 +43,14 @@ export const updateUser = async (
     throw new AppError(ErrorCode.InternalError, 'Failed to update user')
   }
 
-  // Role is not known here; callers that need it should re-query
-  return { ...updatedUser, role: Role.User }
+  // Since role lives in a separate table - call `userRepo.findById` to get the real role.
+  const userWithRole = await findUserById(userId, tx)
+
+  if (!userWithRole) {
+    throw new AppError(ErrorCode.InternalError, 'Failed to fetch user after update')
+  }
+
+  return userWithRole
 }
 
 export const deleteUser = async (email: string, tx?: Database): Promise<void> => {

--- a/src/use-cases/auth/__tests__/accept-invite.test.ts
+++ b/src/use-cases/auth/__tests__/accept-invite.test.ts
@@ -83,8 +83,7 @@ describe('Accept Invite', () => {
       update: mock(async () => {}),
     }
     mockUserRepo = {
-      findById: mock(async () => mockActivatedUser),
-      update: mock(async () => {}),
+      update: mock(async () => mockActivatedUser),
     }
     mockRefreshTokenRepo = {
       create: mock(async () => {}),
@@ -167,7 +166,6 @@ describe('Accept Invite', () => {
       }, {})
       expect(mockUserRepo.update).toHaveBeenCalledTimes(1)
 
-      expect(mockUserRepo.findById).toHaveBeenCalledWith(mockTokenRecord.userId)
       expect(mockSignJwt).toHaveBeenCalledTimes(1)
       expect(mockRefreshTokenRepo.create).toHaveBeenCalledTimes(1)
 

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -1,7 +1,6 @@
 import type { DeviceInfo } from '@/net/http/device'
 
 import { authRepo, db, teamRepo, tokenRepo, userRepo } from '@/data'
-import { AppError, ErrorCode } from '@/errors'
 import { hashPassword } from '@/security/password'
 import { TokenStatus, TokenType, TokenValidator } from '@/security/token'
 import Status from '@/types/status'
@@ -25,7 +24,7 @@ const acceptInvite = async (
 ) => {
   const validatedToken = await validateToken(token)
 
-  await db.transaction(async (tx) => {
+  const user = await db.transaction(async (tx) => {
     // Mark token as used
     await tokenRepo.update(validatedToken.id, {
       status: TokenStatus.Used,
@@ -37,14 +36,8 @@ const acceptInvite = async (
     await authRepo.update(validatedToken.userId, { passwordHash }, tx)
 
     // Activate user
-    await userRepo.update(validatedToken.userId, { status: Status.Active }, tx)
+    return userRepo.update(validatedToken.userId, { status: Status.Active }, tx)
   })
-
-  const user = await userRepo.findById(validatedToken.userId)
-
-  if (!user) {
-    throw new AppError(ErrorCode.InternalError, 'User not found after accepting invite')
-  }
 
   const [accessToken, refreshToken, team] = await Promise.all([
     createAccessToken(user),


### PR DESCRIPTION
1. [Fix]: `updateUser` always returned `role: Role.User` due to Drizzle ORM UPDATE...RETURNING not supporting JOINs
2. [Fix]: Internally call `findUserById` after update so callers always get the correct role
3. [Improvement]: Remove redundant `userRepo.findById` call in `accept-invite.ts` — `userRepo.update` now returns the full user
4. [Fix]: Update `accept-invite` test mock to reflect new `userRepo.update` return contract