### PR TITLE
Add PATCH /user/verified/users/:userId endpoint

### DIFF
--- a/src/data/repositories/team/index.ts
+++ b/src/data/repositories/team/index.ts
@@ -5,6 +5,7 @@ import {
   updateTeamMember,
 } from './mutations'
 import {
+  findSharedTeam,
   findTeamById,
   findTeamMember,
   findTeamMembers,
@@ -23,6 +24,7 @@ const teamMutations = {
 const teamQueries = {
   find: findTeamWithMemberCount,
   findById: findTeamById,
+  findSharedTeam,
   findUserTeam,
   search: searchTeams,
 }

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -150,6 +150,26 @@ export const findTeamWithMemberCount = async (
   }
 }
 
+export const findSharedTeam = async (
+  callerId: string,
+  targetUserId: string,
+  tx?: Database,
+): Promise<{ teamId: string } | undefined> => {
+  const executor = tx || db
+
+  const callerTeams = alias(teamMembersTable, 'caller_teams')
+  const targetTeams = alias(teamMembersTable, 'target_teams')
+
+  const [result] = await executor
+    .select({ teamId: callerTeams.teamId })
+    .from(callerTeams)
+    .innerJoin(targetTeams, eq(callerTeams.teamId, targetTeams.teamId))
+    .where(and(eq(callerTeams.userId, callerId), eq(targetTeams.userId, targetUserId)))
+    .limit(1)
+
+  return result
+}
+
 export const findUserTeam = async (
   userId: string,
   tx?: Database,

--- a/src/middleware/team-access/__tests__/team-access.test.ts
+++ b/src/middleware/team-access/__tests__/team-access.test.ts
@@ -12,10 +12,12 @@ import { Role, Status } from '@/types'
 import { teamAccessMiddleware } from '../team-access'
 
 const mockTeamRepoFindMember = mock()
+const mockTeamRepoFindSharedTeam = mock()
 
 void mock.module('@/data', () => ({
   teamRepo: {
     findMember: mockTeamRepoFindMember,
+    findSharedTeam: mockTeamRepoFindSharedTeam,
   },
 }))
 
@@ -26,9 +28,10 @@ describe('Team Access Middleware', () => {
     app = new Hono<AppContext>()
     app.onError(onError)
     mockTeamRepoFindMember.mockClear()
+    mockTeamRepoFindSharedTeam.mockClear()
   })
 
-  describe('Regular User Access', () => {
+  describe('teamId param', () => {
     it('should allow access when user has valid team membership', async () => {
       mockTeamRepoFindMember.mockImplementation(async () => ({
         userId: testUuids.USER_1,
@@ -54,6 +57,7 @@ describe('Team Access Middleware', () => {
 
       expect(res.status).toBe(HttpStatus.OK)
       expect(mockTeamRepoFindMember).toHaveBeenCalledWith(testUuids.TEAM_1, testUuids.USER_1)
+      expect(mockTeamRepoFindSharedTeam).not.toHaveBeenCalled()
 
       const json = await res.json()
       expect(json.message).toBe('success')
@@ -105,136 +109,11 @@ describe('Team Access Middleware', () => {
     })
   })
 
-  describe('Admin User Access', () => {
-    it('should allow Admin access without team membership', async () => {
-      app.use('/teams/:teamId', async (c, next) => {
-        c.set('user', {
-          id: testUuids.ADMIN_1,
-          email: 'admin@example.com',
-          role: Role.Admin,
-          status: Status.Active,
-        })
-        await next()
-      })
-      app.use('/teams/:teamId', teamAccessMiddleware)
-      app.get('/teams/:teamId', c => c.json({ message: 'success' }))
+  describe('userId param', () => {
+    it('should allow access when caller shares a team with the target user', async () => {
+      mockTeamRepoFindSharedTeam.mockImplementation(async () => ({ teamId: testUuids.TEAM_1 }))
 
-      const res = await app.request(`/teams/${testUuids.TEAM_1}`)
-
-      expect(res.status).toBe(HttpStatus.OK)
-      expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
-
-      const json = await res.json()
-      expect(json.message).toBe('success')
-    })
-
-    it('should allow Admin access to any team', async () => {
-      app.use('/teams/:teamId', async (c, next) => {
-        c.set('user', {
-          id: testUuids.ADMIN_1,
-          email: 'admin@example.com',
-          role: Role.Admin,
-          status: Status.Active,
-        })
-        await next()
-      })
-      app.use('/teams/:teamId', teamAccessMiddleware)
-      app.get('/teams/:teamId', c => c.json({ message: 'success' }))
-
-      const res = await app.request(`/teams/${testUuids.TEAM_2}`)
-
-      expect(res.status).toBe(HttpStatus.OK)
-      expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('Owner User Access', () => {
-    it('should allow Owner access without team membership', async () => {
-      app.use('/teams/:teamId', async (c, next) => {
-        c.set('user', {
-          id: testUuids.OWNER_1,
-          email: 'owner@example.com',
-          role: Role.Owner,
-          status: Status.Active,
-        })
-        await next()
-      })
-      app.use('/teams/:teamId', teamAccessMiddleware)
-      app.get('/teams/:teamId', c => c.json({ message: 'success' }))
-
-      const res = await app.request(`/teams/${testUuids.TEAM_1}`)
-
-      expect(res.status).toBe(HttpStatus.OK)
-      expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
-
-      const json = await res.json()
-      expect(json.message).toBe('success')
-    })
-
-    it('should allow Owner access to any team', async () => {
-      app.use('/teams/:teamId', async (c, next) => {
-        c.set('user', {
-          id: testUuids.OWNER_1,
-          email: 'owner@example.com',
-          role: Role.Owner,
-          status: Status.Active,
-        })
-        await next()
-      })
-      app.use('/teams/:teamId', teamAccessMiddleware)
-      app.get('/teams/:teamId', c => c.json({ message: 'success' }))
-
-      const res = await app.request(`/teams/${testUuids.TEAM_2}`)
-
-      expect(res.status).toBe(HttpStatus.OK)
-      expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('Database Query Optimization', () => {
-    it('should skip database query for Admin users', async () => {
-      app.use('/teams/:teamId', async (c, next) => {
-        c.set('user', {
-          id: testUuids.ADMIN_1,
-          email: 'admin@example.com',
-          role: Role.Admin,
-          status: Status.Active,
-        })
-        await next()
-      })
-      app.use('/teams/:teamId', teamAccessMiddleware)
-      app.get('/teams/:teamId', c => c.json({ message: 'success' }))
-
-      await app.request(`/teams/${testUuids.TEAM_1}`)
-
-      expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
-    })
-
-    it('should skip database query for Owner users', async () => {
-      app.use('/teams/:teamId', async (c, next) => {
-        c.set('user', {
-          id: testUuids.OWNER_1,
-          email: 'owner@example.com',
-          role: Role.Owner,
-          status: Status.Active,
-        })
-        await next()
-      })
-      app.use('/teams/:teamId', teamAccessMiddleware)
-      app.get('/teams/:teamId', c => c.json({ message: 'success' }))
-
-      await app.request(`/teams/${testUuids.TEAM_1}`)
-
-      expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
-    })
-
-    it('should query database for regular User', async () => {
-      mockTeamRepoFindMember.mockImplementation(async () => ({
-        userId: testUuids.USER_1,
-        teamId: testUuids.TEAM_1,
-      }))
-
-      app.use('/teams/:teamId', async (c, next) => {
+      app.use('/users/:userId', async (c, next) => {
         c.set('user', {
           id: testUuids.USER_1,
           email: 'user@example.com',
@@ -243,21 +122,109 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
+      app.use('/users/:userId', teamAccessMiddleware)
+      app.patch('/users/:userId', c => c.json({ message: 'success' }))
+
+      const res = await app.request(`/users/${testUuids.USER_2}`, { method: 'PATCH' })
+
+      expect(res.status).toBe(HttpStatus.OK)
+      expect(mockTeamRepoFindSharedTeam).toHaveBeenCalledWith(testUuids.USER_1, testUuids.USER_2)
+      expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
+
+      const json = await res.json()
+      expect(json.message).toBe('success')
+    })
+
+    it('should throw Forbidden when caller shares no team with the target user', async () => {
+      mockTeamRepoFindSharedTeam.mockImplementation(async () => undefined)
+
+      app.use('/users/:userId', async (c, next) => {
+        c.set('user', {
+          id: testUuids.USER_1,
+          email: 'user@example.com',
+          role: Role.User,
+          status: Status.Active,
+        })
+        await next()
+      })
+      app.use('/users/:userId', teamAccessMiddleware)
+      app.patch('/users/:userId', c => c.json({ message: 'success' }))
+
+      const res = await app.request(`/users/${testUuids.USER_2}`, { method: 'PATCH' })
+
+      expect(res.status).toBe(HttpStatus.FORBIDDEN)
+      expect(mockTeamRepoFindSharedTeam).toHaveBeenCalledWith(testUuids.USER_1, testUuids.USER_2)
+
+      const json = await res.json()
+      expect(json.code).toBe(ErrorCode.Forbidden)
+    })
+  })
+
+  describe('Admin / Owner bypass', () => {
+    it('should allow Admin access via teamId without membership check', async () => {
+      app.use('/teams/:teamId', async (c, next) => {
+        c.set('user', {
+          id: testUuids.ADMIN_1,
+          email: 'admin@example.com',
+          role: Role.Admin,
+          status: Status.Active,
+        })
+        await next()
+      })
       app.use('/teams/:teamId', teamAccessMiddleware)
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
-      await app.request(`/teams/${testUuids.TEAM_1}`)
+      const res = await app.request(`/teams/${testUuids.TEAM_1}`)
 
-      expect(mockTeamRepoFindMember).toHaveBeenCalledTimes(1)
-      expect(mockTeamRepoFindMember).toHaveBeenCalledWith(testUuids.TEAM_1, testUuids.USER_1)
+      expect(res.status).toBe(HttpStatus.OK)
+      expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
+      expect(mockTeamRepoFindSharedTeam).not.toHaveBeenCalled()
+    })
+
+    it('should allow Owner access via teamId without membership check', async () => {
+      app.use('/teams/:teamId', async (c, next) => {
+        c.set('user', {
+          id: testUuids.OWNER_1,
+          email: 'owner@example.com',
+          role: Role.Owner,
+          status: Status.Active,
+        })
+        await next()
+      })
+      app.use('/teams/:teamId', teamAccessMiddleware)
+      app.get('/teams/:teamId', c => c.json({ message: 'success' }))
+
+      const res = await app.request(`/teams/${testUuids.TEAM_1}`)
+
+      expect(res.status).toBe(HttpStatus.OK)
+      expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
+      expect(mockTeamRepoFindSharedTeam).not.toHaveBeenCalled()
+    })
+
+    it('should allow Admin access via userId without shared team check', async () => {
+      app.use('/users/:userId', async (c, next) => {
+        c.set('user', {
+          id: testUuids.ADMIN_1,
+          email: 'admin@example.com',
+          role: Role.Admin,
+          status: Status.Active,
+        })
+        await next()
+      })
+      app.use('/users/:userId', teamAccessMiddleware)
+      app.patch('/users/:userId', c => c.json({ message: 'success' }))
+
+      const res = await app.request(`/users/${testUuids.USER_1}`, { method: 'PATCH' })
+
+      expect(res.status).toBe(HttpStatus.OK)
+      expect(mockTeamRepoFindMember).not.toHaveBeenCalled()
+      expect(mockTeamRepoFindSharedTeam).not.toHaveBeenCalled()
     })
   })
 
   describe('Error Handling', () => {
-    it('should throw AppError with Forbidden code for unauthorized access', async () => {
-      mockTeamRepoFindMember.mockImplementation(async () => undefined)
-
-      app.use('/teams/:teamId', async (c, next) => {
+    it('should throw Forbidden when neither teamId nor userId param is present', async () => {
+      app.use('/resource', async (c, next) => {
         c.set('user', {
           id: testUuids.USER_1,
           email: 'user@example.com',
@@ -266,19 +233,15 @@ describe('Team Access Middleware', () => {
         })
         await next()
       })
-      app.use('/teams/:teamId', teamAccessMiddleware)
-      app.get('/teams/:teamId', c => c.json({ message: 'success' }))
+      app.use('/resource', teamAccessMiddleware)
+      app.get('/resource', c => c.json({ message: 'success' }))
 
-      const res = await app.request(`/teams/${testUuids.TEAM_1}`)
+      const res = await app.request('/resource')
 
       expect(res.status).toBe(HttpStatus.FORBIDDEN)
-
-      const json = await res.json()
-      expect(json.code).toBe(ErrorCode.Forbidden)
-      expect(json.error).toBeDefined()
     })
 
-    it('should propagate database errors', async () => {
+    it('should propagate database errors from findMember', async () => {
       mockTeamRepoFindMember.mockImplementation(async () => {
         throw new Error('Database connection failed')
       })
@@ -296,6 +259,28 @@ describe('Team Access Middleware', () => {
       app.get('/teams/:teamId', c => c.json({ message: 'success' }))
 
       const res = await app.request(`/teams/${testUuids.TEAM_1}`)
+
+      expect(res.status).toBe(HttpStatus.INTERNAL_SERVER_ERROR)
+    })
+
+    it('should propagate database errors from findSharedTeam', async () => {
+      mockTeamRepoFindSharedTeam.mockImplementation(async () => {
+        throw new Error('Database connection failed')
+      })
+
+      app.use('/users/:userId', async (c, next) => {
+        c.set('user', {
+          id: testUuids.USER_1,
+          email: 'user@example.com',
+          role: Role.User,
+          status: Status.Active,
+        })
+        await next()
+      })
+      app.use('/users/:userId', teamAccessMiddleware)
+      app.patch('/users/:userId', c => c.json({ message: 'success' }))
+
+      const res = await app.request(`/users/${testUuids.USER_2}`, { method: 'PATCH' })
 
       expect(res.status).toBe(HttpStatus.INTERNAL_SERVER_ERROR)
     })

--- a/src/middleware/team-access/team-access.ts
+++ b/src/middleware/team-access/team-access.ts
@@ -7,9 +7,15 @@ import { AppError, ErrorCode } from '@/errors'
 import { isAdmin } from '@/types'
 
 /**
- * Team access middleware - ensures user has access to the team.
+ * Team access middleware - ensures the caller has access to a team resource.
  *
- * Note: teamId is already validated by requestValidator middleware
+ * Resolves the team context from route params in order:
+ * - teamId: direct team access — caller must be a member of that team
+ * - userId: cross-user access — caller must share a team with the target user
+ *
+ * Admins and owners bypass the membership check entirely.
+ *
+ * Note: params are already validated by requestValidator middleware
  *
  * TODO: Add Redis caching for team membership queries
  * Currently queries database on every request (~1-5ms per query).
@@ -17,20 +23,36 @@ import { isAdmin } from '@/types'
  * See: https://github.com/SlavaMelanko/smela-back/issues/58
  */
 export const teamAccessMiddleware = createMiddleware<AppContext>(async (c, next) => {
-  const teamId = c.req.param('teamId')!
-  const { id: userId, role } = c.get('user')
+  const { id: callerId, role } = c.get('user')
 
-  // Admins and owners have access to all teams
+  // Admins and owners have access to all teams and users
   if (isAdmin(role)) {
     return next()
   }
 
-  // Regular users must be team members
-  const membership = await teamRepo.findMember(teamId, userId)
+  const teamId = c.req.param('teamId')
 
-  if (!membership) {
-    throw new AppError(ErrorCode.Forbidden)
+  if (teamId) {
+    const membership = await teamRepo.findMember(teamId, callerId)
+
+    if (!membership) {
+      throw new AppError(ErrorCode.Forbidden)
+    }
+
+    return next()
   }
 
-  return next()
+  const targetUserId = c.req.param('userId')
+
+  if (targetUserId) {
+    const sharedTeam = await teamRepo.findSharedTeam(callerId, targetUserId)
+
+    if (!sharedTeam) {
+      throw new AppError(ErrorCode.Forbidden)
+    }
+
+    return next()
+  }
+
+  throw new AppError(ErrorCode.Forbidden)
 })

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -12,7 +12,7 @@ import {
   verifyEmailRoute,
 } from './auth'
 import { ownerAdminsRoute } from './owner'
-import { meRoute, teamsRoute } from './user'
+import { meRoute, teamsRoute, usersRoute } from './user'
 
 export const authPublicRoutes = [
   acceptInviteRoute,
@@ -29,7 +29,7 @@ export const authPublicRoutes = [
 
 export const userRoutesAllowNew = [meRoute]
 
-export const userRoutesVerifiedOnly = [teamsRoute]
+export const userRoutesVerifiedOnly = [teamsRoute, usersRoute]
 
 export const adminRoutes = [adminTeamsRoute, adminUsersRoute]
 

--- a/src/routes/user/index.ts
+++ b/src/routes/user/index.ts
@@ -1,2 +1,3 @@
 export { meRoute } from './me'
 export { teamsRoute } from './teams'
+export { usersRoute } from './users'

--- a/src/routes/user/users/$id/handler.ts
+++ b/src/routes/user/users/$id/handler.ts
@@ -1,0 +1,13 @@
+import { HttpStatus } from '@/net/http'
+import { updateUser } from '@/use-cases/admin'
+
+import type { UpdateUserCtx } from './schema'
+
+export const updateUserHandler = async (c: UpdateUserCtx) => {
+  const { userId } = c.req.valid('param')
+  const body = c.req.valid('json')
+
+  const result = await updateUser(userId, body)
+
+  return c.json(result, HttpStatus.OK)
+}

--- a/src/routes/user/users/$id/index.ts
+++ b/src/routes/user/users/$id/index.ts
@@ -1,0 +1,18 @@
+import { Hono } from 'hono'
+
+import type { AppContext } from '@/context'
+
+import { requestValidator, teamAccessMiddleware } from '@/middleware'
+
+import { updateUserHandler } from './handler'
+import { updateUserBodySchema, userIdParamsSchema } from './schema'
+
+export const userByIdRoute = new Hono<AppContext>()
+
+userByIdRoute.patch(
+  '/',
+  requestValidator('param', userIdParamsSchema),
+  requestValidator('json', updateUserBodySchema),
+  teamAccessMiddleware,
+  updateUserHandler,
+)

--- a/src/routes/user/users/$id/schema.ts
+++ b/src/routes/user/users/$id/schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+import type { ValidatedParamCtx, ValidatedParamJsonCtx } from '@/routes/@shared'
+
+import { requestValidationRules as rules } from '@/routes/@shared'
+
+export const userIdParamsSchema = z.object({
+  userId: rules.data.id,
+})
+
+export type UserIdParams = z.infer<typeof userIdParamsSchema>
+export type UserIdCtx = ValidatedParamCtx<UserIdParams>
+
+export const updateUserBodySchema = z.object({
+  firstName: rules.data.firstName.optional(),
+  lastName: rules.data.lastName.optional(),
+}).strict()
+
+export type UpdateUserBody = z.infer<typeof updateUserBodySchema>
+export type UpdateUserCtx = ValidatedParamJsonCtx<UserIdParams, UpdateUserBody>

--- a/src/routes/user/users/index.ts
+++ b/src/routes/user/users/index.ts
@@ -1,0 +1,9 @@
+import { Hono } from 'hono'
+
+import type { AppContext } from '@/context'
+
+import { userByIdRoute } from './$id'
+
+export const usersRoute = new Hono<AppContext>()
+
+usersRoute.route('/users/:userId', userByIdRoute)


### PR DESCRIPTION
## Changes

[Feature]: Add `PATCH /api/v1/user/verified/users/:userId` to let team members update another user's firstName/lastName
[Feature]: Add `findSharedTeam` repo query to check if two users share a common team membership
[Improvement]: Merge `userAccessMiddleware` into `teamAccessMiddleware` — resolves access via `teamId` param first, then `userId` param as fallback
[Improvement]: Extend `teamAccessMiddleware` tests to cover the `userId` param branch, admin/owner bypass, and missing-param fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)