### PR TITLE
Apply .strict() to all body schemas consistently

### DIFF
--- a/src/routes/admin/teams/schema.ts
+++ b/src/routes/admin/teams/schema.ts
@@ -16,7 +16,7 @@ export const createTeamBodySchema = z.object({
   name: rules.team.name,
   website: rules.team.website,
   description: rules.team.description.optional(),
-})
+}).strict()
 
 export type CreateTeamBody = z.infer<typeof createTeamBodySchema>
 export type CreateTeamCtx = ValidatedJsonCtx<CreateTeamBody>

--- a/src/routes/auth/request-password-reset/schema.ts
+++ b/src/routes/auth/request-password-reset/schema.ts
@@ -12,7 +12,7 @@ export const requestPasswordResetSchema = z.object({
   preferences: z.object({
     locale: rules.preferences.locale,
     theme: rules.preferences.theme,
-  }).optional(),
+  }).strict().optional(),
 }).strict()
 
 export type RequestPasswordResetBody = z.infer<typeof requestPasswordResetSchema>

--- a/src/routes/auth/resend-verification-email/schema.ts
+++ b/src/routes/auth/resend-verification-email/schema.ts
@@ -12,7 +12,7 @@ export const resendVerificationEmailSchema = z.object({
   preferences: z.object({
     locale: rules.preferences.locale,
     theme: rules.preferences.theme,
-  }).optional(),
+  }).strict().optional(),
 }).strict()
 
 export type ResendVerificationEmailBody = z.infer<typeof resendVerificationEmailSchema>

--- a/src/routes/auth/signup/schema.ts
+++ b/src/routes/auth/signup/schema.ts
@@ -15,7 +15,7 @@ export const signupSchema = z.object({
   preferences: z.object({
     locale: rules.preferences.locale,
     theme: rules.preferences.theme,
-  }).optional(),
+  }).strict().optional(),
 }).strict()
 
 export type SignupBody = z.infer<typeof signupSchema>

--- a/src/routes/owner/admins/$id/permissions/schema.ts
+++ b/src/routes/owner/admins/$id/permissions/schema.ts
@@ -4,14 +4,16 @@ import type { ValidatedParamCtx, ValidatedParamJsonCtx } from '@/routes/validate
 
 import { rules } from '@/routes/rules'
 
-const adminIdParamsSchema = z.object({
+export const adminIdParamsSchema = z.object({
   adminId: rules.user.id,
 })
 
 export type GetAdminPermissionsParams = z.infer<typeof adminIdParamsSchema>
 export type GetAdminPermissionsCtx = ValidatedParamCtx<GetAdminPermissionsParams>
 
-export const updateAdminPermissionsBodySchema = z.object({ permissions: rules.permissions })
+export const updateAdminPermissionsBodySchema = z.object({
+  permissions: rules.permissions,
+}).strict()
 
 export type UpdateAdminPermissionsParams = z.infer<typeof adminIdParamsSchema>
 export type UpdateAdminPermissionsBody = z.infer<typeof updateAdminPermissionsBodySchema>
@@ -19,5 +21,3 @@ export type UpdateAdminPermissionsCtx = ValidatedParamJsonCtx<
   UpdateAdminPermissionsParams,
   UpdateAdminPermissionsBody
 >
-
-export { adminIdParamsSchema }

--- a/src/routes/owner/admins/schema.ts
+++ b/src/routes/owner/admins/schema.ts
@@ -18,7 +18,7 @@ export const createAdminBodySchema = z.object({
   lastName: rules.user.lastName.optional(),
   email: rules.user.email,
   permissions: rules.permissions,
-})
+}).strict()
 
 export type CreateAdminBody = z.infer<typeof createAdminBodySchema>
 export type CreateAdminCtx = ValidatedJsonCtx<CreateAdminBody>

--- a/src/routes/user/teams/$id/members/$id/schema.ts
+++ b/src/routes/user/teams/$id/members/$id/schema.ts
@@ -20,7 +20,7 @@ export const updateTeamMemberBodySchema = z.object({
     firstName: rules.user.firstName.optional(),
     lastName: rules.user.lastName.optional(),
   }).optional(),
-})
+}).strict()
 
 export type UpdateTeamMemberBody = z.infer<typeof updateTeamMemberBodySchema>
 export type UpdateTeamMemberCtx = ValidatedParamJsonCtx<MemberIdParams, UpdateTeamMemberBody>

--- a/src/routes/user/teams/$id/members/schema.ts
+++ b/src/routes/user/teams/$id/members/schema.ts
@@ -17,7 +17,7 @@ export const inviteMemberBodySchema = z.object({
   email: rules.user.email,
   position: rules.team.position.optional(),
   permissions: rules.permissions,
-})
+}).strict()
 
 export type InviteMemberBody = z.infer<typeof inviteMemberBodySchema>
 export type InviteMemberCtx = ValidatedParamJsonCtx<TeamIdParams, InviteMemberBody>

--- a/src/routes/user/teams/$id/schema.ts
+++ b/src/routes/user/teams/$id/schema.ts
@@ -15,7 +15,7 @@ export const updateTeamBodySchema = z.object({
   name: rules.team.name.optional(),
   website: rules.team.website.optional(),
   description: rules.team.description.nullish(),
-})
+}).strict()
 
 export type UpdateTeamBody = z.infer<typeof updateTeamBodySchema>
 export type UpdateTeamCtx = ValidatedParamJsonCtx<TeamIdParams, UpdateTeamBody>


### PR DESCRIPTION
[Security]: Enforce strict unknown-field rejection on all auth and internal API body schemas
[Improvement]: Add \`.strict()\` to 4 missing top-level body schemas across admin, owner, and user routes
[Improvement]: Add \`.strict()\` to 3 nested \`preferences\` objects in auth routes (signup, request-password-reset, resend-verification-email)