### PR TITLE
Fix ambiguous column refs in search SQL queries

### DIFF
--- a/src/data/migrations/custom/README.md
+++ b/src/data/migrations/custom/README.md
@@ -15,8 +15,9 @@ Custom SQL migrations that extend Drizzle ORM's auto-generated migrations.
 The query expression must exactly match the index expression:
 
 - Index: see `0000_search_indexes.sql`
-- Query: `src/data/repositories/user/queries.ts` (search function)
+- Queries: `src/data/repositories/user/queries.ts`, `src/data/repositories/team/queries.ts`
 - To add a searchable column, update both the migration AND the query
+- Raw SQL expressions must use table-qualified column references (e.g. `usersTable.id`) to avoid ambiguity when joins are present
 
 ### Capabilities
 

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -25,7 +25,7 @@ export const searchTeams = async (
     if (search && search.length > 0) {
       // Use concatenated expression to leverage GIN index (idx_teams_search_trgm)
       conditions.push(
-        sql`(id::text || ' ' || name || ' ' || COALESCE(website, '') || ' ' || COALESCE(description, '')) ILIKE ${`%${search}%`}`,
+        sql`(${teamsTable.id}::text || ' ' || ${teamsTable.name} || ' ' || COALESCE(${teamsTable.website}, '') || ' ' || COALESCE(${teamsTable.description}, '')) ILIKE ${`%${search}%`}`,
       )
     }
 

--- a/src/data/repositories/user/queries.ts
+++ b/src/data/repositories/user/queries.ts
@@ -110,7 +110,7 @@ const buildWhereConditions = ({ search, roles, statuses }: SearchParams) => {
   if (search && search.length > 0) {
     // Use concatenated expression to leverage GIN index (idx_users_search_trgm)
     conditions.push(
-      sql`(id::text || ' ' || first_name || ' ' || COALESCE(last_name, '') || ' ' || email) ILIKE ${`%${search}%`}`,
+      sql`(${usersTable.id}::text || ' ' || ${usersTable.firstName} || ' ' || COALESCE(${usersTable.lastName}, '') || ' ' || ${usersTable.email}) ILIKE ${`%${search}%`}`,
     )
   }
 


### PR DESCRIPTION
[Fix]: Qualify bare column names in raw SQL search expressions with table references to prevent ambiguous column errors when multiple tables with an \`id\` column are joined

[Improvement]: Update search index README to reference both user and team query files and document the table-qualification requirement