### PR TITLE
Standardize naming conventions for schemas and input types

### DIFF
--- a/src/routes/auth/accept-invite/index.ts
+++ b/src/routes/auth/accept-invite/index.ts
@@ -5,12 +5,12 @@ import type { AppContext } from '@/context'
 import { requestValidator } from '@/middleware'
 
 import { acceptInviteHandler } from './handler'
-import { acceptInviteSchema as schema } from './schema'
+import { acceptInviteBodySchema } from './schema'
 
 export const acceptInviteRoute = new Hono<AppContext>()
 
 acceptInviteRoute.post(
   '/accept-invite',
-  requestValidator('json', schema),
+  requestValidator('json', acceptInviteBodySchema),
   acceptInviteHandler,
 )

--- a/src/routes/auth/accept-invite/schema.ts
+++ b/src/routes/auth/accept-invite/schema.ts
@@ -4,10 +4,10 @@ import type { ValidatedJsonCtx } from '@/routes/validated-ctx'
 
 import { rules } from '@/routes/rules'
 
-export const acceptInviteSchema = z.object({
+export const acceptInviteBodySchema = z.object({
   token: rules.token.oneTime,
   password: rules.user.password,
 }).strict()
 
-export type AcceptInviteBody = z.infer<typeof acceptInviteSchema>
+export type AcceptInviteBody = z.infer<typeof acceptInviteBodySchema>
 export type AcceptInviteCtx = ValidatedJsonCtx<AcceptInviteBody>

--- a/src/routes/auth/check-invite/index.ts
+++ b/src/routes/auth/check-invite/index.ts
@@ -5,12 +5,12 @@ import type { AppContext } from '@/context'
 import { requestValidator } from '@/middleware'
 
 import { checkInviteHandler } from './handler'
-import { checkInviteSchema as schema } from './schema'
+import { checkInviteQuerySchema } from './schema'
 
 export const checkInviteRoute = new Hono<AppContext>()
 
 checkInviteRoute.get(
   '/check-invite',
-  requestValidator('query', schema),
+  requestValidator('query', checkInviteQuerySchema),
   checkInviteHandler,
 )

--- a/src/routes/auth/check-invite/schema.ts
+++ b/src/routes/auth/check-invite/schema.ts
@@ -4,9 +4,9 @@ import type { ValidatedQueryCtx } from '@/routes/validated-ctx'
 
 import { rules } from '@/routes/rules'
 
-export const checkInviteSchema = z.object({
+export const checkInviteQuerySchema = z.object({
   token: rules.token.oneTime,
 })
 
-export type CheckInviteQuery = z.infer<typeof checkInviteSchema>
+export type CheckInviteQuery = z.infer<typeof checkInviteQuerySchema>
 export type CheckInviteCtx = ValidatedQueryCtx<CheckInviteQuery>

--- a/src/routes/auth/login/index.ts
+++ b/src/routes/auth/login/index.ts
@@ -5,13 +5,13 @@ import type { AppContext } from '@/context'
 import { captchaMiddleware, requestValidator } from '@/middleware'
 
 import { loginHandler } from './handler'
-import { loginSchema as schema } from './schema'
+import { loginBodySchema } from './schema'
 
 export const loginRoute = new Hono<AppContext>()
 
 loginRoute.post(
   '/login',
-  requestValidator('json', schema),
+  requestValidator('json', loginBodySchema),
   captchaMiddleware(),
   loginHandler,
 )

--- a/src/routes/auth/login/schema.ts
+++ b/src/routes/auth/login/schema.ts
@@ -4,7 +4,7 @@ import type { ValidatedJsonCtx } from '@/routes/validated-ctx'
 
 import { rules } from '@/routes/rules'
 
-export const loginSchema = z.object({
+export const loginBodySchema = z.object({
   email: rules.user.email,
   password: rules.user.password,
   captcha: z.object({
@@ -12,5 +12,5 @@ export const loginSchema = z.object({
   }).strict(),
 }).strict()
 
-export type LoginBody = z.infer<typeof loginSchema>
+export type LoginBody = z.infer<typeof loginBodySchema>
 export type LoginCtx = ValidatedJsonCtx<LoginBody>

--- a/src/routes/auth/request-password-reset/index.ts
+++ b/src/routes/auth/request-password-reset/index.ts
@@ -5,13 +5,13 @@ import type { AppContext } from '@/context'
 import { captchaMiddleware, requestValidator } from '@/middleware'
 
 import { requestPasswordResetHandler } from './handler'
-import { requestPasswordResetSchema as schema } from './schema'
+import { requestPasswordResetBodySchema } from './schema'
 
 export const requestPasswordResetRoute = new Hono<AppContext>()
 
 requestPasswordResetRoute.post(
   '/request-password-reset',
-  requestValidator('json', schema),
+  requestValidator('json', requestPasswordResetBodySchema),
   captchaMiddleware(),
   requestPasswordResetHandler,
 )

--- a/src/routes/auth/request-password-reset/schema.ts
+++ b/src/routes/auth/request-password-reset/schema.ts
@@ -4,7 +4,7 @@ import type { ValidatedJsonCtx } from '@/routes/validated-ctx'
 
 import { rules } from '@/routes/rules'
 
-export const requestPasswordResetSchema = z.object({
+export const requestPasswordResetBodySchema = z.object({
   email: rules.user.email,
   captcha: z.object({
     token: rules.captcha.token,
@@ -15,5 +15,5 @@ export const requestPasswordResetSchema = z.object({
   }).strict().optional(),
 }).strict()
 
-export type RequestPasswordResetBody = z.infer<typeof requestPasswordResetSchema>
+export type RequestPasswordResetBody = z.infer<typeof requestPasswordResetBodySchema>
 export type RequestPasswordResetCtx = ValidatedJsonCtx<RequestPasswordResetBody>

--- a/src/routes/auth/resend-verification-email/index.ts
+++ b/src/routes/auth/resend-verification-email/index.ts
@@ -5,13 +5,13 @@ import type { AppContext } from '@/context'
 import { captchaMiddleware, requestValidator } from '@/middleware'
 
 import { resendVerificationEmailHandler } from './handler'
-import { resendVerificationEmailSchema as schema } from './schema'
+import { resendVerificationEmailBodySchema } from './schema'
 
 export const resendVerificationEmailRoute = new Hono<AppContext>()
 
 resendVerificationEmailRoute.post(
   '/resend-verification-email',
-  requestValidator('json', schema),
+  requestValidator('json', resendVerificationEmailBodySchema),
   captchaMiddleware(),
   resendVerificationEmailHandler,
 )

--- a/src/routes/auth/resend-verification-email/schema.ts
+++ b/src/routes/auth/resend-verification-email/schema.ts
@@ -4,7 +4,7 @@ import type { ValidatedJsonCtx } from '@/routes/validated-ctx'
 
 import { rules } from '@/routes/rules'
 
-export const resendVerificationEmailSchema = z.object({
+export const resendVerificationEmailBodySchema = z.object({
   email: rules.user.email,
   captcha: z.object({
     token: rules.captcha.token,
@@ -15,5 +15,5 @@ export const resendVerificationEmailSchema = z.object({
   }).strict().optional(),
 }).strict()
 
-export type ResendVerificationEmailBody = z.infer<typeof resendVerificationEmailSchema>
+export type ResendVerificationEmailBody = z.infer<typeof resendVerificationEmailBodySchema>
 export type ResendVerificationEmailCtx = ValidatedJsonCtx<ResendVerificationEmailBody>

--- a/src/routes/auth/reset-password/index.ts
+++ b/src/routes/auth/reset-password/index.ts
@@ -5,12 +5,12 @@ import type { AppContext } from '@/context'
 import { requestValidator } from '@/middleware'
 
 import { resetPasswordHandler } from './handler'
-import { resetPasswordSchema as schema } from './schema'
+import { resetPasswordBodySchema } from './schema'
 
 export const resetPasswordRoute = new Hono<AppContext>()
 
 resetPasswordRoute.post(
   '/reset-password',
-  requestValidator('json', schema),
+  requestValidator('json', resetPasswordBodySchema),
   resetPasswordHandler,
 )

--- a/src/routes/auth/reset-password/schema.ts
+++ b/src/routes/auth/reset-password/schema.ts
@@ -4,10 +4,10 @@ import type { ValidatedJsonCtx } from '@/routes/validated-ctx'
 
 import { rules } from '@/routes/rules'
 
-export const resetPasswordSchema = z.object({
+export const resetPasswordBodySchema = z.object({
   token: rules.token.oneTime,
   password: rules.user.password,
 }).strict()
 
-export type ResetPasswordBody = z.infer<typeof resetPasswordSchema>
+export type ResetPasswordBody = z.infer<typeof resetPasswordBodySchema>
 export type ResetPasswordCtx = ValidatedJsonCtx<ResetPasswordBody>

--- a/src/routes/auth/signup/index.ts
+++ b/src/routes/auth/signup/index.ts
@@ -5,13 +5,13 @@ import type { AppContext } from '@/context'
 import { captchaMiddleware, requestValidator } from '@/middleware'
 
 import { signupHandler } from './handler'
-import { signupSchema as schema } from './schema'
+import { signupBodySchema } from './schema'
 
 export const signupRoute = new Hono<AppContext>()
 
 signupRoute.post(
   '/signup',
-  requestValidator('json', schema),
+  requestValidator('json', signupBodySchema),
   captchaMiddleware(),
   signupHandler,
 )

--- a/src/routes/auth/signup/schema.ts
+++ b/src/routes/auth/signup/schema.ts
@@ -4,7 +4,7 @@ import type { ValidatedJsonCtx } from '@/routes/validated-ctx'
 
 import { rules } from '@/routes/rules'
 
-export const signupSchema = z.object({
+export const signupBodySchema = z.object({
   firstName: rules.user.firstName,
   lastName: rules.user.lastName.optional(),
   email: rules.user.email,
@@ -18,5 +18,5 @@ export const signupSchema = z.object({
   }).strict().optional(),
 }).strict()
 
-export type SignupBody = z.infer<typeof signupSchema>
+export type SignupBody = z.infer<typeof signupBodySchema>
 export type SignupCtx = ValidatedJsonCtx<SignupBody>

--- a/src/routes/auth/verify-email/index.ts
+++ b/src/routes/auth/verify-email/index.ts
@@ -5,12 +5,12 @@ import type { AppContext } from '@/context'
 import { requestValidator } from '@/middleware'
 
 import { verifyEmailHandler } from './handler'
-import { verifyEmailSchema as schema } from './schema'
+import { verifyEmailBodySchema } from './schema'
 
 export const verifyEmailRoute = new Hono<AppContext>()
 
 verifyEmailRoute.post(
   '/verify-email',
-  requestValidator('json', schema),
+  requestValidator('json', verifyEmailBodySchema),
   verifyEmailHandler,
 )

--- a/src/routes/auth/verify-email/schema.ts
+++ b/src/routes/auth/verify-email/schema.ts
@@ -4,9 +4,9 @@ import type { ValidatedJsonCtx } from '@/routes/validated-ctx'
 
 import { rules } from '@/routes/rules'
 
-export const verifyEmailSchema = z.object({
+export const verifyEmailBodySchema = z.object({
   token: rules.token.oneTime,
 }).strict()
 
-export type VerifyEmailBody = z.infer<typeof verifyEmailSchema>
+export type VerifyEmailBody = z.infer<typeof verifyEmailBodySchema>
 export type VerifyEmailCtx = ValidatedJsonCtx<VerifyEmailBody>

--- a/src/use-cases/admin/teams.ts
+++ b/src/use-cases/admin/teams.ts
@@ -2,12 +2,6 @@ import type { PaginationParams, TeamSearchParams } from '@/data'
 
 import { teamRepo } from '@/data'
 
-export interface CreateTeamParams {
-  name: string
-  website: string
-  description?: string
-}
-
 export const getTeams = async (
   params: TeamSearchParams,
   pagination: PaginationParams,
@@ -15,8 +9,14 @@ export const getTeams = async (
   return teamRepo.search(params, pagination)
 }
 
-export const createTeam = async (params: CreateTeamParams) => {
-  const team = await teamRepo.create(params)
+export interface CreateTeamInput {
+  name: string
+  website: string
+  description?: string
+}
+
+export const createTeam = async (input: CreateTeamInput) => {
+  const team = await teamRepo.create(input)
 
   return { team }
 }

--- a/src/use-cases/admin/users.ts
+++ b/src/use-cases/admin/users.ts
@@ -5,7 +5,7 @@ import { userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { isUser, Role } from '@/types'
 
-export interface UpdateUserParams {
+export interface UpdateUserInput {
   firstName?: string
   lastName?: string
   status?: Status
@@ -40,14 +40,14 @@ export const getUser = async (userId: string) => {
   return { user }
 }
 
-export const updateUser = async (userId: string, params: UpdateUserParams) => {
+export const updateUser = async (userId: string, updates: UpdateUserInput) => {
   const user = await userRepo.findById(userId)
 
   if (!user || !isUser(user.role)) {
     throw new AppError(ErrorCode.NotFound, 'User not found')
   }
 
-  const updatedUser = await userRepo.update(userId, params)
+  const updatedUser = await userRepo.update(userId, updates)
 
   return { user: updatedUser }
 }

--- a/src/use-cases/owner/admins/admins.ts
+++ b/src/use-cases/owner/admins/admins.ts
@@ -44,20 +44,20 @@ export const getAdmin = async (adminId: string) => {
   }
 }
 
-export interface UpdateAdminParams {
+export interface UpdateAdminInput {
   firstName?: string
   lastName?: string
   status?: Status
 }
 
-export const updateAdmin = async (adminId: string, params: UpdateAdminParams) => {
+export const updateAdmin = async (adminId: string, updates: UpdateAdminInput) => {
   const admin = await userRepo.findById(adminId)
 
   if (!admin || admin.role !== Role.Admin) {
     throw new AppError(ErrorCode.NotFound, 'Admin not found')
   }
 
-  const updatedAdmin = await userRepo.update(adminId, params)
+  const updatedAdmin = await userRepo.update(adminId, updates)
 
   return { admin: updatedAdmin }
 }

--- a/src/use-cases/owner/admins/index.ts
+++ b/src/use-cases/owner/admins/index.ts
@@ -1,5 +1,5 @@
 export { getAdmin, getAdmins, updateAdmin } from './admins'
-export type { UpdateAdminParams } from './admins'
+export type { UpdateAdminInput } from './admins'
 export { cancelAdminInvite, inviteAdmin, resendAdminInvite } from './invites'
-export type { AdminInvitationParams } from './invites'
+export type { InviteAdminInput } from './invites'
 export { getAdminPermissions, updateAdminPermissions } from './permissions'

--- a/src/use-cases/owner/admins/invites.ts
+++ b/src/use-cases/owner/admins/invites.ts
@@ -8,16 +8,16 @@ import { generateToken, TokenType } from '@/security/token'
 import { emailAgent } from '@/services/email'
 import { AuthProvider, Role, Status } from '@/types'
 
-export interface AdminInvitationParams {
+export interface InviteAdminInput {
   firstName: string
   lastName?: string
   email: string
   permissions: PermissionsInput
 }
 
-export const inviteAdmin = async (params: AdminInvitationParams, inviterId: string) => {
+export const inviteAdmin = async (admin: InviteAdminInput, inviterId: string) => {
   const [existingUser, inviter] = await Promise.all([
-    userRepo.findByEmail(params.email),
+    userRepo.findByEmail(admin.email),
     userRepo.findById(inviterId),
   ])
 
@@ -31,11 +31,11 @@ export const inviteAdmin = async (params: AdminInvitationParams, inviterId: stri
 
   const role = Role.Admin
 
-  const { admin, token } = await db.transaction(async (tx) => {
+  const { admin: newAdmin, token } = await db.transaction(async (tx) => {
     const newAdmin = await userRepo.create({
-      firstName: params.firstName,
-      lastName: params.lastName,
-      email: params.email,
+      firstName: admin.firstName,
+      lastName: admin.lastName,
+      email: admin.email,
       status: Status.Pending,
     }, tx)
 
@@ -45,7 +45,7 @@ export const inviteAdmin = async (params: AdminInvitationParams, inviterId: stri
     await authRepo.create({
       userId: newAdmin.id,
       provider: AuthProvider.Local,
-      identifier: params.email,
+      identifier: admin.email,
       passwordHash,
     }, tx)
 
@@ -55,7 +55,7 @@ export const inviteAdmin = async (params: AdminInvitationParams, inviterId: stri
       invitedBy: inviterId,
     }, tx)
 
-    await rbacRepo.setUserPermissions(newAdmin.id, params.permissions, tx)
+    await rbacRepo.setUserPermissions(newAdmin.id, admin.permissions, tx)
 
     const { type, token, expiresAt } = generateToken(TokenType.UserInvite)
 
@@ -70,14 +70,14 @@ export const inviteAdmin = async (params: AdminInvitationParams, inviterId: stri
   })
 
   await emailAgent.sendUserInvitationEmail(
-    admin.firstName,
-    admin.email,
+    newAdmin.firstName,
+    newAdmin.email,
     token,
     inviter.firstName,
     env.COMPANY_NAME,
   )
 
-  return { admin }
+  return { admin: newAdmin }
 }
 
 export const resendAdminInvite = async (adminId: string, inviterId: string) => {

--- a/src/use-cases/user/invites.ts
+++ b/src/use-cases/user/invites.ts
@@ -7,7 +7,7 @@ import { generateToken, TokenType } from '@/security/token'
 import { emailAgent } from '@/services/email'
 import { AuthProvider, Status } from '@/types'
 
-export interface InviteMemberParams {
+export interface InviteMemberInput {
   firstName: string
   lastName?: string
   email: string
@@ -17,7 +17,7 @@ export interface InviteMemberParams {
 
 export const inviteMember = async (
   teamId: string,
-  member: InviteMemberParams,
+  member: InviteMemberInput,
   inviterId: string,
 ) => {
   const [inviter, team, existingUser] = await Promise.all([

--- a/src/use-cases/user/members.ts
+++ b/src/use-cases/user/members.ts
@@ -21,7 +21,7 @@ export const getTeamMember = async (
   return { member }
 }
 
-export interface UpdateTeamMemberParams {
+export interface UpdateTeamMemberInput {
   membership?: {
     position?: string | null
   }
@@ -34,7 +34,7 @@ export interface UpdateTeamMemberParams {
 export const updateTeamMember = async (
   teamId: string,
   memberId: string,
-  params: UpdateTeamMemberParams,
+  input: UpdateTeamMemberInput,
 ) => {
   const existing = await teamRepo.findMember(teamId, memberId)
 
@@ -44,12 +44,12 @@ export const updateTeamMember = async (
 
   const updates: Array<Promise<unknown>> = []
 
-  if (params.membership) {
-    updates.push(teamRepo.updateMember(memberId, teamId, params.membership))
+  if (input.membership) {
+    updates.push(teamRepo.updateMember(memberId, teamId, input.membership))
   }
 
-  if (params.member) {
-    updates.push(userRepo.update(memberId, params.member))
+  if (input.member) {
+    updates.push(userRepo.update(memberId, input.member))
   }
 
   await Promise.all(updates)

--- a/src/use-cases/user/teams.ts
+++ b/src/use-cases/user/teams.ts
@@ -11,7 +11,7 @@ export const getTeam = async (teamId: string) => {
   return { team }
 }
 
-export interface UpdateTeamParams {
+export interface UpdateTeamInput {
   name?: string
   website?: string
   description?: string | null
@@ -19,7 +19,7 @@ export interface UpdateTeamParams {
 
 export const updateTeam = async (
   teamId: string,
-  params: UpdateTeamParams,
+  updates: UpdateTeamInput,
 ) => {
   const existing = await teamRepo.findById(teamId)
 
@@ -27,7 +27,7 @@ export const updateTeam = async (
     throw new AppError(ErrorCode.NotFound, 'Team not found')
   }
 
-  const team = await teamRepo.update(teamId, params)
+  const team = await teamRepo.update(teamId, updates)
 
   return { team }
 }


### PR DESCRIPTION
[Improvement]: Add \`Body\`/\`Query\` suffix to all auth route Zod schemas to make validator type explicit (e.g. \`signupSchema\` → \`signupBodySchema\`, \`checkInviteSchema\` → \`checkInviteQuerySchema\`)
[Improvement]: Rename \`AdminInvitationInput\` to \`InviteAdminInput\` in use-cases to align with the \`[Action][Entity]Input\` pattern used everywhere else
[Improvement]: Move input type interfaces immediately before the function they are used in across use-cases module