### PR TITLE
Refactor findUserPermissions to return effective grants only

### DIFF
--- a/src/data/repositories/rbac/queries.ts
+++ b/src/data/repositories/rbac/queries.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, isNotNull, isNull, or } from 'drizzle-orm'
 
 import type { Action, Resource, Role } from '@/types'
 
@@ -7,11 +7,9 @@ import type { Database } from '../../clients'
 import { db } from '../../clients'
 import { permissionsTable, rolePermissionsTable, userPermissionsTable } from '../../schema'
 
-export interface PermissionRow {
+export interface ActivePermissionRow {
   action: Action
   resource: Resource
-  default: boolean
-  override: boolean | null // null = no user override, use role default
 }
 
 export interface RolePermissionRow {
@@ -35,19 +33,24 @@ export const findRolePermissions = async (
     .where(eq(rolePermissionsTable.role, role))
 }
 
+/**
+ * Returns all permissions effectively granted to a user given their role.
+ *
+ * A permission is included when:
+ * - The user has an explicit override (`granted = true`), or
+ * - No user override exists and the role has the permission by default
+ *
+ * Explicit revocations (`granted = false`) are excluded.
+ */
 export const findUserPermissions = async (
   userId: string,
   role: Role,
   tx?: Database,
-): Promise<PermissionRow[]> => {
-  const executor = tx || db
-
-  return executor
+): Promise<ActivePermissionRow[]> => {
+  return (tx || db)
     .select({
       action: permissionsTable.action,
       resource: permissionsTable.resource,
-      default: sql<boolean>`${rolePermissionsTable.id} IS NOT NULL`,
-      override: userPermissionsTable.granted,
     })
     .from(permissionsTable)
     .leftJoin(rolePermissionsTable, and(
@@ -58,4 +61,13 @@ export const findUserPermissions = async (
       eq(userPermissionsTable.permissionId, permissionsTable.id),
       eq(userPermissionsTable.userId, userId),
     ))
+    .where(
+      or(
+        eq(userPermissionsTable.granted, true),
+        and(
+          isNull(userPermissionsTable.granted),
+          isNotNull(rolePermissionsTable.id),
+        ),
+      ),
+    )
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,6 @@
 export { default as Action } from './action'
-
 export { default as AuthProvider } from './auth-providers'
-
+export { default as Permission } from './permission'
 export { default as Resource } from './resource'
 export { isAdmin, isOwner, isUser, isUserOrAdmin, default as Role } from './role'
 export { isActive, isActiveOnly, isNewOrActive, default as Status } from './status'

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -1,0 +1,10 @@
+enum Permission {
+  ViewUsers = 'view:users',
+  ViewAdmins = 'view:admins',
+  ViewTeams = 'view:teams',
+  ManageUsers = 'manage:users',
+  ManageAdmins = 'manage:admins',
+  ManageTeams = 'manage:teams',
+}
+
+export default Permission

--- a/src/use-cases/__tests__/resolve-permissions.test.ts
+++ b/src/use-cases/__tests__/resolve-permissions.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { ActivePermissionRow } from '@/data/repositories/rbac/queries'
+
+import { ModuleMocker, testUuids } from '@/__tests__'
+import { Action, Permission, Resource, Role } from '@/types'
+
+import { resolvePermissions } from '../resolve-permissions'
+
+describe('resolvePermissions', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockFindUserPermissions: any
+
+  beforeEach(async () => {
+    mockFindUserPermissions = mock(async (): Promise<ActivePermissionRow[]> => [])
+
+    await moduleMocker.mock('@/data', () => ({
+      rbacRepo: {
+        findUserPermissions: mockFindUserPermissions,
+      },
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should return empty array when user has no permissions', async () => {
+    const result = await resolvePermissions(testUuids.USER_1, Role.User)
+
+    expect(result).toEqual([])
+    expect(mockFindUserPermissions).toHaveBeenCalledWith(testUuids.USER_1, Role.User)
+  })
+
+  it('should map action:resource rows to typed Permission values', async () => {
+    mockFindUserPermissions.mockImplementation(async () => [
+      { action: Action.View, resource: Resource.Users },
+      { action: Action.Manage, resource: Resource.Teams },
+    ])
+
+    const result = await resolvePermissions(testUuids.ADMIN_1, Role.Admin)
+
+    expect(result).toEqual([Permission.ViewUsers, Permission.ManageTeams])
+  })
+
+  it('should pass userId and role to the repository', async () => {
+    await resolvePermissions(testUuids.ADMIN_1, Role.Admin)
+
+    expect(mockFindUserPermissions).toHaveBeenCalledWith(testUuids.ADMIN_1, Role.Admin)
+    expect(mockFindUserPermissions).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return all permissions when multiple rows are returned', async () => {
+    mockFindUserPermissions.mockImplementation(async () => [
+      { action: Action.View, resource: Resource.Users },
+      { action: Action.View, resource: Resource.Admins },
+      { action: Action.View, resource: Resource.Teams },
+      { action: Action.Manage, resource: Resource.Users },
+      { action: Action.Manage, resource: Resource.Admins },
+      { action: Action.Manage, resource: Resource.Teams },
+    ])
+
+    const result = await resolvePermissions(testUuids.USER_1, Role.Owner)
+
+    expect(result).toHaveLength(6)
+    expect(result).toContain(Permission.ViewUsers)
+    expect(result).toContain(Permission.ViewAdmins)
+    expect(result).toContain(Permission.ViewTeams)
+    expect(result).toContain(Permission.ManageUsers)
+    expect(result).toContain(Permission.ManageAdmins)
+    expect(result).toContain(Permission.ManageTeams)
+  })
+})

--- a/src/use-cases/resolve-permissions.ts
+++ b/src/use-cases/resolve-permissions.ts
@@ -1,0 +1,9 @@
+import type { Permission, Role } from '@/types'
+
+import { rbacRepo } from '@/data'
+
+export const resolvePermissions = async (userId: string, role: Role): Promise<Permission[]> => {
+  const rows = await rbacRepo.findUserPermissions(userId, role)
+
+  return rows.map(row => `${row.action}:${row.resource}` as Permission)
+}


### PR DESCRIPTION
1. [Improvement]: `findUserPermissions` now filters in SQL — returns only effective grants, not all rows
2. [Breaking]: Replace `PermissionRow` with `ActivePermissionRow`, removing `default` and `override` fields
3. [Feature]: Add `Permission` enum (`view:users`, `manage:teams`, etc.) as a typed alternative to raw strings
4. [Feature]: Add `resolvePermissions` use-case that maps DB rows to typed `Permission[]` values
5. [Feature]: Add unit tests for `resolvePermissions` covering empty results, mapping, and full permission sets