### PR TITLE
Add default permissions endpoints for admins and members

### DIFF
--- a/postman.json
+++ b/postman.json
@@ -676,6 +676,26 @@
           "response": []
         },
         {
+          "name": "teams/:id/members/permissions",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{user_verified_only_api_url}}/teams/{{last_team_id}}/members/permissions",
+              "host": [
+                "{{user_verified_only_api_url}}"
+              ],
+              "path": [
+                "teams",
+                "{{last_team_id}}",
+                "members",
+                "permissions"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "teams/:id/members",
           "event": [
             {
@@ -867,6 +887,37 @@
               ],
               "path": [
                 "admins"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "admins/permissions",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{owner_api_url}}/admins/permissions",
+              "host": [
+                "{{owner_api_url}}"
+              ],
+              "path": [
+                "admins",
+                "permissions"
               ]
             }
           },

--- a/src/routes/owner/admins/__tests__/handler.test.ts
+++ b/src/routes/owner/admins/__tests__/handler.test.ts
@@ -4,9 +4,33 @@ import type { User } from '@/data'
 
 import { ModuleMocker, testUuids } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
-import { Role, Status } from '@/types'
+import { Resource, Role, Status } from '@/types'
 
-import { getAdminHandler, getAdminsHandler } from '../handler'
+import { getAdminDefaultPermissionsHandler, getAdminHandler, getAdminsHandler } from '../handler'
+
+describe('getAdminDefaultPermissionsHandler', () => {
+  let mockJson: ReturnType<typeof mock>
+  let mockContext: { json: typeof mockJson }
+
+  beforeEach(() => {
+    mockJson = mock((data: unknown, status: number) => ({ data, status }))
+    mockContext = { json: mockJson }
+  })
+
+  it('should return default admin permissions with OK status', () => {
+    getAdminDefaultPermissionsHandler(mockContext as any, async () => {})
+
+    expect(mockJson).toHaveBeenCalledWith(
+      {
+        permissions: {
+          [Resource.Users]: { view: true, manage: true },
+          [Resource.Teams]: { view: true, manage: true },
+        },
+      },
+      HttpStatus.OK,
+    )
+  })
+})
 
 describe('ownerGetAdminsHandler', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)

--- a/src/routes/owner/admins/handler.ts
+++ b/src/routes/owner/admins/handler.ts
@@ -1,7 +1,16 @@
+import type { Handler } from 'hono'
+
+import type { AppContext } from '@/context'
+
 import { HttpStatus } from '@/net/http'
+import { getAdminDefaultPermissions } from '@/types'
 import { cancelAdminInvite, getAdmin, getAdmins, inviteAdmin, resendAdminInvite } from '@/use-cases/owner'
 
 import type { CancelAdminInviteCtx, CreateAdminCtx, GetAdminCtx, GetAdminsCtx, ResendAdminInviteCtx } from './schema'
