### PR TITLE
Move createTeam and getTeams to admin use cases

### DIFF
--- a/src/use-cases/admin/teams.ts
+++ b/src/use-cases/admin/teams.ts
@@ -1,2 +1,22 @@
-export { createTeam, getTeams } from '@/use-cases/user/teams'
-export type { CreateTeamParams } from '@/use-cases/user/teams'
+import type { PaginationParams, TeamSearchParams } from '@/data'
+
+import { teamRepo } from '@/data'
+
+export interface CreateTeamParams {
+  name: string
+  website?: string
+  description?: string
+}
+
+export const getTeams = async (
+  params: TeamSearchParams,
+  pagination: PaginationParams,
+) => {
+  return teamRepo.search(params, pagination)
+}
+
+export const createTeam = async (params: CreateTeamParams) => {
+  const team = await teamRepo.create(params)
+
+  return { team }
+}

--- a/src/use-cases/user/teams.ts
+++ b/src/use-cases/user/teams.ts
@@ -1,14 +1,5 @@
-import type { PaginationParams, TeamSearchParams } from '@/data'
-
 import { teamRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
-
-export const getTeams = async (
-  params: TeamSearchParams,
-  pagination: PaginationParams,
-) => {
-  return teamRepo.search(params, pagination)
-}
 
 export const getTeam = async (teamId: string) => {
   const team = await teamRepo.find(teamId)
@@ -16,18 +7,6 @@ export const getTeam = async (teamId: string) => {
   if (!team) {
     throw new AppError(ErrorCode.NotFound, 'Team not found')
   }
-
-  return { team }
-}
-
-export interface CreateTeamParams {
-  name: string
-  website?: string
-  description?: string
-}
-
-export const createTeam = async (params: CreateTeamParams) => {
-  const team = await teamRepo.create(params)
 
   return { team }
 }


### PR DESCRIPTION
[Improvement]: Move \`createTeam\` and \`getTeams\` use cases from user layer to admin layer where they belong
[Fix]: Remove re-export hack in \`admin/teams.ts\` that was delegating to user use cases