### PR TITLE
Add PATCH /api/v1/user/me/password endpoint

### DIFF
--- a/src/data/repositories/refresh-token/index.ts
+++ b/src/data/repositories/refresh-token/index.ts
@@ -2,6 +2,7 @@ import {
   cleanupExpiredTokens,
   createRefreshToken,
   revokeByHash,
+  revokeByUserId,
 } from './mutations'
 import { findByTokenHash } from './queries'
 
@@ -10,6 +11,7 @@ export * from './types'
 export const refreshTokenRepo = {
   create: createRefreshToken,
   revokeByHash,
+  revokeByUserId,
   cleanupExpired: cleanupExpiredTokens,
   findByHash: findByTokenHash,
 }

--- a/src/data/repositories/refresh-token/mutations.ts
+++ b/src/data/repositories/refresh-token/mutations.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, lt } from 'drizzle-orm'
+import { and, eq, isNull, lt, ne } from 'drizzle-orm'
 
 import type { Database } from '../../clients'
 import type { CreateRefreshTokenInput } from './types'
@@ -38,6 +38,31 @@ export const revokeByHash = async (
     .returning({ id: refreshTokensTable.id })
 
   return result.length > 0
+}
+
+/**
+ * @param userId - the user whose tokens to revoke
+ * @param excludeHash - token hash to exclude from revocation,
+ *   used to preserve the current session on updating password
+ * @param tx - optional transaction
+ */
+export const revokeByUserId = async (
+  userId: string,
+  excludeHash?: string,
+  tx?: Database,
+): Promise<void> => {
+  const executor = tx || db
+
+  await executor
+    .update(refreshTokensTable)
+    .set({ revokedAt: new Date() })
+    .where(
+      and(
+        eq(refreshTokensTable.userId, userId),
+        isNull(refreshTokensTable.revokedAt),
+        ...(excludeHash ? [ne(refreshTokensTable.tokenHash, excludeHash)] : []),
+      ),
+    )
 }
 
 // Scheduled cleanup job — see https://github.com/SlavaMelanko/smela-back/issues/118