+
+export const getAdminDefaultPermissionsHandler: Handler<AppContext> = (c) => {
+  return c.json({ permissions: getAdminDefaultPermissions() }, HttpStatus.OK)
+}
 
 export const getAdminsHandler = async (c: GetAdminsCtx) => {
   const { search, statuses, page, limit } = c.req.valid('query')

--- a/src/routes/owner/admins/index.ts
+++ b/src/routes/owner/admins/index.ts
@@ -7,6 +7,7 @@ import { requestValidator } from '@/middleware'
 import {
   cancelAdminInviteHandler,
   createAdminHandler,
+  getAdminDefaultPermissionsHandler,
   getAdminHandler,
   getAdminsHandler,
   resendAdminInviteHandler,
@@ -31,6 +32,11 @@ ownerAdminsRoute.post(
   '/admins',
   requestValidator('json', createAdminBodySchema),
   createAdminHandler,
+)
+
+ownerAdminsRoute.get(
+  '/admins/permissions',
+  getAdminDefaultPermissionsHandler,
 )
 
 ownerAdminsRoute.get(

--- a/src/routes/user/teams/members/__tests__/handler.test.ts
+++ b/src/routes/user/teams/members/__tests__/handler.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import { HttpStatus } from '@/net/http'
+import { Resource } from '@/types'
+
+import { getMemberDefaultPermissionsHandler } from '../handler'
+
+describe('getMemberDefaultPermissionsHandler', () => {
+  let mockJson: ReturnType<typeof mock>
+  let mockContext: { json: typeof mockJson }
+
+  beforeEach(() => {
+    mockJson = mock((data: unknown, status: number) => ({ data, status }))
+    mockContext = { json: mockJson }
+  })
+
+  it('should return default member permissions with OK status', () => {
+    getMemberDefaultPermissionsHandler(mockContext as any, async () => {})
+
+    expect(mockJson).toHaveBeenCalledWith(
+      {
+        permissions: {
+          [Resource.Users]: { view: true, manage: false },
+          [Resource.Teams]: { view: true, manage: false },
+        },
+      },
+      HttpStatus.OK,
+    )
+  })
+})

--- a/src/routes/user/teams/members/handler.ts
+++ b/src/routes/user/teams/members/handler.ts
@@ -1,4 +1,9 @@
+import type { Handler } from 'hono'
+
+import type { AppContext } from '@/context'
+
 import { HttpStatus } from '@/net/http'
+import { getMemberDefaultPermissions } from '@/types'
 import {
   cancelMemberInvite,
   getTeamMember,
@@ -16,6 +21,10 @@ import type {
   TeamMembersParamsCtx,
   UpdateTeamMemberCtx,
 } from './schema'
+
+export const getMemberDefaultPermissionsHandler: Handler<AppContext> = (c) => {
+  return c.json({ permissions: getMemberDefaultPermissions() }, HttpStatus.OK)
+}
 
 export const getTeamMembersHandler = async (c: TeamMembersParamsCtx) => {
   const { teamId } = c.req.valid('param')

--- a/src/routes/user/teams/members/index.ts
+++ b/src/routes/user/teams/members/index.ts
@@ -7,6 +7,7 @@ import { requestValidator, teamAccessMiddleware } from '@/middleware'
 import {
   cancelMemberInviteHandler,
   createMemberHandler,
+  getMemberDefaultPermissionsHandler,
   getTeamMemberHandler,
   getTeamMembersHandler,
   resendMemberInviteHandler,
@@ -37,6 +38,11 @@ teamsMembersRoute.post(
   requestValidator('json', inviteMemberBodySchema),
   teamAccessMiddleware,
   createMemberHandler,
+)
+
+teamsMembersRoute.get(
+  '/permissions',
+  getMemberDefaultPermissionsHandler,
 )
 
 teamsMembersRoute.get(

--- a/src/routes/user/teams/members/index.ts
+++ b/src/routes/user/teams/members/index.ts
@@ -42,6 +42,8 @@ teamsMembersRoute.post(
 
 teamsMembersRoute.get(
   '/permissions',
+  requestValidator('param', teamMembersParamsSchema),
+  teamAccessMiddleware,
   getMemberDefaultPermissionsHandler,
 )
 

--- a/src/types/__tests__/permission.test.ts
+++ b/src/types/__tests__/permission.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test'
+
+import { getAdminDefaultPermissions, getMemberDefaultPermissions } from '../permission'
+import Resource from '../resource'
+
+describe('getAdminDefaultPermissions', () => {
+  it('should grant view and manage for users', () => {
+    const permissions = getAdminDefaultPermissions()
+
+    expect(permissions[Resource.Users]).toEqual({ view: true, manage: true })
+  })
+
+  it('should grant view and manage for teams', () => {
+    const permissions = getAdminDefaultPermissions()
+
+    expect(permissions[Resource.Teams]).toEqual({ view: true, manage: true })
+  })
+
+  it('should cover all expected resources', () => {
+    const permissions = getAdminDefaultPermissions()
+
+    expect(Object.keys(permissions)).toContain(Resource.Users)
+    expect(Object.keys(permissions)).toContain(Resource.Teams)
+  })
+})
+
+describe('getMemberDefaultPermissions', () => {
+  it('should grant view but not manage for users', () => {
+    const permissions = getMemberDefaultPermissions()
+
+    expect(permissions[Resource.Users]).toEqual({ view: true, manage: false })
+  })
+
+  it('should grant view but not manage for teams', () => {
+    const permissions = getMemberDefaultPermissions()
+
+    expect(permissions[Resource.Teams]).toEqual({ view: true, manage: false })
+  })
+
+  it('should cover all expected resources', () => {
+    const permissions = getMemberDefaultPermissions()
+
+    expect(Object.keys(permissions)).toContain(Resource.Users)
+    expect(Object.keys(permissions)).toContain(Resource.Teams)
+  })
+})

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 export { default as Action } from './action'
 export { default as AuthProvider } from './auth-providers'
-export { default as Permission } from './permission'
+export { getAdminDefaultPermissions, getMemberDefaultPermissions, default as Permission } from './permission'
 export { default as Resource } from './resource'
 export { isAdmin, isOwner, isUser, isUserOrAdmin, default as Role } from './role'
 export { isActive, isActiveOnly, isNewOrActive, default as Status } from './status'

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -1,3 +1,5 @@
+import Resource from './resource'
+
 enum Permission {
   ViewUsers = 'view:users',
   ViewAdmins = 'view:admins',
@@ -6,5 +8,15 @@ enum Permission {
   ManageAdmins = 'manage:admins',
   ManageTeams = 'manage:teams',
 }
+
+export const getAdminDefaultPermissions = () => ({
+  [Resource.Users]: { view: true, manage: true },
+  [Resource.Teams]: { view: true, manage: true },
+})
+
+export const getMemberDefaultPermissions = () => ({
+  [Resource.Users]: { view: true, manage: false },
+  [Resource.Teams]: { view: true, manage: false },
+})
 
 export default Permission


### PR DESCRIPTION
1. [Feature]: Add \`GET /owner/admins/permissions\` returning default allowed permissions for admins
2. [Feature]: Add \`GET /user/teams/:teamId/members/permissions\` returning default allowed permissions for team members
3. [Fix]: Validate \`teamId\` param and enforce \`teamAccessMiddleware\` on the members permissions endpoint
4. [Improvement]: Extract \`getAdminDefaultPermissions\` and \`getMemberDefaultPermissions\` into \`src/types/permission.ts\` as reusable functions
5. [Improvement]: Return resource-keyed permission object \`{ users: { view, manage }, teams: { view, manage } }\` instead of flat array, aligning with existing \`permissionsSchema\` shape
6. [Improvement]: Add unit tests for permission utility functions and both default permissions handlers