### PR TITLE
Add PATCH /admins/:adminId endpoint

### DIFF
--- a/src/routes/owner/admins/__tests__/handler.test.ts
+++ b/src/routes/owner/admins/__tests__/handler.test.ts
@@ -6,7 +6,7 @@ import { ModuleMocker, testUuids } from '@/__tests__'
 import { HttpStatus } from '@/net/http'
 import { Resource, Role, Status } from '@/types'
 
-import { getAdminDefaultPermissionsHandler, getAdminHandler, getAdminsHandler } from '../handler'
+import { getAdminDefaultPermissionsHandler, getAdminHandler, getAdminsHandler, updateAdminHandler } from '../handler'
 
 describe('getAdminDefaultPermissionsHandler', () => {
   let mockJson: ReturnType<typeof mock>
@@ -185,5 +185,77 @@ describe('ownerGetAdminHandler', () => {
     })
 
     expect(getAdminHandler(mockContext)).rejects.toThrow('Admin not found')
+  })
+})
+
+describe('ownerUpdateAdminHandler', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockContext: any
+  let mockJson: any
+
+  let mockAdmin: User
+  let mockUpdateAdmin: any
+
+  beforeEach(async () => {
+    mockAdmin = {
+      id: testUuids.ADMIN_1,
+      firstName: 'Updated',
+      lastName: 'Name',
+      email: 'admin@example.com',
+      role: Role.Admin,
+      status: Status.Active,
+      createdAt: new Date('2024-01-01'),
+      updatedAt: new Date('2024-01-02'),
+    }
+
+    mockJson = mock((data: any, status: number) => ({ data, status }))
+
+    mockContext = {
+      req: {
+        valid: mock((type: string) => {
+          if (type === 'param') {
+            return { adminId: testUuids.ADMIN_1 }
+          }
+
+          return { firstName: 'Updated', lastName: 'Name' }
+        }),
+      },
+      json: mockJson,
+    }
+
+    mockUpdateAdmin = mock(async () => ({ admin: mockAdmin }))
+
+    await moduleMocker.mock('@/use-cases/owner', () => ({
+      updateAdmin: mockUpdateAdmin,
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should call updateAdmin with correct params and body', async () => {
+    await updateAdminHandler(mockContext)
+
+    expect(mockUpdateAdmin).toHaveBeenCalledWith(
+      testUuids.ADMIN_1,
+      { firstName: 'Updated', lastName: 'Name' },
+    )
+  })
+
+  it('should return updated admin with OK status', async () => {
+    const result = await updateAdminHandler(mockContext)
+
+    expect(mockJson).toHaveBeenCalledWith({ admin: mockAdmin }, HttpStatus.OK)
+    expect(result.status).toBe(HttpStatus.OK)
+  })
+
+  it('should propagate error when updateAdmin throws', async () => {
+    mockUpdateAdmin.mockImplementation(async () => {
+      throw new Error('Admin not found')
+    })
+
+    expect(updateAdminHandler(mockContext)).rejects.toThrow('Admin not found')
   })
 })

--- a/src/routes/owner/admins/handler.ts
+++ b/src/routes/owner/admins/handler.ts
@@ -4,13 +4,23 @@ import type { AppContext } from '@/context'
 
 import { HttpStatus } from '@/net/http'
 import { getAdminDefaultPermissions } from '@/types'
-import { cancelAdminInvite, getAdmin, getAdmins, inviteAdmin, resendAdminInvite } from '@/use-cases/owner'
+import {
+  cancelAdminInvite,
+  getAdmin,
+  getAdmins,
+  inviteAdmin,
+  resendAdminInvite,
+  updateAdmin,
+} from '@/use-cases/owner'
 
-import type { CancelAdminInviteCtx, CreateAdminCtx, GetAdminCtx, GetAdminsCtx, ResendAdminInviteCtx } from './schema'
-
-export const getAdminDefaultPermissionsHandler: Handler<AppContext> = (c) => {
-  return c.json({ permissions: getAdminDefaultPermissions() }, HttpStatus.OK)
-}
+import type {
+  CancelAdminInviteCtx,
+  CreateAdminCtx,
+  GetAdminCtx,
+  GetAdminsCtx,
+  ResendAdminInviteCtx,
+  UpdateAdminCtx,
+} from './schema'
 
 export const getAdminsHandler = async (c: GetAdminsCtx) => {
   const { search, statuses, page, limit } = c.req.valid('query')
@@ -31,10 +41,23 @@ export const createAdminHandler = async (c: CreateAdminCtx) => {
   return c.json(result, HttpStatus.CREATED)
 }
 
+export const getAdminDefaultPermissionsHandler: Handler<AppContext> = (c) => {
+  return c.json({ permissions: getAdminDefaultPermissions() }, HttpStatus.OK)
+}
+
 export const getAdminHandler = async (c: GetAdminCtx) => {
   const { adminId } = c.req.valid('param')
 
   const result = await getAdmin(adminId)
+
+  return c.json(result, HttpStatus.OK)
+}
+
+export const updateAdminHandler = async (c: UpdateAdminCtx) => {
+  const { adminId } = c.req.valid('param')
+  const body = c.req.valid('json')
+
+  const result = await updateAdmin(adminId, body)
 
   return c.json(result, HttpStatus.OK)
 }

--- a/src/routes/owner/admins/index.ts
+++ b/src/routes/owner/admins/index.ts
@@ -11,6 +11,7 @@ import {
   getAdminHandler,
   getAdminsHandler,
   resendAdminInviteHandler,
+  updateAdminHandler,
 } from './handler'
 import {
   cancelAdminInviteParamsSchema,
@@ -18,6 +19,8 @@ import {
   getAdminParamsSchema,
   getAdminsQuerySchema,
   resendAdminInviteParamsSchema,
+  updateAdminBodySchema,
+  updateAdminParamsSchema,
 } from './schema'
 
 const ownerAdminsRoute = new Hono<AppContext>()
@@ -43,6 +46,13 @@ ownerAdminsRoute.get(
   '/admins/:adminId',
   requestValidator('param', getAdminParamsSchema),
   getAdminHandler,
+)
+
+ownerAdminsRoute.patch(
+  '/admins/:adminId',
+  requestValidator('param', updateAdminParamsSchema),
+  requestValidator('json', updateAdminBodySchema),
+  updateAdminHandler,
 )
 
 ownerAdminsRoute.post(

--- a/src/routes/owner/admins/schema.ts
+++ b/src/routes/owner/admins/schema.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod'
 
-import type { ValidatedJsonCtx, ValidatedParamCtx, ValidatedQueryCtx } from '../../@shared'
+import { Status } from '@/types'
+
+import type { ValidatedJsonCtx, ValidatedParamCtx, ValidatedParamJsonCtx, ValidatedQueryCtx } from '../../@shared'
 
 import { requestValidationRules as rules } from '../../@shared'
 import { permissionsSchema } from '../../@shared/permissions-schema'
@@ -44,3 +46,17 @@ export const cancelAdminInviteParamsSchema = z.object({
 
 export type CancelAdminInviteParams = z.infer<typeof cancelAdminInviteParamsSchema>
 export type CancelAdminInviteCtx = ValidatedParamCtx<CancelAdminInviteParams>
+
+export const updateAdminParamsSchema = z.object({
+  adminId: rules.data.id,
+})
+
+export const updateAdminBodySchema = z.object({
+  firstName: rules.data.firstName.optional(),
+  lastName: rules.data.lastName.optional(),
+  status: z.enum(Status).optional(),
+}).strict()
+
+export type UpdateAdminParams = z.infer<typeof updateAdminParamsSchema>
+export type UpdateAdminBody = z.infer<typeof updateAdminBodySchema>
+export type UpdateAdminCtx = ValidatedParamJsonCtx<UpdateAdminParams, UpdateAdminBody>

--- a/src/routes/owner/admins/schema.ts
+++ b/src/routes/owner/admins/schema.ts
@@ -37,6 +37,16 @@ export const resendAdminInviteParamsSchema = z.object({
   adminId: rules.data.id,
 })
 
+export const updateAdminBodySchema = z.object({
+  firstName: rules.data.firstName.optional(),
+  lastName: rules.data.lastName.optional(),
+  status: z.enum(Status).optional(),
+}).strict()
+
+export type UpdateAdminParams = z.infer<typeof updateAdminParamsSchema>
+export type UpdateAdminBody = z.infer<typeof updateAdminBodySchema>
+export type UpdateAdminCtx = ValidatedParamJsonCtx<UpdateAdminParams, UpdateAdminBody>
+
 export type ResendAdminInviteParams = z.infer<typeof resendAdminInviteParamsSchema>
 export type ResendAdminInviteCtx = ValidatedParamCtx<ResendAdminInviteParams>
 
@@ -50,13 +60,3 @@ export type CancelAdminInviteCtx = ValidatedParamCtx<CancelAdminInviteParams>
 export const updateAdminParamsSchema = z.object({
   adminId: rules.data.id,
 })
-
-export const updateAdminBodySchema = z.object({
-  firstName: rules.data.firstName.optional(),
-  lastName: rules.data.lastName.optional(),
-  status: z.enum(Status).optional(),
-}).strict()
-
-export type UpdateAdminParams = z.infer<typeof updateAdminParamsSchema>
-export type UpdateAdminBody = z.infer<typeof updateAdminBodySchema>
-export type UpdateAdminCtx = ValidatedParamJsonCtx<UpdateAdminParams, UpdateAdminBody>

--- a/src/use-cases/owner/admins.ts
+++ b/src/use-cases/owner/admins.ts
@@ -31,23 +31,6 @@ export const getAdmins = async (params: SearchParams, pagination: PaginationPara
   }
 }
 
-export const getAdmin = async (adminId: string) => {
-  const admin = await userRepo.findById(adminId)
-
-  if (!admin || admin.role !== Role.Admin) {
-    throw new AppError(ErrorCode.NotFound, 'Admin not found')
-  }
-
-  const inviters = await rbacRepo.findInviters([adminId])
-
-  return {
-    admin: {
-      ...admin,
-      inviter: inviters.get(adminId),
-    },
-  }
-}
-
 export interface AdminInvitationParams {
   firstName: string
   lastName?: string
@@ -118,6 +101,41 @@ export const inviteAdmin = async (params: AdminInvitationParams, inviterId: stri
   )
 
   return { admin }
+}
+
+export const getAdmin = async (adminId: string) => {
+  const admin = await userRepo.findById(adminId)
+
+  if (!admin || admin.role !== Role.Admin) {
+    throw new AppError(ErrorCode.NotFound, 'Admin not found')
+  }
+
+  const inviters = await rbacRepo.findInviters([adminId])
+
+  return {
+    admin: {
+      ...admin,
+      inviter: inviters.get(adminId),
+    },
+  }
+}
+
+export interface UpdateAdminParams {
+  firstName?: string
+  lastName?: string
+  status?: Status
+}
+
+export const updateAdmin = async (adminId: string, params: UpdateAdminParams) => {
+  const admin = await userRepo.findById(adminId)
+
+  if (!admin || admin.role !== Role.Admin) {
+    throw new AppError(ErrorCode.NotFound, 'Admin not found')
+  }
+
+  const updatedAdmin = await userRepo.update(adminId, params)
+
+  return { admin: updatedAdmin }
 }
 
 export const resendAdminInvite = async (adminId: string, inviterId: string) => {

--- a/src/use-cases/owner/index.ts
+++ b/src/use-cases/owner/index.ts
@@ -1,1 +1,8 @@
-export { cancelAdminInvite, getAdmin, getAdmins, inviteAdmin, resendAdminInvite } from './admins'
+export {
+  cancelAdminInvite,
+  getAdmin,
+  getAdmins,
+  inviteAdmin,
+  resendAdminInvite,
+  updateAdmin,
+} from './admins'


### PR DESCRIPTION
[Feature]: Add \`PATCH /admins/:adminId\` route allowing the owner to update an admin's \`firstName\`, \`lastName\`, and \`status\`
[Feature]: Add \`updateAdmin\` use case with role guard — returns 404 if target user is not an Admin
[Improvement]: Reorder use case functions in \`admins.ts\` to follow the natural lifecycle: \`getAdmins → inviteAdmin → getAdmin → updateAdmin → resendAdminInvite → cancelAdminInvite\`
[Feature]: Add handler tests for \`updateAdminHandler\` covering correct param forwarding, OK response, and error propagation