### PR TITLE
Add findByIdWithTeam for admin getUser

### DIFF
--- a/src/data/repositories/user/index.ts
+++ b/src/data/repositories/user/index.ts
@@ -1,5 +1,5 @@
 import { createUser, updateUser } from './mutations'
-import { findUserByEmail, findUserById, search } from './queries'
+import { findUserByEmail, findUserById, findUserByIdWithTeam, search } from './queries'
 
 export * from './types'
 
@@ -7,6 +7,7 @@ export const userRepo = {
   create: createUser,
   findByEmail: findUserByEmail,
   findById: findUserById,
+  findByIdWithTeam: findUserByIdWithTeam,
   search,
   update: updateUser,
 }

--- a/src/data/repositories/user/queries.ts
+++ b/src/data/repositories/user/queries.ts
@@ -60,6 +60,23 @@ const findUserBy = async (
 export const findUserById = async (userId: string, tx?: Database) =>
   findUserBy(eq(usersTable.id, userId), tx)
 
+export const findUserByIdWithTeam = async (
+  userId: string,
+  tx?: Database,
+): Promise<User | undefined> => {
+  const executor = tx || db
+
+  const [row] = await selectUserWithRoleAndTeam(executor).where(eq(usersTable.id, userId))
+
+  if (!row) {
+    return undefined
+  }
+
+  const { team, ...user } = row
+
+  return team?.id != null ? { ...user, team } : user
+}
+
 export const findUserByEmail = async (email: string, tx?: Database) =>
   findUserBy(eq(usersTable.email, email), tx)
 

--- a/src/use-cases/admin/__tests__/users.test.ts
+++ b/src/use-cases/admin/__tests__/users.test.ts
@@ -89,7 +89,7 @@ describe('getUser', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
   let mockUser: User
-  let mockFindById: any
+  let mockFindByIdWithTeam: any
 
   beforeEach(async () => {
     mockUser = {
@@ -103,10 +103,10 @@ describe('getUser', () => {
       updatedAt: new Date('2024-01-01'),
     }
 
-    mockFindById = mock(async () => mockUser)
+    mockFindByIdWithTeam = mock(async () => mockUser)
 
     await moduleMocker.mock('@/data', () => ({
-      userRepo: { findById: mockFindById },
+      userRepo: { findByIdWithTeam: mockFindByIdWithTeam },
     }))
   })
 
@@ -117,12 +117,12 @@ describe('getUser', () => {
   it('should return user when found', async () => {
     const result = await getUser(testUuids.USER_1)
 
-    expect(mockFindById).toHaveBeenCalledWith(testUuids.USER_1)
+    expect(mockFindByIdWithTeam).toHaveBeenCalledWith(testUuids.USER_1)
     expect(result).toEqual({ user: mockUser })
   })
 
   it('should throw NotFound error when user does not exist', async () => {
-    mockFindById.mockImplementation(async () => undefined)
+    mockFindByIdWithTeam.mockImplementation(async () => undefined)
 
     expect(getUser(testUuids.NON_EXISTENT)).rejects.toThrow(AppError)
     expect(getUser(testUuids.NON_EXISTENT)).rejects.toMatchObject({

--- a/src/use-cases/admin/users.ts
+++ b/src/use-cases/admin/users.ts
@@ -31,7 +31,7 @@ export const searchUsers = async (params: SearchParams, pagination: PaginationPa
 }
 
 export const getUser = async (userId: string) => {
-  const user = await userRepo.findById(userId)
+  const user = await userRepo.findByIdWithTeam(userId)
 
   if (!user || !isUser(user.role)) {
     throw new AppError(ErrorCode.NotFound, 'User not found')


### PR DESCRIPTION
[Feature]: Add \`findByIdWithTeam\` to user repository, fetching team membership alongside user data
[Improvement]: Switch admin \`getUser\` use case to use \`findByIdWithTeam\` so the response includes \`user.team\` when the user belongs to a team
[Fix]: Update \`getUser\` tests to mock \`findByIdWithTeam\` instead of \`findById\`