### PR TITLE
Move createTeam and getTeams to admin use cases

### DIFF
--- a/src/routes/admin/teams/__tests__/handler.test.ts
+++ b/src/routes/admin/teams/__tests__/handler.test.ts
@@ -53,7 +53,7 @@ describe('getTeamsHandler', () => {
       },
     }))
 
-    await moduleMocker.mock('@/use-cases/user', () => ({
+    await moduleMocker.mock('@/use-cases/admin', () => ({
       getTeams: mockGetTeams,
     }))
   })
@@ -145,7 +145,7 @@ describe('createTeamHandler', () => {
 
     mockCreateTeam = mock(async () => ({ team: mockTeam }))
 
-    await moduleMocker.mock('@/use-cases/user', () => ({
+    await moduleMocker.mock('@/use-cases/admin', () => ({
       createTeam: mockCreateTeam,
     }))
   })

--- a/src/routes/admin/teams/handler.ts
+++ b/src/routes/admin/teams/handler.ts
@@ -1,5 +1,5 @@
 import { HttpStatus } from '@/net/http'
-import { createTeam, getTeams } from '@/use-cases/user'
+import { createTeam, getTeams } from '@/use-cases/admin'
 
 import type { CreateTeamCtx, GetTeamsCtx } from './schema'
 

--- a/src/use-cases/admin/__tests__/teams.test.ts
+++ b/src/use-cases/admin/__tests__/teams.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { Team, TeamSearchResult } from '@/data'
+
+import { ModuleMocker, testUuids } from '@/__tests__'
+
+import { createTeam, getTeams } from '../teams'
+
+const { TEAM_1 } = testUuids
+
+describe('getTeams', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  const DEFAULT_PAGINATION = { page: 1, limit: 25 }
+
+  let mockSearchResult: TeamSearchResult
+  let mockTeamRepoSearch: any
+
+  beforeEach(async () => {
+    mockSearchResult = {
+      teams: [
+        {
+          id: TEAM_1,
+          name: 'Acme Corp',
+          website: 'https://acme.com',
+          description: 'A test team',
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+        },
+      ],
+      pagination: { page: 1, limit: 25, total: 1, totalPages: 1 },
+    }
+
+    mockTeamRepoSearch = mock(async () => mockSearchResult)
+
+    await moduleMocker.mock('@/data', () => ({
+      teamRepo: { search: mockTeamRepoSearch },
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should call teamRepo.search with correct params', async () => {
+    await getTeams({ search: 'acme' }, DEFAULT_PAGINATION)
+
+    expect(mockTeamRepoSearch).toHaveBeenCalledWith(
+      { search: 'acme' },
+      DEFAULT_PAGINATION,
+    )
+  })
+
+  it('should return teams and pagination', async () => {
+    const result = await getTeams({}, DEFAULT_PAGINATION)
+
+    expect(result).toEqual(mockSearchResult)
+  })
+})
+
+describe('createTeam', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockTeam: Team
+  let mockTeamRepoCreate: any
+
+  beforeEach(async () => {
+    mockTeam = {
+      id: TEAM_1,
+      name: 'New Team',
+      website: 'https://newteam.com',
+      description: 'A new team',
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-01'),
+    }
+
+    mockTeamRepoCreate = mock(async () => mockTeam)
+
+    await moduleMocker.mock('@/data', () => ({
+      teamRepo: {
+        create: mockTeamRepoCreate,
+      },
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should create team', async () => {
+    const params = { name: 'New Team', website: 'https://newteam.com' }
+
+    const result = await createTeam(params)
+
+    expect(mockTeamRepoCreate).toHaveBeenCalledWith(params)
+    expect(result).toEqual({ team: mockTeam })
+  })
+})

--- a/src/use-cases/admin/index.ts
+++ b/src/use-cases/admin/index.ts
@@ -1,1 +1,3 @@
+export { createTeam, getTeams } from './teams'
+
 export { getUser, searchUsers } from './users'

--- a/src/use-cases/admin/teams.ts
+++ b/src/use-cases/admin/teams.ts
@@ -1,0 +1,2 @@
+export { createTeam, getTeams } from '@/use-cases/user/teams'
+export type { CreateTeamParams } from '@/use-cases/user/teams'

--- a/src/use-cases/user/__tests__/teams.test.ts
+++ b/src/use-cases/user/__tests__/teams.test.ts
@@ -1,69 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-import type { Team, TeamSearchResult, TeamWithMemberCount } from '@/data'
+import type { Team, TeamWithMemberCount } from '@/data'
 
 import { ModuleMocker, testUuids } from '@/__tests__'
 import AppError from '@/errors/app-error'
 import ErrorCode from '@/errors/codes'
 
 import {
-  createTeam,
   getTeam,
-  getTeams,
   updateTeam,
 } from '../teams'
 
 const { TEAM_1 } = testUuids
-
-describe('getTeams', () => {
-  const moduleMocker = new ModuleMocker(import.meta.url)
-
-  const DEFAULT_PAGINATION = { page: 1, limit: 25 }
-
-  let mockSearchResult: TeamSearchResult
-  let mockTeamRepoSearch: any
-
-  beforeEach(async () => {
-    mockSearchResult = {
-      teams: [
-        {
-          id: TEAM_1,
-          name: 'Acme Corp',
-          website: 'https://acme.com',
-          description: 'A test team',
-          createdAt: new Date('2024-01-01'),
-          updatedAt: new Date('2024-01-01'),
-        },
-      ],
-      pagination: { page: 1, limit: 25, total: 1, totalPages: 1 },
-    }
-
-    mockTeamRepoSearch = mock(async () => mockSearchResult)
-
-    await moduleMocker.mock('@/data', () => ({
-      teamRepo: { search: mockTeamRepoSearch },
-    }))
-  })
-
-  afterEach(async () => {
-    await moduleMocker.clear()
-  })
-
-  it('should call teamRepo.search with correct params', async () => {
-    await getTeams({ search: 'acme' }, DEFAULT_PAGINATION)
-
-    expect(mockTeamRepoSearch).toHaveBeenCalledWith(
-      { search: 'acme' },
-      DEFAULT_PAGINATION,
-    )
-  })
-
-  it('should return teams and pagination', async () => {
-    const result = await getTeams({}, DEFAULT_PAGINATION)
-
-    expect(result).toEqual(mockSearchResult)
-  })
-})
 
 describe('getTeam', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
@@ -113,45 +61,6 @@ describe('getTeam', () => {
       code: ErrorCode.NotFound,
       message: 'Team not found',
     })
-  })
-})
-
-describe('createTeam', () => {
-  const moduleMocker = new ModuleMocker(import.meta.url)
-
-  let mockTeam: Team
-  let mockTeamRepoCreate: any
-
-  beforeEach(async () => {
-    mockTeam = {
-      id: TEAM_1,
-      name: 'New Team',
-      website: 'https://newteam.com',
-      description: 'A new team',
-      createdAt: new Date('2024-01-01'),
-      updatedAt: new Date('2024-01-01'),
-    }
-
-    mockTeamRepoCreate = mock(async () => mockTeam)
-
-    await moduleMocker.mock('@/data', () => ({
-      teamRepo: {
-        create: mockTeamRepoCreate,
-      },
-    }))
-  })
-
-  afterEach(async () => {
-    await moduleMocker.clear()
-  })
-
-  it('should create team', async () => {
-    const params = { name: 'New Team', website: 'https://newteam.com' }
-
-    const result = await createTeam(params)
-
-    expect(mockTeamRepoCreate).toHaveBeenCalledWith(params)
-    expect(result).toEqual({ team: mockTeam })
   })
 })
 

--- a/src/use-cases/user/index.ts
+++ b/src/use-cases/user/index.ts
@@ -5,8 +5,6 @@ export { getUser, updateUser } from './me'
 export { getTeamMember, getTeamMembers, updateTeamMember } from './members'
 
 export {
-  createTeam,
   getTeam,
-  getTeams,
   updateTeam,
 } from './teams'


### PR DESCRIPTION
1. [Improvement]: Relocate \`createTeam\` and \`getTeams\` from user to admin use-case layer
2. [Improvement]: Add \`src/use-cases/admin/teams.ts\` re-exporting from user domain module
3. [Improvement]: Update admin route handler import to source from \`@/use-cases/admin\`
4. [Improvement]: Move \`getTeams\` and \`createTeam\` unit tests to admin use-case test suite