### PR TITLE
Extract validateStringToken into shared tokens module

### DIFF
--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -5,7 +5,7 @@ import { hashPassword } from '@/security/password'
 import { TokenStatus, TokenType } from '@/security/token'
 import Status from '@/types/status'
 
-import { createAccessToken, createRefreshToken, validateStringToken } from '../tokens'
+import { createAccessToken, createRefreshToken, validateOneTimeToken } from '../tokens'
 
 export interface AcceptInviteParams {
   token: string
@@ -16,7 +16,7 @@ const acceptInvite = async (
   { token, password }: AcceptInviteParams,
   deviceInfo: DeviceInfo,
 ) => {
-  const validatedToken = await validateStringToken(token, TokenType.UserInvite)
+  const validatedToken = await validateOneTimeToken(token, TokenType.UserInvite)
 
   const user = await db.transaction(async (tx) => {
     // Mark token as used

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -2,27 +2,21 @@ import type { DeviceInfo } from '@/net/http/device'
 
 import { authRepo, db, teamRepo, tokenRepo, userRepo } from '@/data'
 import { hashPassword } from '@/security/password'
-import { TokenStatus, TokenType, TokenValidator } from '@/security/token'
+import { TokenStatus, TokenType } from '@/security/token'
 import Status from '@/types/status'
 
-import { createAccessToken, createRefreshToken } from '../create-tokens'
+import { createAccessToken, createRefreshToken, validateStringToken } from '../tokens'
 
 export interface AcceptInviteParams {
   token: string
   password: string
 }
 
-const validateToken = async (token: string) => {
-  const tokenRecord = await tokenRepo.findByToken(token)
-
-  return TokenValidator.validate(tokenRecord, TokenType.UserInvite)
-}
-
 const acceptInvite = async (
   { token, password }: AcceptInviteParams,
   deviceInfo: DeviceInfo,
 ) => {
-  const validatedToken = await validateToken(token)
+  const validatedToken = await validateStringToken(token, TokenType.UserInvite)
 
   const user = await db.transaction(async (tx) => {
     // Mark token as used

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -4,7 +4,7 @@ import { authRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { comparePasswordHashes } from '@/security/password'
 
-import { createAccessToken, createRefreshToken } from '../create-tokens'
+import { createAccessToken, createRefreshToken } from '../tokens'
 
 export interface LoginParams {
   email: string

--- a/src/use-cases/auth/refresh-token.ts
+++ b/src/use-cases/auth/refresh-token.ts
@@ -5,7 +5,7 @@ import { AppError, ErrorCode } from '@/errors'
 import { logger } from '@/logging'
 import { hashToken } from '@/security/token'
 
-import { createAccessToken, createRefreshToken } from '../create-tokens'
+import { createAccessToken, createRefreshToken } from '../tokens'
 
 const validateToken = async (refreshToken: string | undefined) => {
   if (!refreshToken) {

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -5,7 +5,7 @@ import { AppError, ErrorCode } from '@/errors'
 import { hashPassword } from '@/security/password'
 import { TokenStatus, TokenType } from '@/security/token'
 
-import { createAccessToken, createRefreshToken, validateStringToken } from '../tokens'
+import { createAccessToken, createRefreshToken, validateOneTimeToken } from '../tokens'
 
 export interface ResetPasswordParams {
   token: string
@@ -16,7 +16,7 @@ const resetPassword = async (
   { token, password }: ResetPasswordParams,
   deviceInfo: DeviceInfo,
 ) => {
-  const validatedToken = await validateStringToken(token, TokenType.PasswordReset)
+  const validatedToken = await validateOneTimeToken(token, TokenType.PasswordReset)
 
   await db.transaction(async (tx) => {
     // Mark token as used

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -3,26 +3,20 @@ import type { DeviceInfo } from '@/net/http/device'
 import { authRepo, db, teamRepo, tokenRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { hashPassword } from '@/security/password'
-import { TokenStatus, TokenType, TokenValidator } from '@/security/token'
+import { TokenStatus, TokenType } from '@/security/token'
 
-import { createAccessToken, createRefreshToken } from '../create-tokens'
+import { createAccessToken, createRefreshToken, validateStringToken } from '../tokens'
 
 export interface ResetPasswordParams {
   token: string
   password: string
 }
 
-const validateToken = async (token: string) => {
-  const tokenRecord = await tokenRepo.findByToken(token)
-
-  return TokenValidator.validate(tokenRecord, TokenType.PasswordReset)
-}
-
 const resetPassword = async (
   { token, password }: ResetPasswordParams,
   deviceInfo: DeviceInfo,
 ) => {
-  const validatedToken = await validateToken(token)
+  const validatedToken = await validateStringToken(token, TokenType.PasswordReset)
 
   await db.transaction(async (tx) => {
     // Mark token as used

--- a/src/use-cases/auth/signup.ts
+++ b/src/use-cases/auth/signup.ts
@@ -9,7 +9,7 @@ import { generateToken, TokenType } from '@/security/token'
 import { emailAgent } from '@/services'
 import { AuthProvider, Status } from '@/types'
 
-import { createAccessToken, createRefreshToken } from '../create-tokens'
+import { createAccessToken, createRefreshToken } from '../tokens'
 
 export interface SignupParams {
   firstName: string

--- a/src/use-cases/auth/verify-email.ts
+++ b/src/use-cases/auth/verify-email.ts
@@ -1,23 +1,17 @@
 import type { DeviceInfo } from '@/net/http/device'
 
 import { db, tokenRepo, userRepo } from '@/data'
-import { TokenStatus, TokenType, TokenValidator } from '@/security/token'
+import { TokenStatus, TokenType } from '@/security/token'
 import { Status } from '@/types'
 
-import { createAccessToken, createRefreshToken } from '../create-tokens'
+import { createAccessToken, createRefreshToken, validateStringToken } from '../tokens'
 
 export interface VerifyEmailParams {
   token: string
 }
 
-const validateToken = async (token: string) => {
-  const tokenRecord = await tokenRepo.findByToken(token)
-
-  return TokenValidator.validate(tokenRecord, TokenType.EmailVerification)
-}
-
 const verifyEmail = async ({ token }: VerifyEmailParams, deviceInfo: DeviceInfo) => {
-  const validatedToken = await validateToken(token)
+  const validatedToken = await validateStringToken(token, TokenType.EmailVerification)
 
   const updatedUser = await db.transaction(async (tx) => {
     // Mark token as used

--- a/src/use-cases/auth/verify-email.ts
+++ b/src/use-cases/auth/verify-email.ts
@@ -4,14 +4,14 @@ import { db, tokenRepo, userRepo } from '@/data'
 import { TokenStatus, TokenType } from '@/security/token'
 import { Status } from '@/types'
 
-import { createAccessToken, createRefreshToken, validateStringToken } from '../tokens'
+import { createAccessToken, createRefreshToken, validateOneTimeToken } from '../tokens'
 
 export interface VerifyEmailParams {
   token: string
 }
 
 const verifyEmail = async ({ token }: VerifyEmailParams, deviceInfo: DeviceInfo) => {
-  const validatedToken = await validateStringToken(token, TokenType.EmailVerification)
+  const validatedToken = await validateOneTimeToken(token, TokenType.EmailVerification)
 
   const updatedUser = await db.transaction(async (tx) => {
     // Mark token as used

--- a/src/use-cases/tokens.ts
+++ b/src/use-cases/tokens.ts
@@ -1,9 +1,9 @@
 import type { Database, User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
 
-import { refreshTokenRepo } from '@/data'
+import { refreshTokenRepo, tokenRepo } from '@/data'
 import { signJwt } from '@/security/jwt'
-import { generateHashedToken, TokenType } from '@/security/token'
+import { generateHashedToken, TokenType, TokenValidator } from '@/security/token'
 
 export const createAccessToken = async (user: User) => signJwt({
   id: user.id,
@@ -30,4 +30,10 @@ export const createRefreshToken = async (
   }, tx)
 
   return raw
+}
+
+export const validateStringToken = async (token: string, type: TokenType) => {
+  const tokenRecord = await tokenRepo.findByToken(token)
+
+  return TokenValidator.validate(tokenRecord, type)
 }

--- a/src/use-cases/tokens.ts
+++ b/src/use-cases/tokens.ts
@@ -32,7 +32,7 @@ export const createRefreshToken = async (
   return raw
 }
 
-export const validateStringToken = async (token: string, type: TokenType) => {
+export const validateOneTimeToken = async (token: string, type: TokenType) => {
   const tokenRecord = await tokenRepo.findByToken(token)
 
   return TokenValidator.validate(tokenRecord, type)


### PR DESCRIPTION
1. [Improvement]: Rename \`create-tokens.ts\` to \`tokens.ts\` to reflect its broader responsibility
2. [Improvement]: Add \`validateOneTimeToken\` to eliminate duplicated token validation logic across 3 use-cases
3. [Improvement]: Remove private \`validateToken\` functions from \`verify-email\`, \`accept-invite\`, and \`reset-password\`
4. [Improvement]: Update all 6 consumers to import from the new \`tokens\` module