### PR TITLE
Extend updateTeamMember to support name field updates

### DIFF
--- a/src/routes/user/teams/$id/members/$id/schema.ts
+++ b/src/routes/user/teams/$id/members/$id/schema.ts
@@ -13,7 +13,13 @@ export type MemberIdParams = z.infer<typeof memberIdParamsSchema>
 export type MemberIdCtx = ValidatedParamCtx<MemberIdParams>
 
 export const updateTeamMemberBodySchema = z.object({
-  position: rules.team.position.nullish(),
+  membership: z.object({
+    position: rules.team.position.nullish(),
+  }).optional(),
+  member: z.object({
+    firstName: rules.data.firstName.optional(),
+    lastName: rules.data.lastName.optional(),
+  }).optional(),
 })
 
 export type UpdateTeamMemberBody = z.infer<typeof updateTeamMemberBodySchema>

--- a/src/use-cases/user/members.ts
+++ b/src/use-cases/user/members.ts
@@ -1,4 +1,4 @@
-import { teamRepo } from '@/data'
+import { teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 
 export const getTeamMembers = async (teamId: string) => {
@@ -21,7 +21,13 @@ export const getTeamMember = async (
 }
 
 export interface UpdateTeamMemberParams {
-  position?: string | null
+  membership?: {
+    position?: string | null
+  }
+  member?: {
+    firstName?: string
+    lastName?: string | null
+  }
 }
 
 export const updateTeamMember = async (
@@ -35,7 +41,19 @@ export const updateTeamMember = async (
     throw new AppError(ErrorCode.NotFound, 'Member not found')
   }
 
-  const member = await teamRepo.updateMember(memberId, teamId, params)
+  const updates: Array<Promise<unknown>> = []
+
+  if (params.membership) {
+    updates.push(teamRepo.updateMember(memberId, teamId, params.membership))
+  }
+
+  if (params.member) {
+    updates.push(userRepo.update(memberId, params.member))
+  }
+
+  await Promise.all(updates)
+
+  const member = await teamRepo.findMember(teamId, memberId)
 
   return { member }
 }


### PR DESCRIPTION
[Feature]: Add `member.firstName` and `member.lastName` fields to the PATCH team member endpoint, allowing name updates alongside membership position changes
[Fix]: Wrap `membership` and `member` sub-objects in `z.object()` — they were plain objects before, making the schema invalid
[Fix]: Correct field references from non-existent `rules.user.*` to `rules.data.*`
[Improvement]: Run membership and user updates concurrently via `Promise.all` when both are present