### PR TITLE
Refactor permission use cases and add resolvePermissionMap

### DIFF
--- a/src/use-cases/__tests__/resolve-permissions.test.ts
+++ b/src/use-cases/__tests__/resolve-permissions.test.ts
@@ -5,9 +5,9 @@ import type { ActivePermissionRow } from '@/data/repositories/rbac/types'
 import { ModuleMocker, testUuids } from '@/__tests__'
 import { Action, Permission, Resource } from '@/types'
 
-import { resolvePermissions } from '../resolve-permissions'
+import { resolvePermissionList } from '../resolve-permissions'
 
-describe('resolvePermissions', () => {
+describe('resolvePermissionList', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
   let mockFindUserPermissions: any
@@ -27,7 +27,7 @@ describe('resolvePermissions', () => {
   })
 
   it('should return undefined when user has no permissions', async () => {
-    const result = await resolvePermissions(testUuids.USER_1)
+    const result = await resolvePermissionList(testUuids.USER_1)
 
     expect(result).toBeUndefined()
     expect(mockFindUserPermissions).toHaveBeenCalledWith(testUuids.USER_1)
@@ -39,13 +39,13 @@ describe('resolvePermissions', () => {
       { action: Action.Manage, resource: Resource.Teams },
     ])
 
-    const result = await resolvePermissions(testUuids.ADMIN_1)
+    const result = await resolvePermissionList(testUuids.ADMIN_1)
 
     expect(result).toEqual([Permission.ViewUsers, Permission.ManageTeams])
   })
 
   it('should pass userId to the repository', async () => {
-    await resolvePermissions(testUuids.ADMIN_1)
+    await resolvePermissionList(testUuids.ADMIN_1)
 
     expect(mockFindUserPermissions).toHaveBeenCalledWith(testUuids.ADMIN_1)
     expect(mockFindUserPermissions).toHaveBeenCalledTimes(1)
@@ -61,7 +61,7 @@ describe('resolvePermissions', () => {
       { action: Action.Manage, resource: Resource.Teams },
     ])
 
-    const result = await resolvePermissions(testUuids.USER_1)
+    const result = await resolvePermissionList(testUuids.USER_1)
 
     expect(result).toHaveLength(6)
     expect(result).toContain(Permission.ViewUsers)

--- a/src/use-cases/auth/__tests__/accept-invite.test.ts
+++ b/src/use-cases/auth/__tests__/accept-invite.test.ts
@@ -134,7 +134,7 @@ describe('Accept Invite', () => {
     mockResolvePermissions = mock(async () => undefined)
 
     await moduleMocker.mock('../../resolve-permissions', () => ({
-      resolvePermissions: mockResolvePermissions,
+      resolvePermissionList: mockResolvePermissions,
     }))
   })
 

--- a/src/use-cases/auth/__tests__/login.test.ts
+++ b/src/use-cases/auth/__tests__/login.test.ts
@@ -109,7 +109,7 @@ describe('Login with Email', () => {
     mockResolvePermissions = mock(async () => undefined)
 
     await moduleMocker.mock('../../resolve-permissions', () => ({
-      resolvePermissions: mockResolvePermissions,
+      resolvePermissionList: mockResolvePermissions,
     }))
   })
 

--- a/src/use-cases/auth/__tests__/refresh-token.test.ts
+++ b/src/use-cases/auth/__tests__/refresh-token.test.ts
@@ -108,7 +108,7 @@ describe('Refresh Auth Tokens', () => {
     mockResolvePermissions = mock(async () => undefined)
 
     await moduleMocker.mock('../../resolve-permissions', () => ({
-      resolvePermissions: mockResolvePermissions,
+      resolvePermissionList: mockResolvePermissions,
     }))
   })
 

--- a/src/use-cases/auth/__tests__/reset-password.test.ts
+++ b/src/use-cases/auth/__tests__/reset-password.test.ts
@@ -130,7 +130,7 @@ describe('Reset Password', () => {
     mockResolvePermissions = mock(async () => undefined)
 
     await moduleMocker.mock('../../resolve-permissions', () => ({
-      resolvePermissions: mockResolvePermissions,
+      resolvePermissionList: mockResolvePermissions,
     }))
   })
 

--- a/src/use-cases/auth/accept-invite.ts
+++ b/src/use-cases/auth/accept-invite.ts
@@ -5,7 +5,7 @@ import { hashPassword } from '@/security/password'
 import { TokenStatus, TokenType } from '@/security/token'
 import Status from '@/types/status'
 
-import { resolvePermissions } from '../resolve-permissions'
+import { resolvePermissionList } from '../resolve-permissions'
 import { createAuthTokens, validateOneTimeToken } from '../tokens'
 
 export interface AcceptInviteParams {
@@ -36,7 +36,7 @@ const acceptInvite = async (
 
   const [team, permissions] = await Promise.all([
     teamRepo.findUserTeam(user.id),
-    resolvePermissions(user.id),
+    resolvePermissionList(user.id),
   ])
 
   const [accessToken, refreshToken] = await createAuthTokens(user, deviceInfo, permissions)

--- a/src/use-cases/auth/login.ts
+++ b/src/use-cases/auth/login.ts
@@ -4,7 +4,7 @@ import { authRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { comparePasswordHashes } from '@/security/password'
 
-import { resolvePermissions } from '../resolve-permissions'
+import { resolvePermissionList } from '../resolve-permissions'
 import { createAuthTokens } from '../tokens'
 
 export interface LoginParams {
@@ -36,7 +36,7 @@ const logInWithEmail = async (
 
   const [team, permissions] = await Promise.all([
     teamRepo.findUserTeam(user.id),
-    resolvePermissions(user.id),
+    resolvePermissionList(user.id),
   ])
 
   const [accessToken, refreshToken] = await createAuthTokens(user, deviceInfo, permissions)

--- a/src/use-cases/auth/refresh-token.ts
+++ b/src/use-cases/auth/refresh-token.ts
@@ -5,7 +5,7 @@ import { AppError, ErrorCode } from '@/errors'
 import { logger } from '@/logging'
 import { hashToken } from '@/security/token'
 
-import { resolvePermissions } from '../resolve-permissions'
+import { resolvePermissionList } from '../resolve-permissions'
 import { createAccessToken, createRefreshToken } from '../tokens'
 
 const validateToken = async (refreshToken: string | undefined) => {
@@ -67,7 +67,7 @@ const refreshAuthTokens = async (
 
   validateDevice(storedToken, deviceInfo, user.id)
 
-  const permissions = await resolvePermissions(user.id)
+  const permissions = await resolvePermissionList(user.id)
 
   const [accessToken, newRefreshToken] = await Promise.all([
     createAccessToken(user, permissions),

--- a/src/use-cases/auth/reset-password.ts
+++ b/src/use-cases/auth/reset-password.ts
@@ -5,7 +5,7 @@ import { AppError, ErrorCode } from '@/errors'
 import { hashPassword } from '@/security/password'
 import { TokenStatus, TokenType } from '@/security/token'
 
-import { resolvePermissions } from '../resolve-permissions'
+import { resolvePermissionList } from '../resolve-permissions'
 import { createAuthTokens, validateOneTimeToken } from '../tokens'
 
 export interface ResetPasswordParams {
@@ -39,7 +39,7 @@ const resetPassword = async (
 
   const [team, permissions] = await Promise.all([
     teamRepo.findUserTeam(user.id),
-    resolvePermissions(user.id),
+    resolvePermissionList(user.id),
   ])
 
   const [accessToken, refreshToken] = await createAuthTokens(user, deviceInfo, permissions)

--- a/src/use-cases/resolve-permissions.ts
+++ b/src/use-cases/resolve-permissions.ts
@@ -13,3 +13,20 @@ export const resolvePermissionList = async (
 
   return permissions.length > 0 ? permissions : undefined
 }
+
+// Builds a permission matrix keyed by resource, e.g.
+// { users: { view: true }, teams: { view: true, manage: true } }
+// Suitable for frontend permission grids where resource is the row
+// and actions (view, manage) are the columns with switches/checkboxes
+export const resolvePermissionMap = async (
+  userId: string,
+): Promise<Record<string, Record<string, boolean>>> => {
+  const rows = await rbacRepo.findUserPermissions(userId)
+
+  return rows.reduce<Record<string, Record<string, boolean>>>((acc, row) => {
+    acc[row.resource] ??= {}
+    acc[row.resource][row.action] = true
+
+    return acc
+  }, {})
+}

--- a/src/use-cases/resolve-permissions.ts
+++ b/src/use-cases/resolve-permissions.ts
@@ -2,7 +2,7 @@ import type { Permission } from '@/types'
 
 import { rbacRepo } from '@/data'
 
-export const resolvePermissions = async (
+export const resolvePermissionList = async (
   userId: string,
 ): Promise<Permission[] | undefined> => {
   const rows = await rbacRepo.findUserPermissions(userId)

--- a/src/use-cases/resolve-permissions.ts
+++ b/src/use-cases/resolve-permissions.ts
@@ -7,6 +7,8 @@ export const resolvePermissionList = async (
 ): Promise<Permission[] | undefined> => {
   const rows = await rbacRepo.findUserPermissions(userId)
 
+  // Maps DB rows to "action:resource" strings, e.g.
+  // "view:users", "manage:teams" for frontend consumption
   const permissions = rows.map(row => `${row.action}:${row.resource}` as Permission)
 
   return permissions.length > 0 ? permissions : undefined

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -48,7 +48,7 @@ describe('User Me Use Cases', () => {
     mockResolvePermissions = mock(async () => undefined)
 
     await moduleMocker.mock('../../resolve-permissions', () => ({
-      resolvePermissions: mockResolvePermissions,
+      resolvePermissionList: mockResolvePermissions,
     }))
   })
 

--- a/src/use-cases/user/me.ts
+++ b/src/use-cases/user/me.ts
@@ -3,7 +3,7 @@ import type { UpdateUserInput } from '@/data'
 import { teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 
-import { resolvePermissions } from '../resolve-permissions'
+import { resolvePermissionList } from '../resolve-permissions'
 
 const prepareValidUpdates = (updates: UpdateUserInput): UpdateUserInput => {
   return Object.fromEntries(
@@ -15,7 +15,7 @@ export const getUser = async (userId: string) => {
   const [user, team, permissions] = await Promise.all([
     userRepo.findById(userId),
     teamRepo.findUserTeam(userId),
-    resolvePermissions(userId),
+    resolvePermissionList(userId),
   ])
 
   if (!user) {
@@ -40,7 +40,7 @@ export const updateUser = async (userId: string, updates: UpdateUserInput) => {
       updatedAt: new Date(),
     }),
     teamRepo.findUserTeam(userId),
-    resolvePermissions(userId),
+    resolvePermissionList(userId),
   ])
 
   return { user, team, permissions }


### PR DESCRIPTION
[Improvement]: Rename \`resolvePermissions\` to \`resolvePermissionList\` for clarity across all callers and tests
[Feature]: Add \`resolvePermissionMap\` use case that builds a resource-keyed matrix for frontend permission grids
[Improvement]: Document permission string format ("view:users", "manage:teams") and matrix shape in inline comments