### PR TITLE
Rename user query helpers to abstract suffixes

### DIFF
--- a/src/data/repositories/user/index.ts
+++ b/src/data/repositories/user/index.ts
@@ -1,5 +1,5 @@
 import { createUser, updateUser } from './mutations'
-import { findUserByEmail, findUserById, findUserByIdWithTeam, search } from './queries'
+import { findUserByEmail, findUserById, findUserByIdExtended, search } from './queries'
 
 export * from './types'
 
@@ -7,7 +7,7 @@ export const userRepo = {
   create: createUser,
   findByEmail: findUserByEmail,
   findById: findUserById,
-  findByIdWithTeam: findUserByIdWithTeam,
+  findByIdExtended: findUserByIdExtended,
   search,
   update: updateUser,
 }

--- a/src/data/repositories/user/queries.ts
+++ b/src/data/repositories/user/queries.ts
@@ -11,7 +11,7 @@ import { teamMembersTable, teamsTable, userRoleTable, usersTable } from '../../s
 import { buildPagination, calcOffset } from '../pagination'
 import { lastActiveSubquery } from '../refresh-token/queries'
 
-const selectUserWithRole = (executor: Database) =>
+const selectUserBase = (executor: Database) =>
   executor
     .select({
       id: usersTable.id,
@@ -26,7 +26,7 @@ const selectUserWithRole = (executor: Database) =>
     .from(usersTable)
     .leftJoin(userRoleTable, eq(usersTable.id, userRoleTable.userId))
 
-const selectUserWithRoleAndTeam = (executor: Database) => {
+const selectUserExtended = (executor: Database) => {
   const lastActiveSq = lastActiveSubquery(executor)
 
   return executor
@@ -58,7 +58,7 @@ const findUserBy = async (
 ): Promise<User | undefined> => {
   const executor = tx || db
 
-  const [row] = await selectUserWithRole(executor).where(condition)
+  const [row] = await selectUserBase(executor).where(condition)
 
   return row
 }
@@ -66,13 +66,13 @@ const findUserBy = async (
 export const findUserById = async (userId: string, tx?: Database) =>
   findUserBy(eq(usersTable.id, userId), tx)
 
-export const findUserByIdWithTeam = async (
+export const findUserByIdExtended = async (
   userId: string,
   tx?: Database,
 ): Promise<User | undefined> => {
   const executor = tx || db
 
-  const [row] = await selectUserWithRoleAndTeam(executor).where(eq(usersTable.id, userId))
+  const [row] = await selectUserExtended(executor).where(eq(usersTable.id, userId))
 
   if (!row) {
     return undefined
@@ -130,7 +130,7 @@ export const search = async (
 ): Promise<SearchResult> => {
   const executor = tx || db
 
-  const searchQuery = selectUserWithRoleAndTeam(executor)
+  const searchQuery = selectUserExtended(executor)
 
   const countQuery = executor
     .select({ value: count() })

--- a/src/use-cases/admin/__tests__/users.test.ts
+++ b/src/use-cases/admin/__tests__/users.test.ts
@@ -89,7 +89,7 @@ describe('getUser', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
   let mockUser: User
-  let mockFindByIdWithTeam: any
+  let mockFindByIdExtended: any
 
   beforeEach(async () => {
     mockUser = {
@@ -103,10 +103,10 @@ describe('getUser', () => {
       updatedAt: new Date('2024-01-01'),
     }
 
-    mockFindByIdWithTeam = mock(async () => mockUser)
+    mockFindByIdExtended = mock(async () => mockUser)
 
     await moduleMocker.mock('@/data', () => ({
-      userRepo: { findByIdWithTeam: mockFindByIdWithTeam },
+      userRepo: { findByIdExtended: mockFindByIdExtended },
     }))
   })
 
@@ -117,12 +117,12 @@ describe('getUser', () => {
   it('should return user when found', async () => {
     const result = await getUser(testUuids.USER_1)
 
-    expect(mockFindByIdWithTeam).toHaveBeenCalledWith(testUuids.USER_1)
+    expect(mockFindByIdExtended).toHaveBeenCalledWith(testUuids.USER_1)
     expect(result).toEqual({ user: mockUser })
   })
 
   it('should throw NotFound error when user does not exist', async () => {
-    mockFindByIdWithTeam.mockImplementation(async () => undefined)
+    mockFindByIdExtended.mockImplementation(async () => undefined)
 
     expect(getUser(testUuids.NON_EXISTENT)).rejects.toThrow(AppError)
     expect(getUser(testUuids.NON_EXISTENT)).rejects.toMatchObject({

--- a/src/use-cases/admin/users.ts
+++ b/src/use-cases/admin/users.ts
@@ -31,7 +31,7 @@ export const searchUsers = async (params: SearchParams, pagination: PaginationPa
 }
 
 export const getUser = async (userId: string) => {
-  const user = await userRepo.findByIdWithTeam(userId)
+  const user = await userRepo.findByIdExtended(userId)
 
   if (!user || !isUser(user.role)) {
     throw new AppError(ErrorCode.NotFound, 'User not found')

--- a/src/use-cases/owner/admins/__tests__/admins.test.ts
+++ b/src/use-cases/owner/admins/__tests__/admins.test.ts
@@ -101,7 +101,7 @@ describe('getAdmin', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
 
   let mockAdmin: User
-  let mockFindById: any
+  let mockFindByIdExtended: any
   let mockFindInvites: any
 
   beforeEach(async () => {
@@ -116,11 +116,11 @@ describe('getAdmin', () => {
       updatedAt: new Date('2024-01-01'),
     }
 
-    mockFindById = mock(async () => mockAdmin)
+    mockFindByIdExtended = mock(async () => mockAdmin)
     mockFindInvites = mock(async () => new Map())
 
     await moduleMocker.mock('@/data', () => ({
-      userRepo: { findById: mockFindById },
+      userRepo: { findByIdExtended: mockFindByIdExtended },
       rbacRepo: { findInviters: mockFindInvites },
     }))
   })
@@ -132,7 +132,7 @@ describe('getAdmin', () => {
   it('should return admin when found', async () => {
     const result = await getAdmin(testUuids.ADMIN_1)
 
-    expect(mockFindById).toHaveBeenCalledWith(testUuids.ADMIN_1)
+    expect(mockFindByIdExtended).toHaveBeenCalledWith(testUuids.ADMIN_1)
     expect(result).toEqual({ admin: { ...mockAdmin, inviter: undefined } })
   })
 
@@ -153,7 +153,7 @@ describe('getAdmin', () => {
   })
 
   it('should throw NotFound error when admin does not exist', async () => {
-    mockFindById.mockImplementation(async () => undefined)
+    mockFindByIdExtended.mockImplementation(async () => undefined)
 
     expect(getAdmin(testUuids.NON_EXISTENT)).rejects.toThrow(AppError)
     expect(getAdmin(testUuids.NON_EXISTENT)).rejects.toMatchObject({
@@ -163,7 +163,7 @@ describe('getAdmin', () => {
   })
 
   it('should throw NotFound error when user is not an Admin role', async () => {
-    mockFindById.mockImplementation(async () => ({
+    mockFindByIdExtended.mockImplementation(async () => ({
       ...mockAdmin,
       role: Role.User,
     }))
@@ -176,7 +176,7 @@ describe('getAdmin', () => {
   })
 
   it('should throw NotFound error when user is Owner role', async () => {
-    mockFindById.mockImplementation(async () => ({
+    mockFindByIdExtended.mockImplementation(async () => ({
       ...mockAdmin,
       role: Role.Owner,
     }))

--- a/src/use-cases/owner/admins/admins.ts
+++ b/src/use-cases/owner/admins/admins.ts
@@ -28,7 +28,7 @@ export const getAdmins = async (params: SearchParams, pagination: PaginationPara
 }
 
 export const getAdmin = async (adminId: string) => {
-  const admin = await userRepo.findById(adminId)
+  const admin = await userRepo.findByIdExtended(adminId)
 
   if (!admin || admin.role !== Role.Admin) {
     throw new AppError(ErrorCode.NotFound, 'Admin not found')


### PR DESCRIPTION
[Improvement]: Rename \`selectUserWithRole\` → \`selectUserBase\` and \`selectUserWithRoleAndTeam\` → \`selectUserExtended\` to use stable, abstract suffixes that won't require renaming as more fields are added
[Improvement]: Rename \`findByIdWithTeam\` → \`findByIdExtended\` on \`userRepo\` and update all call sites in admin and owner use cases
[Fix]: Update test mocks in \`users.test.ts\` and \`admins.test.ts\` to reference the renamed \`findByIdExtended\` repo method