### PR TITLE
Tie refresh token DB expiry to COOKIE_REFRESH_TOKEN_EXPIRATION

### DIFF
--- a/src/use-cases/tokens.ts
+++ b/src/use-cases/tokens.ts
@@ -3,6 +3,7 @@ import type { DeviceInfo } from '@/net/http/device'
 import type { Permission } from '@/types'
 
 import { refreshTokenRepo, tokenRepo } from '@/data'
+import env from '@/env'
 import { signJwt } from '@/security/jwt'
 import { generateHashedToken, TokenType, TokenValidator } from '@/security/token'
 
@@ -21,6 +22,7 @@ export const createRefreshToken = async (
 ) => {
   const { token: { raw, hashed }, expiresAt } = await generateHashedToken(
     TokenType.RefreshToken,
+    { expirySeconds: env.COOKIE_REFRESH_TOKEN_EXPIRATION },
   )
 
   await refreshTokenRepo.create({


### PR DESCRIPTION
## Changes

[Fix]: Refresh token `expires_at` in DB now respects `COOKIE_REFRESH_TOKEN_EXPIRATION` env var, making cookie lifetime and DB expiry consistent

## Test plan
- [ ] Set `COOKIE_REFRESH_TOKEN_EXPIRATION=300` in `.env.development`
- [ ] Login and verify `expires_at` in `refresh_tokens` table is ~5 minutes from `created_at`
- [ ] Confirm session expires after 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)