### PR TITLE
Move Input interfaces adjacent to their use-case functions

### DIFF
--- a/src/use-cases/admin/users.ts
+++ b/src/use-cases/admin/users.ts
@@ -5,12 +5,6 @@ import { userRepo } from '@/data'
 import { AppError, ErrorCode } from '@/errors'
 import { isUser, Role } from '@/types'
 
-export interface UpdateUserInput {
-  firstName?: string
-  lastName?: string
-  status?: Status
-}
-
 const normalizeRoles = (params: SearchParams): SearchParams => {
   const filteredRoles = params.roles.filter(isUser)
   const validRoles = filteredRoles.length > 0 ? filteredRoles : [Role.User]
@@ -38,6 +32,12 @@ export const getUser = async (userId: string) => {
   }
 
   return { user }
+}
+
+export interface UpdateUserInput {
+  firstName?: string
+  lastName?: string
+  status?: Status
 }
 
 export const updateUser = async (userId: string, updates: UpdateUserInput) => {

--- a/src/use-cases/auth/request-password-reset.ts
+++ b/src/use-cases/auth/request-password-reset.ts
@@ -6,10 +6,6 @@ import { generateToken, TokenType } from '@/security/token'
 import { emailAgent } from '@/services'
 import { isActive } from '@/types'
 
-export interface RequestPasswordResetInput {
-  email: string
-}
-
 const createPasswordResetToken = async (userId: string) => {
   const { type, token, expiresAt } = generateToken(TokenType.PasswordReset)
 
@@ -18,6 +14,10 @@ const createPasswordResetToken = async (userId: string) => {
   })
 
   return token
+}
+
+export interface RequestPasswordResetInput {
+  email: string
 }
 
 export const requestPasswordReset = async (

--- a/src/use-cases/auth/resend-verification-email.ts
+++ b/src/use-cases/auth/resend-verification-email.ts
@@ -6,10 +6,6 @@ import { generateToken, TokenType } from '@/security/token'
 import { emailAgent } from '@/services'
 import { Status } from '@/types'
 
-export interface ResendVerificationEmailInput {
-  email: string
-}
-
 const createEmailVerificationToken = async (userId: string) => {
   const { type, token, expiresAt } = generateToken(TokenType.EmailVerification)
 
@@ -18,6 +14,10 @@ const createEmailVerificationToken = async (userId: string) => {
   })
 
   return token
+}
+
+export interface ResendVerificationEmailInput {
+  email: string
 }
 
 export const resendVerificationEmail = async (

--- a/src/use-cases/auth/signup.ts
+++ b/src/use-cases/auth/signup.ts
@@ -11,13 +11,6 @@ import { AuthProvider, Status } from '@/types'
 
 import { createAuthTokens } from '../tokens'
 
-export interface SignupInput {
-  firstName: string
-  lastName?: string
-  email: string
-  password: string
-}
-
 const createNewUser = async (
   firstName: string,
   lastName: string | undefined,
@@ -54,6 +47,13 @@ const createNewUser = async (
   })
 
   return { newUser, verificationToken }
+}
+
+export interface SignupInput {
+  firstName: string
+  lastName?: string
+  email: string
+  password: string
 }
 
 export const signUpWithEmail = async (


### PR DESCRIPTION
[Improvement]: Place each \`Input\` interface immediately before the function it belongs to, improving co-location and readability across auth and admin use-cases