### PR TITLE
Add permissions to auth responses and JWT

### DIFF
--- a/src/data/scripts/seed.ts
+++ b/src/data/scripts/seed.ts
@@ -111,6 +111,13 @@ const seedDefaultAdminPermissions = async () => {
   })
 }
 
+const seedDefaultUserPermissions = async () => {
+  await assignPermissionsToRole({
+    role: Role.User,
+    resources: [Resource.Users, Resource.Teams],
+  })
+}
+
 const seedTeams = async () => {
   const teams = [
     {
@@ -307,6 +314,7 @@ const seed = async () => {
   await seedPermissions()
   await seedOwnerPermissions()
   await seedDefaultAdminPermissions()
+  await seedDefaultUserPermissions()
   await seedSystemUsers()
   const teamId = await seedTeams()
   await seedTestUsers(teamId)

--- a/src/security/jwt/claims/user.ts
+++ b/src/security/jwt/claims/user.ts
@@ -7,6 +7,7 @@ export const userClaimsSchema = z.object({
   email: z.email(),
   role: z.enum(Role),
   status: z.enum(Status),
+  permissions: z.array(z.string()).optional(),
 })
 
 export type UserClaims = z.infer<typeof userClaimsSchema>

--- a/src/use-cases/__tests__/resolve-permissions.test.ts
+++ b/src/use-cases/__tests__/resolve-permissions.test.ts
@@ -72,7 +72,7 @@ describe('resolvePermissions', () => {
     expect(result).toContain(Permission.ManageTeams)
   })
 
-  it('should strip Users and Teams permissions when hasTeam is false', async () => {
+  it('should strip Users and Teams permissions for Role.User without a team', async () => {
     mockFindUserPermissions.mockImplementation(async () => [
       { action: Action.View, resource: Resource.Users },
       { action: Action.View, resource: Resource.Admins },
@@ -82,7 +82,7 @@ describe('resolvePermissions', () => {
       { action: Action.Manage, resource: Resource.Teams },
     ])
 
-    const result = await resolvePermissions(testUuids.USER_1, Role.Owner, false)
+    const result = await resolvePermissions(testUuids.USER_1, Role.User, false)
 
     expect(result).toHaveLength(2)
     expect(result).toContain(Permission.ViewAdmins)
@@ -93,14 +93,25 @@ describe('resolvePermissions', () => {
     expect(result).not.toContain(Permission.ManageTeams)
   })
 
-  it('should return only Admins permissions when hasTeam is false', async () => {
+  it('should not strip Users and Teams permissions for Admin without a team', async () => {
     mockFindUserPermissions.mockImplementation(async () => [
-      { action: Action.View, resource: Resource.Admins },
+      { action: Action.View, resource: Resource.Users },
       { action: Action.Manage, resource: Resource.Teams },
     ])
 
     const result = await resolvePermissions(testUuids.ADMIN_1, Role.Admin, false)
 
-    expect(result).toEqual([Permission.ViewAdmins])
+    expect(result).toEqual([Permission.ViewUsers, Permission.ManageTeams])
+  })
+
+  it('should not strip Users and Teams permissions for Owner without a team', async () => {
+    mockFindUserPermissions.mockImplementation(async () => [
+      { action: Action.View, resource: Resource.Users },
+      { action: Action.Manage, resource: Resource.Teams },
+    ])
+
+    const result = await resolvePermissions(testUuids.USER_1, Role.Owner, false)
+
+    expect(result).toEqual([Permission.ViewUsers, Permission.ManageTeams])
   })
 })

--- a/src/use-cases/__tests__/resolve-permissions.test.ts
+++ b/src/use-cases/__tests__/resolve-permissions.test.ts
@@ -26,10 +26,10 @@ describe('resolvePermissions', () => {
     await moduleMocker.clear()
   })
 
-  it('should return empty array when user has no permissions', async () => {
-    const result = await resolvePermissions(testUuids.USER_1, Role.User)
+  it('should return undefined when user has no permissions', async () => {
+    const result = await resolvePermissions(testUuids.USER_1, Role.User, false)
 
-    expect(result).toEqual([])
+    expect(result).toBeUndefined()
     expect(mockFindUserPermissions).toHaveBeenCalledWith(testUuids.USER_1, Role.User)
   })
 
@@ -39,19 +39,19 @@ describe('resolvePermissions', () => {
       { action: Action.Manage, resource: Resource.Teams },
     ])
 
-    const result = await resolvePermissions(testUuids.ADMIN_1, Role.Admin)
+    const result = await resolvePermissions(testUuids.ADMIN_1, Role.Admin, true)
 
     expect(result).toEqual([Permission.ViewUsers, Permission.ManageTeams])
   })
 
   it('should pass userId and role to the repository', async () => {
-    await resolvePermissions(testUuids.ADMIN_1, Role.Admin)
+    await resolvePermissions(testUuids.ADMIN_1, Role.Admin, false)
 
     expect(mockFindUserPermissions).toHaveBeenCalledWith(testUuids.ADMIN_1, Role.Admin)
     expect(mockFindUserPermissions).toHaveBeenCalledTimes(1)
   })
 
-  it('should return all permissions when multiple rows are returned', async () => {
+  it('should return all permissions when multiple rows are returned and hasTeam is true', async () => {
     mockFindUserPermissions.mockImplementation(async () => [
       { action: Action.View, resource: Resource.Users },
       { action: Action.View, resource: Resource.Admins },
@@ -61,7 +61,7 @@ describe('resolvePermissions', () => {
       { action: Action.Manage, resource: Resource.Teams },
     ])
 
-    const result = await resolvePermissions(testUuids.USER_1, Role.Owner)
+    const result = await resolvePermissions(testUuids.USER_1, Role.Owner, true)
 
     expect(result).toHaveLength(6)
     expect(result).toContain(Permission.ViewUsers)
@@ -70,5 +70,37 @@ describe('resolvePermissions', () => {
     expect(result).toContain(Permission.ManageUsers)
     expect(result).toContain(Permission.ManageAdmins)
     expect(result).toContain(Permission.ManageTeams)
+  })
+
+  it('should strip Users and Teams permissions when hasTeam is false', async () => {
+    mockFindUserPermissions.mockImplementation(async () => [
+      { action: Action.View, resource: Resource.Users },
+      { action: Action.View, resource: Resource.Admins },
+      { action: Action.View, resource: Resource.Teams },
+      { action: Action.Manage, resource: Resource.Users },
+      { action: Action.Manage, resource: Resource.Admins },
+      { action: Action.Manage, resource: Resource.Teams },
+    ])
+
+    const result = await resolvePermissions(testUuids.USER_1, Role.Owner, false)
+
+    expect(result).toHaveLength(2)
+    expect(result).toContain(Permission.ViewAdmins)
+    expect(result).toContain(Permission.ManageAdmins)
+    expect(result).not.toContain(Permission.ViewUsers)
+    expect(result).not.toContain(Permission.ViewTeams)
+    expect(result).not.toContain(Permission.ManageUsers)
+    expect(result).not.toContain(Permission.ManageTeams)
+  })
+
+  it('should return only Admins permissions when hasTeam is false', async () => {
+    mockFindUserPermissions.mockImplementation(async () => [
+      { action: Action.View, resource: Resource.Admins },
+      { action: Action.Manage, resource: Resource.Teams },
+    ])
+
+    const result = await resolvePermissions(testUuids.ADMIN_1, Role.Admin, false)
+
+    expect(result).toEqual([Permission.ViewAdmins])
   })
 })

--- a/src/use-cases/auth/__tests__/accept-invite.test.ts
+++ b/src/use-cases/auth/__tests__/accept-invite.test.ts
@@ -38,6 +38,7 @@ describe('Accept Invite', () => {
   let mockAccessToken: string
   let mockRefreshToken: string
   let mockSignJwt: any
+  let mockResolvePermissions: any
 
   beforeEach(async () => {
     mockPassword = 'NewSecure@123'
@@ -129,6 +130,12 @@ describe('Accept Invite', () => {
     await moduleMocker.mock('@/security/jwt', () => ({
       signJwt: mockSignJwt,
     }))
+
+    mockResolvePermissions = mock(async () => undefined)
+
+    await moduleMocker.mock('../../resolve-permissions', () => ({
+      resolvePermissions: mockResolvePermissions,
+    }))
   })
 
   afterEach(async () => {
@@ -170,7 +177,12 @@ describe('Accept Invite', () => {
       expect(mockRefreshTokenRepo.create).toHaveBeenCalledTimes(1)
 
       expect(result).toEqual({
-        data: { user: mockActivatedUser, team: undefined, accessToken: mockAccessToken },
+        data: {
+          user: mockActivatedUser,
+          team: undefined,
+          permissions: undefined,
+          accessToken: mockAccessToken,
+        },
         refreshToken: mockRefreshToken,
       })
     })
@@ -387,12 +399,28 @@ describe('Accept Invite', () => {
       )
 
       expect(result).toEqual({
-        data: { user: mockActivatedUser, team: undefined, accessToken: mockAccessToken },
+        data: {
+          user: mockActivatedUser,
+          team: undefined,
+          permissions: undefined,
+          accessToken: mockAccessToken,
+        },
         refreshToken: mockRefreshToken,
       })
 
       expect(mockHashPassword).toHaveBeenCalledWith(longPassword)
       expect(mockHashPassword).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('permissions in response', () => {
+    it('should omit permissions from data when user has no permissions', async () => {
+      const result = await acceptInvite(
+        { token: mockTokenString, password: mockPassword },
+        mockDeviceInfo,
+      )
+
+      expect(result.data.permissions).toBeUndefined()
     })
   })
 })

--- a/src/use-cases/auth/__tests__/login.test.ts
+++ b/src/use-cases/auth/__tests__/login.test.ts
@@ -30,6 +30,7 @@ describe('Login with Email', () => {
   let mockCreateJwt: any
 
   let mockGenerateHashedToken: any
+  let mockResolvePermissions: any
 
   beforeEach(async () => {
     mockLoginParams = {
@@ -104,6 +105,12 @@ describe('Login with Email', () => {
       generateHashedToken: mockGenerateHashedToken,
       TokenType: { RefreshToken: 'refresh_token' },
     }))
+
+    mockResolvePermissions = mock(async () => undefined)
+
+    await moduleMocker.mock('../../resolve-permissions', () => ({
+      resolvePermissions: mockResolvePermissions,
+    }))
   })
 
   afterEach(async () => {
@@ -111,13 +118,14 @@ describe('Login with Email', () => {
   })
 
   describe('successful login', () => {
-    it('should return user, team, and token for valid credentials', async () => {
+    it('should return user, team, permissions, and token for valid credentials', async () => {
       const result = await logInWithEmail(mockLoginParams, mockDeviceInfo)
 
       expect(result).toHaveProperty('data')
       expect(result).toHaveProperty('refreshToken')
       expect(result.data.accessToken).toBe(mockJwtToken)
       expect(result.data.team).toBeUndefined()
+      expect(result.data.permissions).toBeUndefined()
       expect(result.refreshToken).toBe('refresh_token_123')
       expect(result.data.user).not.toHaveProperty('tokenVersion')
       expect(result.data.user.email).toBe(mockLoginParams.email)

--- a/src/use-cases/auth/__tests__/refresh-token.test.ts
+++ b/src/use-cases/auth/__tests__/refresh-token.test.ts
@@ -26,6 +26,7 @@ describe('Refresh Auth Tokens', () => {
   let mockSignJwt: any
 
   let mockLogger: any
+  let mockResolvePermissions: any
 
   beforeEach(async () => {
     mockRefreshToken = 'valid_refresh_token_123'
@@ -104,6 +105,12 @@ describe('Refresh Auth Tokens', () => {
     await moduleMocker.mock('@/logging', () => ({
       logger: mockLogger,
     }))
+
+    mockResolvePermissions = mock(async () => undefined)
+
+    await moduleMocker.mock('../../resolve-permissions', () => ({
+      resolvePermissions: mockResolvePermissions,
+    }))
   })
 
   afterEach(async () => {
@@ -111,12 +118,13 @@ describe('Refresh Auth Tokens', () => {
   })
 
   describe('successful token refresh', () => {
-    it('should return new access token and refresh token for valid refresh token', async () => {
+    it('should return new access token, refresh token, and permissions for valid refresh token', async () => {
       const result = await refreshAuthTokens(mockRefreshToken, mockDeviceInfo)
 
       expect(result).toHaveProperty('data')
       expect(result).toHaveProperty('refreshToken')
       expect(result.data.accessToken).toBe(mockJwtToken)
+      expect(result.data.permissions).toBeUndefined()
       expect(result.refreshToken).toBe('new_refresh_token_456')
       expect(result.data.user).toEqual(mockUser)
     })

--- a/src/use-cases/auth/__tests__/reset-password.test.ts
+++ b/src/use-cases/auth/__tests__/reset-password.test.ts
@@ -38,6 +38,7 @@ describe('Reset Password', () => {
   let mockAccessToken: string
   let mockRefreshToken: string
   let mockSignJwt: any
+  let mockResolvePermissions: any
 
   beforeEach(async () => {
     mockPassword = 'NewSecure@123'
@@ -125,6 +126,12 @@ describe('Reset Password', () => {
     await moduleMocker.mock('@/security/jwt', () => ({
       signJwt: mockSignJwt,
     }))
+
+    mockResolvePermissions = mock(async () => undefined)
+
+    await moduleMocker.mock('../../resolve-permissions', () => ({
+      resolvePermissions: mockResolvePermissions,
+    }))
   })
 
   afterEach(async () => {
@@ -162,7 +169,12 @@ describe('Reset Password', () => {
       expect(mockRefreshTokenRepo.create).toHaveBeenCalledTimes(1)
 
       expect(result).toEqual({
-        data: { user: mockUser, team: undefined, accessToken: mockAccessToken },
+        data: {
+          user: mockUser,
+          team: undefined,
+          permissions: undefined,
+          accessToken: mockAccessToken,
+        },
         refreshToken: mockRefreshToken,
       })
     })
@@ -366,12 +378,28 @@ describe('Reset Password', () => {
       )
 
       expect(result).toEqual({
-        data: { user: mockUser, team: undefined, accessToken: mockAccessToken },
+        data: {
+          user: mockUser,
+          team: undefined,
+          permissions: undefined,
+          accessToken: mockAccessToken,
+        },
         refreshToken: mockRefreshToken,
       })
 
       expect(mockHashPassword).toHaveBeenCalledWith(longPassword)
       expect(mockHashPassword).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('permissions in response', () => {
+    it('should omit permissions from data when user has no permissions', async () => {
+      const result = await resetPassword(
+        { token: mockTokenString, password: mockPassword },
+        mockDeviceInfo,
+      )
+
+      expect(result.data.permissions).toBeUndefined()
     })
   })
 })

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -6,7 +6,7 @@ import { TokenStatus, TokenType } from '@/security/token'
 import Status from '@/types/status'
 
 import { resolvePermissions } from '../resolve-permissions'
-import { createAccessToken, createRefreshToken, validateOneTimeToken } from '../tokens'
+import { createAuthTokens, validateOneTimeToken } from '../tokens'
 
 export interface AcceptInviteParams {
   token: string
@@ -35,12 +35,8 @@ const acceptInvite = async (
   })
 
   const team = await teamRepo.findUserTeam(user.id)
-
-  const [permissions, accessToken, refreshToken] = await Promise.all([
-    resolvePermissions(user.id, user.role, !!team),
-    createAccessToken(user),
-    createRefreshToken(user.id, deviceInfo),
-  ])
+  const permissions = await resolvePermissions(user.id, user.role, !!team)
+  const [accessToken, refreshToken] = await createAuthTokens(user, deviceInfo, permissions)
 
   return {
     data: { user, team, permissions, accessToken },

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -5,7 +5,8 @@ import { hashPassword } from '@/security/password'
 import { TokenStatus, TokenType } from '@/security/token'
 import Status from '@/types/status'
 
-import { createAuthTokens, validateOneTimeToken } from '../tokens'
+import { resolvePermissions } from '../resolve-permissions'
+import { createAccessToken, createRefreshToken, validateOneTimeToken } from '../tokens'
 
 export interface AcceptInviteParams {
   token: string
@@ -33,13 +34,16 @@ const acceptInvite = async (
     return userRepo.update(validatedToken.userId, { status: Status.Active }, tx)
   })
 
-  const [team, [accessToken, refreshToken]] = await Promise.all([
-    teamRepo.findUserTeam(user.id),
-    createAuthTokens(user, deviceInfo),
+  const team = await teamRepo.findUserTeam(user.id)
+
+  const [permissions, accessToken, refreshToken] = await Promise.all([
+    resolvePermissions(user.id, user.role, !!team),
+    createAccessToken(user),
+    createRefreshToken(user.id, deviceInfo),
   ])
 
   return {
-    data: { user, team, accessToken },
+    data: { user, team, permissions, accessToken },
     refreshToken,
   }
 }

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -5,7 +5,7 @@ import { AppError, ErrorCode } from '@/errors'
 import { comparePasswordHashes } from '@/security/password'
 
 import { resolvePermissions } from '../resolve-permissions'
-import { createAccessToken, createRefreshToken } from '../tokens'
+import { createAuthTokens } from '../tokens'
 
 export interface LoginParams {
   email: string
@@ -35,12 +35,8 @@ const logInWithEmail = async (
   }
 
   const team = await teamRepo.findUserTeam(user.id)
-
-  const [permissions, accessToken, refreshToken] = await Promise.all([
-    resolvePermissions(user.id, user.role, !!team),
-    createAccessToken(user),
-    createRefreshToken(user.id, deviceInfo),
-  ])
+  const permissions = await resolvePermissions(user.id, user.role, !!team)
+  const [accessToken, refreshToken] = await createAuthTokens(user, deviceInfo, permissions)
 
   return {
     data: { user, team, permissions, accessToken },

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -4,7 +4,8 @@ import { authRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { comparePasswordHashes } from '@/security/password'
 
-import { createAuthTokens } from '../tokens'
+import { resolvePermissions } from '../resolve-permissions'
+import { createAccessToken, createRefreshToken } from '../tokens'
 
 export interface LoginParams {
   email: string
@@ -33,13 +34,16 @@ const logInWithEmail = async (
     throw new AppError(ErrorCode.InvalidCredentials)
   }
 
-  const [team, [accessToken, refreshToken]] = await Promise.all([
-    teamRepo.findUserTeam(user.id),
-    createAuthTokens(user, deviceInfo),
+  const team = await teamRepo.findUserTeam(user.id)
+
+  const [permissions, accessToken, refreshToken] = await Promise.all([
+    resolvePermissions(user.id, user.role, !!team),
+    createAccessToken(user),
+    createRefreshToken(user.id, deviceInfo),
   ])
 
   return {
-    data: { user, team, accessToken },
+    data: { user, team, permissions, accessToken },
     refreshToken,
   }
 }

--- a/src/use-cases/auth/refresh-token.ts
+++ b/src/use-cases/auth/refresh-token.ts
@@ -6,7 +6,7 @@ import { logger } from '@/logging'
 import { hashToken } from '@/security/token'
 
 import { resolvePermissions } from '../resolve-permissions'
-import { createAuthTokens } from '../tokens'
+import { createAccessToken, createRefreshToken } from '../tokens'
 
 const validateToken = async (refreshToken: string | undefined) => {
   if (!refreshToken) {
@@ -67,15 +67,17 @@ const refreshAuthTokens = async (
 
   validateDevice(storedToken, deviceInfo, user.id)
 
-  const [permissions, { accessToken, newRefreshToken }] = await Promise.all([
-    resolvePermissions(user.id, user.role, !!team),
+  const permissions = await resolvePermissions(user.id, user.role, !!team)
+
+  const [accessToken, newRefreshToken] = await Promise.all([
+    createAccessToken(user, permissions),
     db.transaction(async (tx) => {
-      // Create new tokens first (OAuth 2.0 best practice)
-      const [accessToken, newRefreshToken] = await createAuthTokens(user, deviceInfo, tx)
+      // Create new refresh token first (OAuth 2.0 best practice)
+      const newRefreshToken = await createRefreshToken(user.id, deviceInfo, tx)
       // Revoke old token last to prevent user lockout on failures
       await refreshTokenRepo.revokeByHash(hashedToken, tx)
 
-      return { accessToken, newRefreshToken }
+      return newRefreshToken
     }),
   ])
 

--- a/src/use-cases/auth/refresh-token.ts
+++ b/src/use-cases/auth/refresh-token.ts
@@ -5,6 +5,7 @@ import { AppError, ErrorCode } from '@/errors'
 import { logger } from '@/logging'
 import { hashToken } from '@/security/token'
 
+import { resolvePermissions } from '../resolve-permissions'
 import { createAuthTokens } from '../tokens'
 
 const validateToken = async (refreshToken: string | undefined) => {
@@ -66,17 +67,20 @@ const refreshAuthTokens = async (
 
   validateDevice(storedToken, deviceInfo, user.id)
 
-  const { accessToken, newRefreshToken } = await db.transaction(async (tx) => {
-    // Create new tokens first (OAuth 2.0 best practice)
-    const [accessToken, newRefreshToken] = await createAuthTokens(user, deviceInfo, tx)
-    // Revoke old token last to prevent user lockout on failures
-    await refreshTokenRepo.revokeByHash(hashedToken, tx)
+  const [permissions, { accessToken, newRefreshToken }] = await Promise.all([
+    resolvePermissions(user.id, user.role, !!team),
+    db.transaction(async (tx) => {
+      // Create new tokens first (OAuth 2.0 best practice)
+      const [accessToken, newRefreshToken] = await createAuthTokens(user, deviceInfo, tx)
+      // Revoke old token last to prevent user lockout on failures
+      await refreshTokenRepo.revokeByHash(hashedToken, tx)
 
-    return { accessToken, newRefreshToken }
-  })
+      return { accessToken, newRefreshToken }
+    }),
+  ])
 
   return {
-    data: { user, team, accessToken },
+    data: { user, team, permissions, accessToken },
     refreshToken: newRefreshToken,
   }
 }

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -6,7 +6,7 @@ import { hashPassword } from '@/security/password'
 import { TokenStatus, TokenType } from '@/security/token'
 
 import { resolvePermissions } from '../resolve-permissions'
-import { createAccessToken, createRefreshToken, validateOneTimeToken } from '../tokens'
+import { createAuthTokens, validateOneTimeToken } from '../tokens'
 
 export interface ResetPasswordParams {
   token: string
@@ -38,12 +38,8 @@ const resetPassword = async (
   }
 
   const team = await teamRepo.findUserTeam(user.id)
-
-  const [permissions, accessToken, refreshToken] = await Promise.all([
-    resolvePermissions(user.id, user.role, !!team),
-    createAccessToken(user),
-    createRefreshToken(user.id, deviceInfo),
-  ])
+  const permissions = await resolvePermissions(user.id, user.role, !!team)
+  const [accessToken, refreshToken] = await createAuthTokens(user, deviceInfo, permissions)
 
   return {
     data: { user, team, permissions, accessToken },

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -5,7 +5,8 @@ import { AppError, ErrorCode } from '@/errors'
 import { hashPassword } from '@/security/password'
 import { TokenStatus, TokenType } from '@/security/token'
 
-import { createAuthTokens, validateOneTimeToken } from '../tokens'
+import { resolvePermissions } from '../resolve-permissions'
+import { createAccessToken, createRefreshToken, validateOneTimeToken } from '../tokens'
 
 export interface ResetPasswordParams {
   token: string
@@ -36,13 +37,16 @@ const resetPassword = async (
     throw new AppError(ErrorCode.InternalError, 'User not found after password reset')
   }
 
-  const [team, [accessToken, refreshToken]] = await Promise.all([
-    teamRepo.findUserTeam(user.id),
-    createAuthTokens(user, deviceInfo),
+  const team = await teamRepo.findUserTeam(user.id)
+
+  const [permissions, accessToken, refreshToken] = await Promise.all([
+    resolvePermissions(user.id, user.role, !!team),
+    createAccessToken(user),
+    createRefreshToken(user.id, deviceInfo),
   ])
 
   return {
-    data: { user, team, accessToken },
+    data: { user, team, permissions, accessToken },
     refreshToken,
   }
 }

--- a/src/use-cases/resolve-permissions.ts
+++ b/src/use-cases/resolve-permissions.ts
@@ -1,9 +1,18 @@
 import type { Permission, Role } from '@/types'
 
 import { rbacRepo } from '@/data'
+import Resource from '@/types/resource'
 
-export const resolvePermissions = async (userId: string, role: Role): Promise<Permission[]> => {
+export const resolvePermissions = async (
+  userId: string,
+  role: Role,
+  hasTeam: boolean,
+): Promise<Permission[] | undefined> => {
   const rows = await rbacRepo.findUserPermissions(userId, role)
 
-  return rows.map(row => `${row.action}:${row.resource}` as Permission)
+  const permissions = rows
+    .filter(row => hasTeam || (row.resource !== Resource.Users && row.resource !== Resource.Teams))
+    .map(row => `${row.action}:${row.resource}` as Permission)
+
+  return permissions.length > 0 ? permissions : undefined
 }

--- a/src/use-cases/resolve-permissions.ts
+++ b/src/use-cases/resolve-permissions.ts
@@ -2,6 +2,10 @@ import type { Permission, Role } from '@/types'
 
 import { rbacRepo } from '@/data'
 import Resource from '@/types/resource'
+import { isUser } from '@/types/role'
+
+const isTeamScoped = (resource: Resource) =>
+  resource === Resource.Users || resource === Resource.Teams
 
 export const resolvePermissions = async (
   userId: string,
@@ -10,8 +14,10 @@ export const resolvePermissions = async (
 ): Promise<Permission[] | undefined> => {
   const rows = await rbacRepo.findUserPermissions(userId, role)
 
+  const isUserWithoutTeam = isUser(role) && !hasTeam
+
   const permissions = rows
-    .filter(row => hasTeam || (row.resource !== Resource.Users && row.resource !== Resource.Teams))
+    .filter(row => isUserWithoutTeam ? !isTeamScoped(row.resource) : true)
     .map(row => `${row.action}:${row.resource}` as Permission)
 
   return permissions.length > 0 ? permissions : undefined

--- a/src/use-cases/tokens.ts
+++ b/src/use-cases/tokens.ts
@@ -1,15 +1,17 @@
 import type { Database, User } from '@/data'
 import type { DeviceInfo } from '@/net/http/device'
+import type { Permission } from '@/types'
 
 import { refreshTokenRepo, tokenRepo } from '@/data'
 import { signJwt } from '@/security/jwt'
 import { generateHashedToken, TokenType, TokenValidator } from '@/security/token'
 
-export const createAccessToken = async (user: User) => signJwt({
+export const createAccessToken = async (user: User, permissions?: Permission[]) => signJwt({
   id: user.id,
   email: user.email,
   role: user.role,
   status: user.status,
+  permissions,
 })
 
 export const createRefreshToken = async (
@@ -35,9 +37,10 @@ export const createRefreshToken = async (
 export const createAuthTokens = async (
   user: User,
   deviceInfo: DeviceInfo,
+  permissions?: Permission[],
   tx?: Database,
 ) => Promise.all([
-  createAccessToken(user),
+  createAccessToken(user, permissions),
   createRefreshToken(user.id, deviceInfo, tx),
 ])
 

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -15,6 +15,7 @@ describe('User Me Use Cases', () => {
   let mockUserRepo: any
   let mockTeamRepo: any
   let mockTeam: UserTeamInfo | undefined
+  let mockResolvePermissions: any
 
   beforeEach(async () => {
     mockUser = {
@@ -43,6 +44,12 @@ describe('User Me Use Cases', () => {
       userRepo: mockUserRepo,
       teamRepo: mockTeamRepo,
     }))
+
+    mockResolvePermissions = mock(async () => undefined)
+
+    await moduleMocker.mock('../../resolve-permissions', () => ({
+      resolvePermissions: mockResolvePermissions,
+    }))
   })
 
   afterEach(async () => {
@@ -50,15 +57,15 @@ describe('User Me Use Cases', () => {
   })
 
   describe('getUser', () => {
-    it('should return user and team undefined when user has no team', async () => {
+    it('should return user, team undefined, and permissions when user has no team', async () => {
       const result = await getUser(testUuids.USER_1)
 
-      expect(result).toEqual({ user: mockUser, team: undefined })
+      expect(result).toEqual({ user: mockUser, team: undefined, permissions: undefined })
       expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
       expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(testUuids.USER_1)
     })
 
-    it('should return user and team info when user belongs to a team', async () => {
+    it('should return user, team info, and permissions when user belongs to a team', async () => {
       mockTeam = {
         id: 'team-789',
         name: 'My Team',
@@ -68,7 +75,7 @@ describe('User Me Use Cases', () => {
 
       const result = await getUser(testUuids.USER_1)
 
-      expect(result).toEqual({ user: mockUser, team: mockTeam })
+      expect(result).toEqual({ user: mockUser, team: mockTeam, permissions: undefined })
       expect(mockTeamRepo.findUserTeam).toHaveBeenCalledWith(testUuids.USER_1)
     })
 
@@ -118,10 +125,10 @@ describe('User Me Use Cases', () => {
       })
     })
 
-    it('should return current user and team when no valid updates provided', async () => {
+    it('should return current user, team, and permissions when no valid updates provided', async () => {
       const result = await updateUser(testUuids.USER_1, {})
 
-      expect(result).toEqual({ user: mockUser, team: undefined })
+      expect(result).toEqual({ user: mockUser, team: undefined, permissions: undefined })
       expect(mockUserRepo.update).not.toHaveBeenCalled()
       expect(mockUserRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
     })

--- a/src/use-cases/user/me.ts
+++ b/src/use-cases/user/me.ts
@@ -3,6 +3,8 @@ import type { UpdateUserInput } from '@/data'
 import { teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 
+import { resolvePermissions } from '../resolve-permissions'
+
 const prepareValidUpdates = (updates: UpdateUserInput): UpdateUserInput => {
   return Object.fromEntries(
     Object.entries(updates).filter(([_, v]) => v !== undefined),
@@ -21,7 +23,9 @@ export const getUser = async (userId: string) => {
     throw new AppError(ErrorCode.InternalError)
   }
 
-  return { user, team }
+  const permissions = await resolvePermissions(userId, user.role, !!team)
+
+  return { user, team, permissions }
 }
 
 export const updateUser = async (userId: string, updates: UpdateUserInput) => {
@@ -39,5 +43,7 @@ export const updateUser = async (userId: string, updates: UpdateUserInput) => {
     teamRepo.findUserTeam(userId),
   ])
 
-  return { user, team }
+  const permissions = await resolvePermissions(userId, user.role, !!team)
+
+  return { user, team, permissions }
 }


### PR DESCRIPTION
1. [Feature]: Resolve and return user permissions in all auth responses (login, refresh, reset, invite)
2. [Feature]: Embed permissions array in JWT access token claims for stateless authorization
3. [Feature]: Add permissions to \`/user/me\` response for current user context
4. [Improvement]: Refactor auth token creation to sequential flow (team → permissions → tokens)
5. [Improvement]: Update \`createAuthTokens\` to accept optional permissions, keeping API consistent
6. [Feature]: Seed default permissions for \`Role.User\` in database seed script