### PR TITLE
Extract buildPagination to shared pagination module

### DIFF
--- a/src/data/repositories/pagination.ts
+++ b/src/data/repositories/pagination.ts
@@ -9,3 +9,18 @@ export interface PaginatedResult extends PaginationParams {
 }
 
 export const calcOffset = ({ page, limit }: PaginationParams) => (page - 1) * limit
+
+export const buildPagination = (
+  pagination: PaginationParams,
+  countResult: { value: number }[],
+): PaginatedResult => {
+  const { page, limit } = pagination
+  const total = countResult[0]?.value ?? 0
+
+  return {
+    page,
+    limit,
+    total,
+    totalPages: Math.ceil(total / limit),
+  }
+}

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -7,7 +7,20 @@ import type { Team, TeamMemberDetails, TeamSearchParams, TeamSearchResult, TeamW
 
 import { db } from '../../clients'
 import { teamMembersTable, teamsTable, usersTable } from '../../schema'
-import { calcOffset } from '../pagination'
+import { buildPagination, calcOffset } from '../pagination'
+
+const buildWhereConditions = ({ search }: TeamSearchParams) => {
+  const conditions = []
+
+  if (search && search.length > 0) {
+    // Use concatenated expression to leverage GIN index (idx_teams_search_trgm)
+    conditions.push(
+      sql`(${teamsTable.id}::text || ' ' || ${teamsTable.name} || ' ' || COALESCE(${teamsTable.website}, '') || ' ' || COALESCE(${teamsTable.description}, '')) ILIKE ${`%${search}%`}`,
+    )
+  }
+
+  return and(...conditions)
+}
 
 export const searchTeams = async (
   filters: TeamSearchParams,
@@ -15,46 +28,26 @@ export const searchTeams = async (
   tx?: Database,
 ): Promise<TeamSearchResult> => {
   const executor = tx || db
-  const { search } = filters
-  const { page, limit } = pagination
-  const offset = calcOffset(pagination)
 
-  const buildWhereConditions = () => {
-    const conditions = []
+  const whereClause = buildWhereConditions(filters)
 
-    if (search && search.length > 0) {
-      // Use concatenated expression to leverage GIN index (idx_teams_search_trgm)
-      conditions.push(
-        sql`(${teamsTable.id}::text || ' ' || ${teamsTable.name} || ' ' || COALESCE(${teamsTable.website}, '') || ' ' || COALESCE(${teamsTable.description}, '')) ILIKE ${`%${search}%`}`,
-      )
-    }
-
-    return and(...conditions)
-  }
-
-  const whereClause = buildWhereConditions()
-
-  const [countResult, teams] = await Promise.all([
-    executor.select({ value: count() }).from(teamsTable).where(whereClause),
+  const [teams, countResult] = await Promise.all([
     executor
       .select()
       .from(teamsTable)
       .where(whereClause)
       .orderBy(desc(teamsTable.createdAt))
-      .limit(limit)
-      .offset(offset),
+      .limit(pagination.limit)
+      .offset(calcOffset(pagination)),
+    executor
+      .select({ value: count() })
+      .from(teamsTable)
+      .where(whereClause),
   ])
-
-  const totalCount = countResult[0]?.value ?? 0
 
   return {
     teams,
-    pagination: {
-      page,
-      limit,
-      total: totalCount,
-      totalPages: Math.ceil(totalCount / limit),
-    },
+    pagination: buildPagination(pagination, countResult),
   }
 }
 

--- a/src/data/repositories/user/queries.ts
+++ b/src/data/repositories/user/queries.ts
@@ -8,7 +8,7 @@ import type { SearchParams, SearchResult, User } from './types'
 
 import { db } from '../../clients'
 import { teamMembersTable, teamsTable, userRolesTable, usersTable } from '../../schema'
-import { calcOffset } from '../pagination'
+import { buildPagination, calcOffset } from '../pagination'
 
 const selectUserWithRole = (executor: Database) =>
   executor
@@ -123,8 +123,6 @@ export const search = async (
   tx?: Database,
 ): Promise<SearchResult> => {
   const executor = tx || db
-  const { page, limit } = pagination
-  const offset = calcOffset(pagination)
 
   const searchQuery = selectUserWithRoleAndTeam(executor)
 
@@ -135,25 +133,18 @@ export const search = async (
 
   const whereClause = buildWhereConditions(filters)
 
-  const [rows, countResult] = await Promise.all([
+  const [users, countResult] = await Promise.all([
     searchQuery
       .where(whereClause)
       .orderBy(desc(usersTable.createdAt))
-      .limit(limit)
-      .offset(offset),
+      .limit(pagination.limit)
+      .offset(calcOffset(pagination)),
     countQuery
       .where(whereClause),
   ])
 
-  const totalCount = countResult[0]?.value ?? 0
-
   return {
-    users: rows.map(({ team, ...user }) => team?.id != null ? { ...user, team } : user),
-    pagination: {
-      page,
-      limit,
-      total: totalCount,
-      totalPages: Math.ceil(totalCount / limit),
-    },
+    users: users.map(({ team, ...user }) => team?.id ? { ...user, team } : user),
+    pagination: buildPagination(pagination, countResult),
   }
 }


### PR DESCRIPTION
[Improvement]: Extract \`buildPagination\` into \`pagination.ts\` so user and team repositories share a single typed helper instead of duplicating the logic

[Improvement]: Add explicit \`PaginatedResult\` return type to \`buildPagination\` for compile-time safety

[Improvement]: Move \`buildWhereConditions\` out of \`searchTeams\` function scope for consistency with the user repository pattern