### PR TITLE
Rename lastActiveAt to lastActive across repositories

### DIFF
--- a/src/data/repositories/refresh-token/queries.ts
+++ b/src/data/repositories/refresh-token/queries.ts
@@ -11,20 +11,20 @@ import { refreshTokensTable } from '../../schema'
  * derived from the most recent refresh token creation.
  *
  * @example
- * const lastActive = lastActiveAtSubquery(executor)
- * executor.select({ lastActiveAt: lastActive.lastActiveAt })
+ * const lastActiveSq = lastActiveSubquery(executor)
+ * executor.select({ lastActive: lastActiveSq.lastActive })
  *   .from(usersTable)
- *   .leftJoin(lastActive, eq(usersTable.id, lastActive.userId))
+ *   .leftJoin(lastActiveSq, eq(usersTable.id, lastActiveSq.userId))
  */
-export const lastActiveAtSubquery = (executor: Database) =>
+export const lastActiveSubquery = (executor: Database) =>
   executor
     .select({
       userId: refreshTokensTable.userId,
-      lastActiveAt: max(refreshTokensTable.createdAt).as('last_active_at'),
+      lastActive: max(refreshTokensTable.createdAt).as('last_active'),
     })
     .from(refreshTokensTable)
     .groupBy(refreshTokensTable.userId)
-    .as('last_active')
+    .as('last_active_subquery')
 
 export const findByTokenHash = async (
   tokenHash: string,

--- a/src/data/repositories/team/queries.ts
+++ b/src/data/repositories/team/queries.ts
@@ -8,7 +8,7 @@ import type { Team, TeamMemberDetails, TeamSearchParams, TeamSearchResult, TeamW
 import { db } from '../../clients'
 import { teamMembersTable, teamsTable, usersTable } from '../../schema'
 import { buildPagination, calcOffset } from '../pagination'
-import { lastActiveAtSubquery } from '../refresh-token/queries'
+import { lastActiveSubquery } from '../refresh-token/queries'
 
 const buildWhereConditions = ({ search }: TeamSearchParams) => {
   const conditions = []
@@ -82,7 +82,7 @@ export const findTeamMembers = async (
     whereConditions.push(eq(teamMembersTable.userId, userId))
   }
 
-  const lastActive = lastActiveAtSubquery(executor)
+  const lastActiveSq = lastActiveSubquery(executor)
 
   const rows = await executor
     .select({
@@ -93,7 +93,7 @@ export const findTeamMembers = async (
       status: usersTable.status,
       createdAt: usersTable.createdAt,
       updatedAt: usersTable.updatedAt,
-      lastActiveAt: lastActive.lastActiveAt,
+      lastActive: lastActiveSq.lastActive,
       position: teamMembersTable.position,
       joinedAt: teamMembersTable.joinedAt,
       inviter: {
@@ -105,7 +105,7 @@ export const findTeamMembers = async (
     .from(teamMembersTable)
     .innerJoin(usersTable, eq(teamMembersTable.userId, usersTable.id))
     .leftJoin(invitersTable, eq(teamMembersTable.invitedBy, invitersTable.id))
-    .leftJoin(lastActive, eq(teamMembersTable.userId, lastActive.userId))
+    .leftJoin(lastActiveSq, eq(teamMembersTable.userId, lastActiveSq.userId))
     .where(and(...whereConditions))
     .orderBy(desc(teamMembersTable.joinedAt))
 

--- a/src/data/repositories/team/types.ts
+++ b/src/data/repositories/team/types.ts
@@ -28,7 +28,7 @@ export interface TeamMemberDetails {
   status: string
   createdAt: Date
   updatedAt: Date
-  lastActiveAt: Date | null
+  lastActive: Date | null
   position: string | null
   inviter: TeamMemberInviter | null
   joinedAt: Date | null

--- a/src/data/repositories/user/queries.ts
+++ b/src/data/repositories/user/queries.ts
@@ -9,7 +9,7 @@ import type { SearchParams, SearchResult, User } from './types'
 import { db } from '../../clients'
 import { teamMembersTable, teamsTable, userRoleTable, usersTable } from '../../schema'
 import { buildPagination, calcOffset } from '../pagination'
-import { lastActiveAtSubquery } from '../refresh-token/queries'
+import { lastActiveSubquery } from '../refresh-token/queries'
 
 const selectUserWithRole = (executor: Database) =>
   executor
@@ -27,7 +27,7 @@ const selectUserWithRole = (executor: Database) =>
     .leftJoin(userRoleTable, eq(usersTable.id, userRoleTable.userId))
 
 const selectUserWithRoleAndTeam = (executor: Database) => {
-  const lastActive = lastActiveAtSubquery(executor)
+  const lastActiveSq = lastActiveSubquery(executor)
 
   return executor
     .select({
@@ -38,7 +38,7 @@ const selectUserWithRoleAndTeam = (executor: Database) => {
       status: usersTable.status,
       createdAt: usersTable.createdAt,
       updatedAt: usersTable.updatedAt,
-      lastActiveAt: lastActive.lastActiveAt,
+      lastActive: lastActiveSq.lastActive,
       role: sql<Role>`COALESCE(${userRoleTable.role}, ${Role.User})`,
       team: {
         id: teamsTable.id,
@@ -49,7 +49,7 @@ const selectUserWithRoleAndTeam = (executor: Database) => {
     .leftJoin(userRoleTable, eq(usersTable.id, userRoleTable.userId))
     .leftJoin(teamMembersTable, eq(usersTable.id, teamMembersTable.userId))
     .leftJoin(teamsTable, eq(teamMembersTable.teamId, teamsTable.id))
-    .leftJoin(lastActive, eq(usersTable.id, lastActive.userId))
+    .leftJoin(lastActiveSq, eq(usersTable.id, lastActiveSq.userId))
 }
 
 const findUserBy = async (

--- a/src/data/repositories/user/types.ts
+++ b/src/data/repositories/user/types.ts
@@ -18,7 +18,7 @@ export interface TeamInfo {
 // Public-facing / API-return type
 export type User = UserRecord & {
   role: Role
-  lastActiveAt?: Date | null
+  lastActive?: Date | null
   team?: TeamInfo
 }
 


### PR DESCRIPTION
[Improvement]: Drop the `At` suffix from `lastActiveAt` fields in user and team types, making the property name consistent with the column alias `last_active`
[Improvement]: Rename `lastActiveAtSubquery` to `lastActiveSubquery` and use `lastActiveSq` as the local variable to avoid the repetitive `lastActive.lastActive` pattern
[Improvement]: Change SQL subquery alias from `last_active` to `last_active_subquery` to distinguish it from the column alias `last_active`