--- a/src/routes/user/me/__tests__/handler.test.ts
+++ b/src/routes/user/me/__tests__/handler.test.ts
@@ -123,6 +123,7 @@ describe('changePasswordHandler', () => {
   let mockContext: any
   let mockBody: any
   let mockChangePassword: any
+  let mockGetRefreshCookie: any
 
   beforeEach(async () => {
     mockBody = { currentPassword: 'OldPass1!', newPassword: 'NewPass1!' }
@@ -130,13 +131,18 @@ describe('changePasswordHandler', () => {
     mockContext = {
       get: mock(() => ({ id: testUuids.USER_1 })),
       req: { valid: mock((): typeof mockBody => mockBody) },
-      body: mock(() => null),
+      json: mock((data: any) => ({ data })),
     }
 
-    mockChangePassword = mock(async () => undefined)
+    mockChangePassword = mock(async () => ({ success: true }))
+    mockGetRefreshCookie = mock(() => 'raw-refresh-token')
 
     await moduleMocker.mock('@/use-cases/user/me', () => ({
       changePassword: mockChangePassword,
+    }))
+
+    await moduleMocker.mock('@/net/http/cookie/refresh-token', () => ({
+      getRefreshCookie: mockGetRefreshCookie,
     }))
   })
 
@@ -144,20 +150,22 @@ describe('changePasswordHandler', () => {
     await moduleMocker.clear()
   })
 
-  it('should call changePassword with user id and passwords from body', async () => {
+  it('should call changePassword with user id, passwords, and refresh token', async () => {
     await changePasswordHandler(mockContext)
 
+    expect(mockGetRefreshCookie).toHaveBeenCalledWith(mockContext)
     expect(mockChangePassword).toHaveBeenCalledWith(
       testUuids.USER_1,
       'OldPass1!',
       'NewPass1!',
+      'raw-refresh-token',
     )
   })
 
-  it('should return 204 No Content on success', async () => {
+  it('should return success response', async () => {
     await changePasswordHandler(mockContext)
 
-    expect(mockContext.body).toHaveBeenCalledWith(null, 204)
+    expect(mockContext.json).toHaveBeenCalledWith({ success: true })
   })
 
   it('should propagate InvalidCredentials error', async () => {

--- a/src/routes/user/me/__tests__/handler.test.ts
+++ b/src/routes/user/me/__tests__/handler.test.ts
@@ -3,9 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { User } from '@/data'
 
 import { ModuleMocker, testUuids } from '@/__tests__'
+import { AppError, ErrorCode } from '@/errors'
 import { Role, Status } from '@/types'
 
-import { getMeHandler, updateMeHandler } from '../handler'
+import { changePasswordHandler, getMeHandler, updateMeHandler } from '../handler'
 
 const mockUser: User = {
   id: testUuids.USER_1,
@@ -113,5 +114,59 @@ describe('updateMeHandler', () => {
     })
 
     expect(updateMeHandler(mockContext)).rejects.toThrow('Update failed')
+  })
+})
+
+describe('changePasswordHandler', () => {
+  const moduleMocker = new ModuleMocker(import.meta.url)
+
+  let mockContext: any
+  let mockBody: any
+  let mockChangePassword: any
+
+  beforeEach(async () => {
+    mockBody = { currentPassword: 'OldPass1!', newPassword: 'NewPass1!' }
+
+    mockContext = {
+      get: mock(() => ({ id: testUuids.USER_1 })),
+      req: { valid: mock((): typeof mockBody => mockBody) },
+      body: mock(() => null),
+    }
+
+    mockChangePassword = mock(async () => undefined)
+
+    await moduleMocker.mock('@/use-cases/user/me', () => ({
+      changePassword: mockChangePassword,
+    }))
+  })
+
+  afterEach(async () => {
+    await moduleMocker.clear()
+  })
+
+  it('should call changePassword with user id and passwords from body', async () => {
+    await changePasswordHandler(mockContext)
+
+    expect(mockChangePassword).toHaveBeenCalledWith(
+      testUuids.USER_1,
+      'OldPass1!',
+      'NewPass1!',
+    )
+  })
+
+  it('should return 204 No Content on success', async () => {
+    await changePasswordHandler(mockContext)
+
+    expect(mockContext.body).toHaveBeenCalledWith(null, 204)
+  })
+
+  it('should propagate InvalidCredentials error', async () => {
+    mockChangePassword.mockImplementation(async () => {
+      throw new AppError(ErrorCode.InvalidCredentials)
+    })
+
+    expect(changePasswordHandler(mockContext)).rejects.toMatchObject({
+      code: ErrorCode.InvalidCredentials,
+    })
   })
 })

--- a/src/routes/user/me/handler.ts
+++ b/src/routes/user/me/handler.ts
@@ -1,7 +1,7 @@
-import { getUser, updateUser } from '@/use-cases/user/me'
+import { changePassword, getUser, updateUser } from '@/use-cases/user/me'
 
 import type { AppCtx } from '../../@shared'
-import type { UpdateProfileCtx } from './schema'
+import type { ChangePasswordCtx, UpdateProfileCtx } from './schema'
 
 export const getMeHandler = async (c: AppCtx) => {
   const user = c.get('user')
@@ -18,4 +18,13 @@ export const updateMeHandler = async (c: UpdateProfileCtx) => {
   const result = await updateUser(user.id, body)
 
   return c.json(result)
+}
+
+export const changePasswordHandler = async (c: ChangePasswordCtx) => {
+  const user = c.get('user')
+  const { currentPassword, newPassword } = c.req.valid('json')
+
+  await changePassword(user.id, currentPassword, newPassword)
+
+  return c.body(null, 204)
 }

--- a/src/routes/user/me/handler.ts
+++ b/src/routes/user/me/handler.ts
@@ -1,3 +1,4 @@
+import { getRefreshCookie } from '@/net/http/cookie/refresh-token'
 import { changePassword, getUser, updateUser } from '@/use-cases/user/me'
 
 import type { AppCtx } from '../../@shared'
@@ -23,8 +24,9 @@ export const updateMeHandler = async (c: UpdateProfileCtx) => {
 export const changePasswordHandler = async (c: ChangePasswordCtx) => {
   const user = c.get('user')
   const { currentPassword, newPassword } = c.req.valid('json')
+  const refreshToken = getRefreshCookie(c)
 
-  await changePassword(user.id, currentPassword, newPassword)
+  const result = await changePassword(user.id, currentPassword, newPassword, refreshToken)
 
-  return c.body(null, 204)
+  return c.json(result)
 }

--- a/src/routes/user/me/index.ts
+++ b/src/routes/user/me/index.ts
@@ -4,11 +4,13 @@ import type { AppContext } from '@/context'
 
 import { requestValidator } from '@/middleware'
 
-import { getMeHandler, updateMeHandler } from './handler'
-import updateProfileSchema from './schema'
+import { changePasswordHandler, getMeHandler, updateMeHandler } from './handler'
+import { changePasswordSchema, updateProfileSchema } from './schema'
 
 export const meRoute = new Hono<AppContext>()
 
 meRoute.get('/me', getMeHandler)
 
 meRoute.patch('/me', requestValidator('json', updateProfileSchema), updateMeHandler)
+
+meRoute.patch('/me/password', requestValidator('json', changePasswordSchema), changePasswordHandler)

--- a/src/routes/user/me/schema.ts
+++ b/src/routes/user/me/schema.ts
@@ -4,7 +4,7 @@ import type { ValidatedJsonCtx } from '../../@shared'
 
 import { requestValidationRules as rules } from '../../@shared'
 
-const updateProfileSchema = z.object({
+export const updateProfileSchema = z.object({
   firstName: rules.data.firstName.optional(),
   lastName: rules.data.lastName.optional(),
 }).strict()
@@ -12,4 +12,10 @@ const updateProfileSchema = z.object({
 export type UpdateProfileBody = z.infer<typeof updateProfileSchema>
 export type UpdateProfileCtx = ValidatedJsonCtx<UpdateProfileBody>
 
-export default updateProfileSchema
+export const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1),
+  newPassword: rules.data.password,
+}).strict()
+
+export type ChangePasswordBody = z.infer<typeof changePasswordSchema>
+export type ChangePasswordCtx = ValidatedJsonCtx<ChangePasswordBody>

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -91,19 +91,26 @@ describe('User Me Use Cases', () => {
 
   describe('changePassword', () => {
     let mockAuthRepo: any
+    let mockRefreshTokenRepo: any
     let mockComparePasswordHashes: any
     let mockHashPassword: any
+    let mockHashToken: any
 
     beforeEach(async () => {
       mockAuthRepo = {
         findById: mock(async () => ({ passwordHash: 'hashed' })),
         update: mock(async () => undefined),
       }
+      mockRefreshTokenRepo = {
+        revokeByUserId: mock(async () => undefined),
+      }
       mockComparePasswordHashes = mock(async () => true)
       mockHashPassword = mock(async () => 'new-hashed')
+      mockHashToken = mock(async () => 'hashed-token')
 
       await moduleMocker.mock('@/data', () => ({
         authRepo: mockAuthRepo,
+        refreshTokenRepo: mockRefreshTokenRepo,
         userRepo: mockUserRepo,
         teamRepo: mockTeamRepo,
       }))
@@ -112,15 +119,34 @@ describe('User Me Use Cases', () => {
         comparePasswordHashes: mockComparePasswordHashes,
         hashPassword: mockHashPassword,
       }))
+
+      await moduleMocker.mock('@/security/token', () => ({
+        hashToken: mockHashToken,
+      }))
     })
 
-    it('should update passwordHash when current password is valid', async () => {
-      await changePassword(testUuids.USER_1, 'OldPass1!', 'NewPass1!')
+    it('should update passwordHash and return success when current password is valid', async () => {
+      const result = await changePassword(testUuids.USER_1, 'OldPass1!', 'NewPass1!')
 
+      expect(result).toEqual({ success: true })
       expect(mockAuthRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
       expect(mockComparePasswordHashes).toHaveBeenCalledWith('OldPass1!', 'hashed')
       expect(mockHashPassword).toHaveBeenCalledWith('NewPass1!')
       expect(mockAuthRepo.update).toHaveBeenCalledWith(testUuids.USER_1, { passwordHash: 'new-hashed' })
+    })
+
+    it('should revoke other sessions excluding current refresh token', async () => {
+      await changePassword(testUuids.USER_1, 'OldPass1!', 'NewPass1!', 'raw-token')
+
+      expect(mockHashToken).toHaveBeenCalledWith('raw-token')
+      expect(mockRefreshTokenRepo.revokeByUserId).toHaveBeenCalledWith(testUuids.USER_1, 'hashed-token')
+    })
+
+    it('should revoke all sessions when no refresh token provided', async () => {
+      await changePassword(testUuids.USER_1, 'OldPass1!', 'NewPass1!')
+
+      expect(mockHashToken).not.toHaveBeenCalled()
+      expect(mockRefreshTokenRepo.revokeByUserId).toHaveBeenCalledWith(testUuids.USER_1, undefined)
     })
 
     it('should throw InvalidCredentials when auth record is not found', async () => {

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -6,7 +6,7 @@ import { ModuleMocker, testUuids } from '@/__tests__'
 import { AppError, ErrorCode } from '@/errors'
 import { Role, Status } from '@/types'
 
-import { getUser, updateUser } from '../me'
+import { changePassword, getUser, updateUser } from '../me'
 
 describe('User Me Use Cases', () => {
   const moduleMocker = new ModuleMocker(import.meta.url)
@@ -85,6 +85,65 @@ describe('User Me Use Cases', () => {
       expect(getUser(testUuids.NON_EXISTENT)).rejects.toThrow(AppError)
       expect(getUser(testUuids.NON_EXISTENT)).rejects.toMatchObject({
         code: ErrorCode.InternalError,
+      })
+    })
+  })
+
+  describe('changePassword', () => {
+    let mockAuthRepo: any
+    let mockComparePasswordHashes: any
+    let mockHashPassword: any
+
+    beforeEach(async () => {
+      mockAuthRepo = {
+        findById: mock(async () => ({ passwordHash: 'hashed' })),
+        update: mock(async () => undefined),
+      }
+      mockComparePasswordHashes = mock(async () => true)
+      mockHashPassword = mock(async () => 'new-hashed')
+
+      await moduleMocker.mock('@/data', () => ({
+        authRepo: mockAuthRepo,
+        userRepo: mockUserRepo,
+        teamRepo: mockTeamRepo,
+      }))
+
+      await moduleMocker.mock('@/security/password', () => ({
+        comparePasswordHashes: mockComparePasswordHashes,
+        hashPassword: mockHashPassword,
+      }))
+    })
+
+    it('should update passwordHash when current password is valid', async () => {
+      await changePassword(testUuids.USER_1, 'OldPass1!', 'NewPass1!')
+
+      expect(mockAuthRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
+      expect(mockComparePasswordHashes).toHaveBeenCalledWith('OldPass1!', 'hashed')
+      expect(mockHashPassword).toHaveBeenCalledWith('NewPass1!')
+      expect(mockAuthRepo.update).toHaveBeenCalledWith(testUuids.USER_1, { passwordHash: 'new-hashed' })
+    })
+
+    it('should throw InvalidCredentials when auth record is not found', async () => {
+      mockAuthRepo.findById.mockImplementation(async () => null)
+
+      expect(changePassword(testUuids.USER_1, 'OldPass1!', 'NewPass1!')).rejects.toMatchObject({
+        code: ErrorCode.InvalidCredentials,
+      })
+    })
+
+    it('should throw InvalidCredentials when auth has no passwordHash', async () => {
+      mockAuthRepo.findById.mockImplementation(async () => ({ passwordHash: null }))
+
+      expect(changePassword(testUuids.USER_1, 'OldPass1!', 'NewPass1!')).rejects.toMatchObject({
+        code: ErrorCode.InvalidCredentials,
+      })
+    })
+
+    it('should throw InvalidCredentials when current password does not match', async () => {
+      mockComparePasswordHashes.mockImplementation(async () => false)
+
+      expect(changePassword(testUuids.USER_1, 'WrongPass1!', 'NewPass1!')).rejects.toMatchObject({
+        code: ErrorCode.InvalidCredentials,
       })
     })
   })

--- a/src/use-cases/user/__tests__/me.test.ts
+++ b/src/use-cases/user/__tests__/me.test.ts
@@ -113,6 +113,9 @@ describe('User Me Use Cases', () => {
         refreshTokenRepo: mockRefreshTokenRepo,
         userRepo: mockUserRepo,
         teamRepo: mockTeamRepo,
+        db: {
+          transaction: mock(async (callback: any) => callback({}) as Promise<void>),
+        },
       }))
 
       await moduleMocker.mock('@/security/password', () => ({
@@ -132,21 +135,25 @@ describe('User Me Use Cases', () => {
       expect(mockAuthRepo.findById).toHaveBeenCalledWith(testUuids.USER_1)
       expect(mockComparePasswordHashes).toHaveBeenCalledWith('OldPass1!', 'hashed')
       expect(mockHashPassword).toHaveBeenCalledWith('NewPass1!')
-      expect(mockAuthRepo.update).toHaveBeenCalledWith(testUuids.USER_1, { passwordHash: 'new-hashed' })
+      expect(mockAuthRepo.update).toHaveBeenCalledWith(testUuids.USER_1, { passwordHash: 'new-hashed' }, {})
     })
 
     it('should revoke other sessions excluding current refresh token', async () => {
       await changePassword(testUuids.USER_1, 'OldPass1!', 'NewPass1!', 'raw-token')
 
       expect(mockHashToken).toHaveBeenCalledWith('raw-token')
-      expect(mockRefreshTokenRepo.revokeByUserId).toHaveBeenCalledWith(testUuids.USER_1, 'hashed-token')
+      expect(mockRefreshTokenRepo.revokeByUserId).toHaveBeenCalledWith(testUuids.USER_1, 'hashed-token', {})
     })
 
     it('should revoke all sessions when no refresh token provided', async () => {
       await changePassword(testUuids.USER_1, 'OldPass1!', 'NewPass1!')
 
       expect(mockHashToken).not.toHaveBeenCalled()
-      expect(mockRefreshTokenRepo.revokeByUserId).toHaveBeenCalledWith(testUuids.USER_1, undefined)
+      expect(mockRefreshTokenRepo.revokeByUserId).toHaveBeenCalledWith(
+        testUuids.USER_1,
+        undefined,
+        {},
+      )
     })
 
     it('should throw InvalidCredentials when auth record is not found', async () => {

--- a/src/use-cases/user/index.ts
+++ b/src/use-cases/user/index.ts
@@ -1,6 +1,6 @@
 export { cancelMemberInvite, inviteMember, resendMemberInvite } from './invites'
 
-export { getUser, updateUser } from './me'
+export { changePassword, getUser, updateUser } from './me'
 
 export { getTeamMember, getTeamMembers, removeTeamMember, updateTeamMember } from './members'
 

--- a/src/use-cases/user/me.ts
+++ b/src/use-cases/user/me.ts
@@ -1,6 +1,6 @@
 import type { UpdateUserInput } from '@/data'
 
-import { authRepo, refreshTokenRepo, teamRepo, userRepo } from '@/data'
+import { authRepo, db, refreshTokenRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { comparePasswordHashes, hashPassword } from '@/security/password'
 import { hashToken } from '@/security/token'
@@ -48,10 +48,12 @@ export const changePassword = async (
   }
 
   const passwordHash = await hashPassword(newPassword)
-  await authRepo.update(userId, { passwordHash })
-
   const excludeHash = refreshToken ? await hashToken(refreshToken) : undefined
-  await refreshTokenRepo.revokeByUserId(userId, excludeHash)
+
+  await db.transaction(async (tx) => {
+    await authRepo.update(userId, { passwordHash }, tx)
+    await refreshTokenRepo.revokeByUserId(userId, excludeHash, tx)
+  })
 
   return { success: true }
 }

--- a/src/use-cases/user/me.ts
+++ b/src/use-cases/user/me.ts
@@ -1,8 +1,9 @@
 import type { UpdateUserInput } from '@/data'
 
-import { authRepo, teamRepo, userRepo } from '@/data'
+import { authRepo, refreshTokenRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { comparePasswordHashes, hashPassword } from '@/security/password'
+import { hashToken } from '@/security/token'
 
 import { resolvePermissionList } from '../resolve-permissions'
 
@@ -32,6 +33,7 @@ export const changePassword = async (
   userId: string,
   currentPassword: string,
   newPassword: string,
+  refreshToken?: string,
 ) => {
   const auth = await authRepo.findById(userId)
 
@@ -46,8 +48,12 @@ export const changePassword = async (
   }
 
   const passwordHash = await hashPassword(newPassword)
-
   await authRepo.update(userId, { passwordHash })
+
+  const excludeHash = refreshToken ? await hashToken(refreshToken) : undefined
+  await refreshTokenRepo.revokeByUserId(userId, excludeHash)
+
+  return { success: true }
 }
 
 export const updateUser = async (userId: string, updates: UpdateUserInput) => {

--- a/src/use-cases/user/me.ts
+++ b/src/use-cases/user/me.ts
@@ -1,7 +1,8 @@
 import type { UpdateUserInput } from '@/data'
 
-import { teamRepo, userRepo } from '@/data'
+import { authRepo, teamRepo, userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
+import { comparePasswordHashes, hashPassword } from '@/security/password'
 
 import { resolvePermissionList } from '../resolve-permissions'
 
@@ -25,6 +26,28 @@ export const getUser = async (userId: string) => {
   }
 
   return { user, team, permissions }
+}
+
+export const changePassword = async (
+  userId: string,
+  currentPassword: string,
+  newPassword: string,
+) => {
+  const auth = await authRepo.findById(userId)
+
+  if (!auth || !auth.passwordHash) {
+    throw new AppError(ErrorCode.InvalidCredentials)
+  }
+
+  const isValid = await comparePasswordHashes(currentPassword, auth.passwordHash)
+
+  if (!isValid) {
+    throw new AppError(ErrorCode.InvalidCredentials)
+  }
+
+  const passwordHash = await hashPassword(newPassword)
+
+  await authRepo.update(userId, { passwordHash })
 }
 
 export const updateUser = async (userId: string, updates: UpdateUserInput) => {


### PR DESCRIPTION
[Feature]: Add `PATCH /api/v1/user/me/password` endpoint to allow authenticated users to change their password
[Security]: Revoke all other active refresh tokens on password change, preserving the current session
[Feature]: Add `revokeByUserId` mutation to soft-delete all refresh tokens for a user, with optional exclusion by hash
[Improvement]: Wrap password update and token revocation in a transaction to ensure atomicity
[Improvement]: `changePassword` returns `{ success: true }` and accepts current refresh token for session preservation