### PR TITLE
Use COALESCE for default user role in SQL query

### DIFF
--- a/src/data/repositories/user/queries.ts
+++ b/src/data/repositories/user/queries.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray, sql } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, isNull, sql } from 'drizzle-orm'
 
 import { Role } from '@/types'
 
@@ -42,8 +42,28 @@ export const findUserById = async (userId: string, tx?: Database) =>
 export const findUserByEmail = async (email: string, tx?: Database) =>
   findUserBy(eq(usersTable.email, email), tx)
 
-const buildWhereConditions = ({ search, statuses }: SearchParams) => {
+const buildRoleCondition = (roles: Role[]) => {
+  if (roles.length === 0) {
+    return undefined
+  }
+
+  // "User" is the default role — users without a row in user_roles
+  // are regular users, so we match them via NULL.
+  if (roles.includes(Role.User)) {
+    return isNull(userRolesTable.userId)
+  }
+
+  // Elevated roles (Admin, Owner) have explicit rows and are matched with inArray
+  return inArray(userRolesTable.role, roles)
+}
+
+const buildWhereConditions = ({ search, roles, statuses }: SearchParams) => {
   const conditions = []
+
+  const roleCondition = buildRoleCondition(roles)
+  if (roleCondition) {
+    conditions.push(roleCondition)
+  }
 
   if (statuses && statuses.length > 0) {
     conditions.push(inArray(usersTable.status, statuses))

--- a/src/data/repositories/user/queries.ts
+++ b/src/data/repositories/user/queries.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray, isNull, sql } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, sql } from 'drizzle-orm'
 
 import { Role } from '@/types'
 
@@ -20,15 +20,10 @@ const selectUserWithRole = (executor: Database) =>
       status: usersTable.status,
       createdAt: usersTable.createdAt,
       updatedAt: usersTable.updatedAt,
-      role: userRolesTable.role,
+      role: sql<Role>`COALESCE(${userRolesTable.role}, ${Role.User})`,
     })
     .from(usersTable)
     .leftJoin(userRolesTable, eq(usersTable.id, userRolesTable.userId))
-
-const toUser = (row: { role: string | null } & Record<string, unknown>): User => ({
-  ...row,
-  role: row.role ?? Role.User,
-}) as User
 
 const findUserBy = async (
   condition: ReturnType<typeof eq>,
@@ -36,10 +31,9 @@ const findUserBy = async (
 ): Promise<User | undefined> => {
   const executor = tx || db
 
-  const [row] = await selectUserWithRole(executor)
-    .where(condition)
+  const [row] = await selectUserWithRole(executor).where(condition)
 
-  return row ? toUser(row) : undefined
+  return row
 }
 
 export const findUserById = async (userId: string, tx?: Database) =>
@@ -48,20 +42,21 @@ export const findUserById = async (userId: string, tx?: Database) =>
 export const findUserByEmail = async (email: string, tx?: Database) =>
   findUserBy(eq(usersTable.email, email), tx)
 
-const buildRoleCondition = (roles: Role[]) => {
-  if (roles.length === 0) {
-    return undefined
+const buildWhereConditions = ({ search, statuses }: SearchParams) => {
+  const conditions = []
+
+  if (statuses && statuses.length > 0) {
+    conditions.push(inArray(usersTable.status, statuses))
   }
 
-  // "User" is the default role — users without a row in user_roles are regular
-  // users, so we match them via NULL.
-  if (roles.includes(Role.User)) {
-    return isNull(userRolesTable.userId)
+  if (search && search.length > 0) {
+    // Use concatenated expression to leverage GIN index (idx_users_search_trgm)
+    conditions.push(
+      sql`(id::text || ' ' || first_name || ' ' || COALESCE(last_name, '') || ' ' || email) ILIKE ${`%${search}%`}`,
+    )
   }
 
-  // Elevated roles (Admin, Owner) have
-  // explicit rows and are matched with inArray
-  return inArray(userRolesTable.role, roles)
+  return conditions.length > 0 ? and(...conditions) : undefined
 }
 
 export const search = async (
@@ -70,33 +65,8 @@ export const search = async (
   tx?: Database,
 ): Promise<SearchResult> => {
   const executor = tx || db
-  const { search, roles, statuses } = filters
   const { page, limit } = pagination
   const offset = calcOffset(pagination)
-
-  const buildWhereConditions = () => {
-    const conditions = []
-
-    const roleCondition = buildRoleCondition(roles)
-    if (roleCondition) {
-      conditions.push(roleCondition)
-    }
-
-    if (statuses && statuses.length > 0) {
-      conditions.push(inArray(usersTable.status, statuses))
-    }
-
-    if (search && search.length > 0) {
-      // Use concatenated expression to leverage GIN index (idx_users_search_trgm)
-      conditions.push(
-        sql`(id::text || ' ' || first_name || ' ' || COALESCE(last_name, '') || ' ' || email) ILIKE ${`%${search}%`}`,
-      )
-    }
-
-    return conditions.length > 0 ? and(...conditions) : undefined
-  }
-
-  const whereClause = buildWhereConditions()
 
   const searchQuery = selectUserWithRole(executor)
 
@@ -104,6 +74,8 @@ export const search = async (
     .select({ value: count() })
     .from(usersTable)
     .leftJoin(userRolesTable, eq(usersTable.id, userRolesTable.userId))
+
+  const whereClause = buildWhereConditions(filters)
 
   const [rows, countResult] = await Promise.all([
     searchQuery
@@ -118,7 +90,7 @@ export const search = async (
   const totalCount = countResult[0]?.value ?? 0
 
   return {
-    users: rows.map(toUser),
+    users: rows,
     pagination: {
       page,
       limit,

--- a/src/data/repositories/user/types.ts
+++ b/src/data/repositories/user/types.ts
@@ -13,7 +13,6 @@ export type UpdateUserInput = Partial<CreateUserInput>
 // Public-facing / API-return type
 export type User = UserRecord & {
   role: Role
-  status: Status
 }
 
 export interface SearchParams {


### PR DESCRIPTION
[Improvement]: Replace JS-level \`toUser\` transform with SQL \`COALESCE\` to default null role to \`User\` at the database layer
[Improvement]: Remove redundant \`status: Status\` override from \`User\` type — already inferred via \`.$type<Status>()\` in the schema