### PR TITLE
Add DELETE endpoint to remove team member

### DIFF
--- a/src/data/repositories/team/index.ts
+++ b/src/data/repositories/team/index.ts
@@ -1,6 +1,7 @@
 import {
   createTeam,
   createTeamMember,
+  deleteTeamMember,
   updateTeam,
   updateTeamMember,
 } from './mutations'
@@ -29,6 +30,7 @@ const teamQueries = {
 
 const memberMutations = {
   createMember: createTeamMember,
+  deleteMember: deleteTeamMember,
   updateMember: updateTeamMember,
 }
 

--- a/src/data/repositories/team/mutations.ts
+++ b/src/data/repositories/team/mutations.ts
@@ -99,3 +99,20 @@ export const updateTeamMember = async (
 
   return membership
 }
+
+export const deleteTeamMember = async (
+  userId: string,
+  teamId: string,
+  tx?: Database,
+): Promise<void> => {
+  const executor = tx || db
+
+  await executor
+    .delete(teamMembersTable)
+    .where(
+      and(
+        eq(teamMembersTable.userId, userId),
+        eq(teamMembersTable.teamId, teamId),
+      ),
+    )
+}

--- a/src/routes/user/teams/$id/members/$id/__tests__/handler.test.ts
+++ b/src/routes/user/teams/$id/members/$id/__tests__/handler.test.ts
@@ -6,6 +6,7 @@ import { HttpStatus } from '@/net/http'
 import {
   cancelMemberInviteHandler,
   getTeamMemberHandler,
+  removeTeamMemberHandler,
   resendMemberInviteHandler,
   updateTeamMemberHandler,
 } from '../handler'
@@ -120,6 +121,54 @@ describe('updateTeamMemberHandler', () => {
     })
 
     expect(updateTeamMemberHandler(mockContext)).rejects.toThrow('Member not found')
+  })
+})
+
+describe('removeTeamMemberHandler', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockContext: any
+  let mockJson: any
+  let mockRemoveTeamMember: any
+
+  beforeEach(async () => {
+    mockJson = mock((data: any, status: number) => ({ data, status }))
+
+    mockContext = {
+      req: { valid: mock(() => mockParams) },
+      json: mockJson,
+    }
+
+    mockRemoveTeamMember = mock(async () => ({ success: true }))
+
+    await moduleMocker.mock('@/use-cases/user', () => ({
+      removeTeamMember: mockRemoveTeamMember,
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should call removeTeamMember with team id and member id', async () => {
+    await removeTeamMemberHandler(mockContext)
+
+    expect(mockRemoveTeamMember).toHaveBeenCalledWith(testUuids.TEAM_1, testUuids.USER_1)
+  })
+
+  it('should return success with OK status', async () => {
+    const result = await removeTeamMemberHandler(mockContext)
+
+    expect(mockJson).toHaveBeenCalledWith({ success: true }, HttpStatus.OK)
+    expect(result.status).toBe(HttpStatus.OK)
+  })
+
+  it('should propagate error when removeTeamMember throws', async () => {
+    mockRemoveTeamMember.mockImplementation(async () => {
+      throw new Error('Member not found')
+    })
+
+    expect(removeTeamMemberHandler(mockContext)).rejects.toThrow('Member not found')
   })
 })
 

--- a/src/routes/user/teams/$id/members/$id/handler.ts
+++ b/src/routes/user/teams/$id/members/$id/handler.ts
@@ -2,6 +2,7 @@ import { HttpStatus } from '@/net/http'
 import {
   cancelMemberInvite,
   getTeamMember,
+  removeTeamMember,
   resendMemberInvite,
   updateTeamMember,
 } from '@/use-cases/user'
@@ -30,6 +31,14 @@ export const resendMemberInviteHandler = async (c: MemberIdCtx) => {
   const { id: inviterId } = c.get('user')
 
   const result = await resendMemberInvite(teamId, memberId, inviterId)
+
+  return c.json(result, HttpStatus.OK)
+}
+
+export const removeTeamMemberHandler = async (c: MemberIdCtx) => {
+  const { teamId, memberId } = c.req.valid('param')
+
+  const result = await removeTeamMember(teamId, memberId)
 
   return c.json(result, HttpStatus.OK)
 }

--- a/src/routes/user/teams/$id/members/$id/index.ts
+++ b/src/routes/user/teams/$id/members/$id/index.ts
@@ -7,6 +7,7 @@ import { requestValidator, teamAccessMiddleware } from '@/middleware'
 import {
   cancelMemberInviteHandler,
   getTeamMemberHandler,
+  removeTeamMemberHandler,
   resendMemberInviteHandler,
   updateTeamMemberHandler,
 } from './handler'
@@ -27,6 +28,13 @@ teamsMemberByIdRoute.patch(
   requestValidator('json', updateTeamMemberBodySchema),
   teamAccessMiddleware,
   updateTeamMemberHandler,
+)
+
+teamsMemberByIdRoute.delete(
+  '/',
+  requestValidator('param', memberIdParamsSchema),
+  teamAccessMiddleware,
+  removeTeamMemberHandler,
 )
 
 teamsMemberByIdRoute.post(

--- a/src/use-cases/user/__tests__/members.test.ts
+++ b/src/use-cases/user/__tests__/members.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import type { TeamMember } from '@/data'
+
+import { ModuleMocker, testUuids } from '@/__tests__'
+import AppError from '@/errors/app-error'
+import ErrorCode from '@/errors/codes'
+import { Status } from '@/types'
+
+import { removeTeamMember } from '../members'
+
+const { TEAM_1, USER_1 } = testUuids
+
+describe('removeTeamMember', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockMembership: TeamMember
+  let mockTeamRepoFindMember: any
+  let mockTeamRepoDeleteMember: any
+  let mockUserRepoUpdate: any
+  let mockTransaction: any
+
+  beforeEach(async () => {
+    mockMembership = {
+      id: 1,
+      userId: USER_1,
+      teamId: TEAM_1,
+      position: 'Developer',
+      invitedBy: null,
+      joinedAt: new Date('2024-01-01'),
+    }
+
+    mockTeamRepoFindMember = mock(async () => mockMembership)
+    mockTeamRepoDeleteMember = mock(async () => {})
+    mockUserRepoUpdate = mock(async () => {})
+    mockTransaction = mock(async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => {
+      return callback({})
+    })
+
+    await moduleMocker.mock('@/data', () => ({
+      teamRepo: {
+        findMember: mockTeamRepoFindMember,
+        deleteMember: mockTeamRepoDeleteMember,
+      },
+      userRepo: { update: mockUserRepoUpdate },
+      db: { transaction: mockTransaction },
+    }))
+
+    await moduleMocker.mock('@/types', () => ({ Status }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should throw NotFound when member is not in team', async () => {
+    mockTeamRepoFindMember.mockImplementation(async () => undefined)
+
+    expect(removeTeamMember(TEAM_1, USER_1)).rejects.toThrow(AppError)
+    expect(removeTeamMember(TEAM_1, USER_1)).rejects.toMatchObject({
+      code: ErrorCode.NotFound,
+      message: 'Member not found',
+    })
+  })
+
+  it('should delete membership row in transaction', async () => {
+    await removeTeamMember(TEAM_1, USER_1)
+
+    expect(mockTeamRepoDeleteMember).toHaveBeenCalledWith(USER_1, TEAM_1, expect.anything())
+  })
+
+  it('should archive user in transaction', async () => {
+    await removeTeamMember(TEAM_1, USER_1)
+
+    expect(mockUserRepoUpdate).toHaveBeenCalledWith(
+      USER_1,
+      { status: Status.Archived },
+      expect.anything(),
+    )
+  })
+
+  it('should run delete and archive atomically in one transaction', async () => {
+    await removeTeamMember(TEAM_1, USER_1)
+
+    expect(mockTransaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return success true', async () => {
+    const result = await removeTeamMember(TEAM_1, USER_1)
+
+    expect(result).toEqual({ success: true })
+  })
+})

--- a/src/use-cases/user/index.ts
+++ b/src/use-cases/user/index.ts
@@ -2,7 +2,7 @@ export { cancelMemberInvite, inviteMember, resendMemberInvite } from './invites'
 
 export { getUser, updateUser } from './me'
 
-export { getTeamMember, getTeamMembers, updateTeamMember } from './members'
+export { getTeamMember, getTeamMembers, removeTeamMember, updateTeamMember } from './members'
 
 export {
   getTeam,

--- a/src/use-cases/user/members.ts
+++ b/src/use-cases/user/members.ts
@@ -1,5 +1,6 @@
-import { teamRepo, userRepo } from '@/data'
+import { db, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
+import { Status } from '@/types'
 
 export const getTeamMembers = async (teamId: string) => {
   const members = await teamRepo.findMembers(teamId)
@@ -56,4 +57,19 @@ export const updateTeamMember = async (
   const member = await teamRepo.findMember(teamId, memberId)
 
   return { member }
+}
+
+export const removeTeamMember = async (teamId: string, memberId: string) => {
+  const existing = await teamRepo.findMember(teamId, memberId)
+
+  if (!existing) {
+    throw new AppError(ErrorCode.NotFound, 'Member not found')
+  }
+
+  await db.transaction(async (tx) => {
+    await teamRepo.deleteMember(memberId, teamId, tx)
+    await userRepo.update(memberId, { status: Status.Archived }, tx)
+  })
+
+  return { success: true }
 }


### PR DESCRIPTION
[Feature]: Add `DELETE /api/v1/user/teams/:teamId/members/:memberId` to hard-delete the membership row and archive the user atomically
[Feature]: Add `deleteTeamMember` repository mutation and expose it as `teamRepo.deleteMember`
[Feature]: Add `removeTeamMember` use-case with DB transaction ensuring both operations succeed or roll back together
[Feature]: Add unit tests for `removeTeamMemberHandler` covering happy path, argument forwarding, and error propagation
[Feature]: Add unit tests for `removeTeamMember` use-case covering 404 guard, transaction atomicity, and correct archival